### PR TITLE
fix: add gemini-api to AskOriginal switch case

### DIFF
--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -509,7 +509,7 @@ func (c *Client) AskOriginal(ctx context.Context, question, awsContext, codeCont
 	switch c.provider {
 	case "bedrock", "claude":
 		return c.askBedrock(ctx, prompt)
-	case "gemini":
+	case "gemini", "gemini-api":
 		return c.askGemini(ctx, prompt)
 	case "anthropic":
 		return c.askAnthropic(ctx, prompt)


### PR DESCRIPTION
## What's broken
Using `gemini-api` provider without AWS/GitHub tools crashes with:

```
Error: AWS CLI call failed: The config profile () could not be found
```

The `AskOriginal` function only had `case "gemini":` — missing `"gemini-api"`, so it fell through to the default Bedrock handler (which needs AWS).

## The fix
Added `"gemini-api"` to the switch case at line 512 — now matches the pattern used elsewhere in the file.

## Other options considered
- **Helper function** like `isGeminiProvider()` — felt like overkill for one provider
- **Normalise at client creation** — store a `providerFamily` that groups variants:
  - `gemini`, `gemini-api` → `"gemini"`
  - `bedrock`, `claude` → `"bedrock"`
  - etc.
  
  This is probably the better long-term fix since it centralises the logic and scales if more variants get added. But it's a bigger change, so went with the minimal fix here.

## Tested
- `clanker ask --ai-profile gemini-api "hello"` ✓
- `clanker ask --ai-profile gemini-api --terraform "..."` no longer crashes ✓