### PR TITLE
fix(k8s): handle eks commands in K8s plan executor

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -1364,6 +1364,12 @@ func executeK8sPlan(ctx context.Context, rawPlan string, profile string, debug b
 		cmdName := cmd.Args[0]
 		cmdArgs := cmd.Args[1:]
 
+		// Handle eks commands - they need to run as "aws eks ..."
+		if cmdName == "eks" {
+			cmdName = "aws"
+			cmdArgs = append([]string{"eks"}, cmdArgs...)
+		}
+
 		// Add profile/region for AWS and eksctl commands
 		if cmdName == "aws" || cmdName == "eksctl" {
 			cmdArgs = append(cmdArgs, "--profile", awsProfile)


### PR DESCRIPTION
The K8s plan executor now properly handles eks commands by prepending aws to run them as aws eks instead of trying to execute eks as a standalone binary.