### PR TITLE
fix: add api_key_env support for OpenAI provider

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -96,11 +96,7 @@ Examples:
 			case "gemini-api":
 				apiKey = resolveGeminiAPIKey(geminiKey)
 			case "openai":
-				if openaiKey != "" {
-					apiKey = openaiKey
-				} else {
-					apiKey = viper.GetString("ai.providers.openai.api_key")
-				}
+				apiKey = resolveOpenAIKey(openaiKey)
 			case "anthropic":
 				if anthropicKey != "" {
 					apiKey = anthropicKey
@@ -459,12 +455,7 @@ Format as a professional compliance table suitable for government security docum
 			case "gemini-api":
 				apiKey = resolveGeminiAPIKey(geminiKey)
 			case "openai":
-				// Get OpenAI API key from flag or config
-				if openaiKey != "" {
-					apiKey = openaiKey
-				} else {
-					apiKey = viper.GetString("ai.providers.openai.api_key")
-				}
+				apiKey = resolveOpenAIKey(openaiKey)
 			case "anthropic":
 				// Get Anthropic API key from flag or config
 				if anthropicKey != "" {
@@ -506,12 +497,7 @@ Format as a professional compliance table suitable for government security docum
 			case "gemini-api":
 				apiKey = resolveGeminiAPIKey(geminiKey)
 			case "openai":
-				// Get OpenAI API key from flag or config
-				if openaiKey != "" {
-					apiKey = openaiKey
-				} else {
-					apiKey = viper.GetString("ai.providers.openai.api_key")
-				}
+				apiKey = resolveOpenAIKey(openaiKey)
 			case "anthropic":
 				// Get Anthropic API key from flag or config
 				if anthropicKey != "" {
@@ -600,6 +586,24 @@ func resolveGeminiAPIKey(flagValue string) string {
 		}
 	}
 	if envVal := os.Getenv("GEMINI_API_KEY"); envVal != "" {
+		return envVal
+	}
+	return ""
+}
+
+func resolveOpenAIKey(flagValue string) string {
+	if flagValue != "" {
+		return flagValue
+	}
+	if key := viper.GetString("ai.providers.openai.api_key"); key != "" {
+		return key
+	}
+	if envName := viper.GetString("ai.providers.openai.api_key_env"); envName != "" {
+		if envVal := os.Getenv(envName); envVal != "" {
+			return envVal
+		}
+	}
+	if envVal := os.Getenv("OPENAI_API_KEY"); envVal != "" {
 		return envVal
 	}
 	return ""


### PR DESCRIPTION
openai was the odd one out - gemini-api already supports api_key_env but openai only looked for api_key in config.

added resolveOpenAIKey function following the same pattern as resolveGeminiAPIKey. now you can use:

```yaml
ai:
  providers:
    openai:
      model: gpt-5
      api_key_env: OPENAI_API_KEY
```

instead of hardcoding the key in the config file.

nice project btw, I've been using it all morning :)