### PR TITLE
feat: add Linux cross-platform support and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,100 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Run go fmt
+        run: |
+          if [ -n "$(gofmt -s -l .)" ]; then
+            echo "Code is not formatted. Run 'go fmt ./...'"
+            gofmt -s -d .
+            exit 1
+          fi
+
+      - name: Run go vet
+        run: go vet ./...
+
+  test:
+    name: Test
+    needs: lint
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        go-version: ['1.23', '1.24']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: go test -short -v ./...
+
+  build:
+    name: Build
+    needs: test
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            goos: linux
+            goarch: amd64
+            binary: clanker
+          - os: ubuntu-latest
+            goos: linux
+            goarch: arm64
+            binary: clanker
+          - os: macos-latest
+            goos: darwin
+            goarch: amd64
+            binary: clanker
+          - os: macos-latest
+            goos: darwin
+            goarch: arm64
+            binary: clanker
+          - os: windows-latest
+            goos: windows
+            goarch: amd64
+            binary: clanker.exe
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Build
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: go build -o ${{ matrix.binary }} ./main.go
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: clanker-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: ${{ matrix.binary }}
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,8 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+
+# Local documentation and task tracking
+CLAUDE.md
+TODO.md
+PLANNING.md


### PR DESCRIPTION
- Fix hardcoded /tmp/bedrock-response.json path in Bedrock client using os.CreateTemp() for cross-platform temp file handling
- Add GitHub Actions CI workflow with multi-platform testing matrix (ubuntu, macos, windows) and multi-architecture builds
- Update .gitignore to exclude local documentation files