### PR TITLE
Fix Hetzner routing, discovery defaults, and AI override handling

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -113,6 +113,8 @@ Examples:
 		}
 		routeOnly, _ := cmd.Flags().GetBool("route-only")
 
+		applyCommandAIOverrides(aiProfile, openaiKey, anthropicKey, geminiKey, deepseekKey, cohereKey, minimaxKey, openaiModel, anthropicModel, geminiModel, deepseekModel, cohereModel, minimaxModel, githubModel)
+
 		// Handle route-only mode: return routing decision as JSON without executing
 		if routeOnly {
 			agent, reason := determineRoutingDecision(question)
@@ -233,9 +235,9 @@ Examples:
 			}
 
 			if strings.EqualFold(strings.TrimSpace(makerPlan.Provider), "hetzner") {
-				hetznerToken := hetzner.ResolveAPIToken()
-				if hetznerToken == "" {
-					return fmt.Errorf("hetzner api_token is required (set hetzner.api_token or HCLOUD_TOKEN)")
+				hetznerToken, err := resolveHetznerToken(ctx, debug)
+				if err != nil {
+					return err
 				}
 				return maker.ExecuteHetznerPlan(ctx, makerPlan, maker.ExecOptions{
 					HetznerAPIToken: hetznerToken,
@@ -371,7 +373,7 @@ Examples:
 			// Priority:
 			//  1) Explicit flags win (--gcp / --aws / --cloudflare)
 			//  2) Infer from question (cheap heuristic)
-			makerProvider := "aws"
+			makerProvider := routing.DefaultInfraProvider()
 			makerProviderReason := "default"
 			explicitGCP := cmd.Flags().Changed("gcp") && includeGCP
 			explicitAWS := cmd.Flags().Changed("aws") && includeAWS
@@ -1408,6 +1410,40 @@ func maybeRunTerraformCommand(ctx context.Context, question string, tfClient *tf
 	return true, nil
 }
 
+func applyCommandAIOverrides(aiProfile, openaiKey, anthropicKey, geminiKey, deepseekKey, cohereKey, minimaxKey, openaiModel, anthropicModel, geminiModel, deepseekModel, cohereModel, minimaxModel, githubModel string) {
+	provider := strings.TrimSpace(aiProfile)
+	if provider != "" {
+		viper.Set("ai.default_provider", provider)
+	} else {
+		provider = strings.TrimSpace(viper.GetString("ai.default_provider"))
+		if provider == "" {
+			provider = "openai"
+			viper.Set("ai.default_provider", provider)
+		}
+	}
+
+	if strings.TrimSpace(openaiKey) != "" {
+		viper.Set("ai.providers.openai.api_key", strings.TrimSpace(openaiKey))
+	}
+	if strings.TrimSpace(anthropicKey) != "" {
+		viper.Set("ai.providers.anthropic.api_key", strings.TrimSpace(anthropicKey))
+	}
+	if strings.TrimSpace(geminiKey) != "" {
+		viper.Set("ai.providers.gemini-api.api_key", strings.TrimSpace(geminiKey))
+	}
+	if strings.TrimSpace(deepseekKey) != "" {
+		viper.Set("ai.providers.deepseek.api_key", strings.TrimSpace(deepseekKey))
+	}
+	if strings.TrimSpace(cohereKey) != "" {
+		viper.Set("ai.providers.cohere.api_key", strings.TrimSpace(cohereKey))
+	}
+	if strings.TrimSpace(minimaxKey) != "" {
+		viper.Set("ai.providers.minimax.api_key", strings.TrimSpace(minimaxKey))
+	}
+
+	maybeOverrideProviderModel(provider, openaiModel, anthropicModel, geminiModel, deepseekModel, cohereModel, minimaxModel, githubModel)
+}
+
 func maybeOverrideProviderModel(provider, openaiModel, anthropicModel, geminiModel, deepseekModel, cohereModel, minimaxModel, githubModel string) {
 	switch provider {
 	case "openai":
@@ -1739,15 +1775,18 @@ func handleCloudflareQuery(ctx context.Context, question string, debug bool) err
 
 	var apiKey string
 	switch aiProfile {
-	case "gemini", "gemini-api":
+	case "gemini":
 		apiKey = ""
+	case "gemini-api":
+		apiKey = resolveGeminiAPIKey("")
 	case "openai":
-		apiKey = viper.GetString("ai.providers.openai.api_key")
-		if apiKey == "" {
-			apiKey = os.Getenv("OPENAI_API_KEY")
-		}
+		apiKey = resolveOpenAIKey("")
+	case "anthropic":
+		apiKey = resolveAnthropicKey("")
 	case "cohere":
 		apiKey = resolveCohereKey("")
+	case "deepseek":
+		apiKey = resolveDeepSeekKey("")
 	case "minimax":
 		apiKey = resolveMiniMaxKey("")
 	default:
@@ -1902,7 +1941,7 @@ func handleDigitalOceanQuery(ctx context.Context, question string, debug bool) e
 		apiKey = viper.GetString("ai.api_key")
 	}
 
-	aiClient := ai.NewClient(provider, apiKey, debug, "")
+	aiClient := ai.NewClient(provider, apiKey, debug, provider)
 
 	prompt := fmt.Sprintf(`You are a Digital Ocean infrastructure expert. Answer the user's question based on the following Digital Ocean context data.
 
@@ -1922,15 +1961,39 @@ Provide a clear, concise answer based on the data above. If the data doesn't con
 	return nil
 }
 
+func resolveHetznerToken(ctx context.Context, debug bool) (string, error) {
+	apiToken := hetzner.ResolveAPIToken()
+	if apiToken != "" {
+		return apiToken, nil
+	}
+
+	backendAPIKey := backend.ResolveAPIKey("")
+	if backendAPIKey != "" {
+		backendClient := backend.NewClient(backendAPIKey, debug)
+		backendCreds, backendErr := backendClient.GetHetznerCredentials(ctx)
+		if backendErr == nil && strings.TrimSpace(backendCreds.APIToken) != "" {
+			if debug {
+				fmt.Println("[backend] Using Hetzner credentials from backend")
+			}
+			return strings.TrimSpace(backendCreds.APIToken), nil
+		}
+		if debug {
+			fmt.Printf("[backend] No Hetzner credentials available (%v), falling back to local\n", backendErr)
+		}
+	}
+
+	return "", fmt.Errorf("hetzner api_token is required (set hetzner.api_token or HCLOUD_TOKEN)")
+}
+
 // handleHetznerQuery delegates a Hetzner Cloud query to the Hetzner client
 func handleHetznerQuery(ctx context.Context, question string, debug bool) error {
 	if debug {
 		fmt.Println("Delegating query to Hetzner Cloud agent...")
 	}
 
-	apiToken := hetzner.ResolveAPIToken()
-	if apiToken == "" {
-		return fmt.Errorf("hetzner api_token is required (set hetzner.api_token or HCLOUD_TOKEN)")
+	apiToken, err := resolveHetznerToken(ctx, debug)
+	if err != nil {
+		return err
 	}
 
 	client, err := hetzner.NewClient(apiToken, debug)
@@ -1971,7 +2034,7 @@ func handleHetznerQuery(ctx context.Context, question string, debug bool) error 
 		apiKey = viper.GetString("ai.api_key")
 	}
 
-	aiClient := ai.NewClient(provider, apiKey, debug, "")
+	aiClient := ai.NewClient(provider, apiKey, debug, provider)
 
 	prompt := fmt.Sprintf(`You are a Hetzner Cloud infrastructure expert. Answer the user's question based on the following Hetzner Cloud context data.
 

--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -40,6 +40,30 @@ import (
 // askCmd represents the ask command
 const defaultGeminiModel = "gemini-2.5-flash"
 
+func applyDiscoveryContextDefaults(includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform bool) (bool, bool, bool, bool, bool, bool, bool) {
+	includeTerraform = true
+	if includeAWS || includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeHetzner {
+		return includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform
+	}
+
+	switch routing.DefaultInfraProvider() {
+	case "gcp":
+		includeGCP = true
+	case "azure":
+		includeAzure = true
+	case "cloudflare":
+		includeCloudflare = true
+	case "digitalocean":
+		includeDigitalOcean = true
+	case "hetzner":
+		includeHetzner = true
+	default:
+		includeAWS = true
+	}
+
+	return includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform
+}
+
 var askCmd = &cobra.Command{
 	Use:   "ask [question]",
 	Short: "Ask AI about your cloud infrastructure or GitHub repository",
@@ -610,10 +634,17 @@ Format as a professional compliance table suitable for government security docum
 
 		// Discovery mode enables comprehensive infrastructure analysis
 		if discovery {
-			includeAWS = true
-			includeTerraform = true
+			includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform = applyDiscoveryContextDefaults(
+				includeAWS,
+				includeGCP,
+				includeAzure,
+				includeCloudflare,
+				includeDigitalOcean,
+				includeHetzner,
+				includeTerraform,
+			)
 			if debug {
-				fmt.Println("Discovery mode enabled: AWS and Terraform contexts activated")
+				fmt.Println("Discovery mode enabled: Terraform context activated alongside the selected infrastructure provider(s)")
 			}
 		}
 

--- a/cmd/ask_test.go
+++ b/cmd/ask_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func useDefaultInfraProvider(t *testing.T, provider string) {
+	t.Helper()
+	previous := viper.GetString("infra.default_provider")
+	viper.Set("infra.default_provider", provider)
+	t.Cleanup(func() {
+		viper.Set("infra.default_provider", previous)
+	})
+}
+
+func TestApplyDiscoveryContextDefaults_UsesConfiguredHetzner(t *testing.T) {
+	useDefaultInfraProvider(t, "hetzner")
+
+	includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform := applyDiscoveryContextDefaults(false, false, false, false, false, false, false)
+
+	if includeAWS {
+		t.Fatal("expected discovery defaults not to force AWS when Hetzner is configured")
+	}
+	if includeGCP || includeAzure || includeCloudflare || includeDigitalOcean {
+		t.Fatal("expected discovery defaults to select only the configured provider")
+	}
+	if !includeHetzner {
+		t.Fatal("expected discovery defaults to enable Hetzner when configured")
+	}
+	if !includeTerraform {
+		t.Fatal("expected discovery defaults to enable Terraform context")
+	}
+}
+
+func TestApplyDiscoveryContextDefaults_PreservesExplicitProviderSelection(t *testing.T) {
+	useDefaultInfraProvider(t, "hetzner")
+
+	includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform := applyDiscoveryContextDefaults(false, false, false, false, false, true, false)
+
+	if includeAWS || includeGCP || includeAzure || includeCloudflare || includeDigitalOcean {
+		t.Fatal("expected explicit provider selection to be preserved without adding other providers")
+	}
+	if !includeHetzner {
+		t.Fatal("expected explicit Hetzner selection to remain enabled")
+	}
+	if !includeTerraform {
+		t.Fatal("expected discovery defaults to enable Terraform context when a provider is already selected")
+	}
+}

--- a/cmd/credentials.go
+++ b/cmd/credentials.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/bgdnvk/clanker/internal/backend"
 	"github.com/bgdnvk/clanker/internal/cloudflare"
+	"github.com/bgdnvk/clanker/internal/hetzner"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -35,13 +36,16 @@ var credentialsStoreCmd = &cobra.Command{
 	Short: "Store credentials in the backend",
 	Long: `Upload local credentials to the clanker backend.
 
-Supported providers: aws, gcp, cloudflare, k8s
+Supported providers: aws, gcp, hetzner, cloudflare, k8s
 
 AWS:
   Exports credentials from local AWS CLI profile using 'aws configure export-credentials'.
 
 GCP:
   Reads Application Default Credentials or specified service account file.
+
+Hetzner:
+  Uses api_token from config or HCLOUD_TOKEN.
 
 Cloudflare:
   Uses api_token and account_id from config or environment variables.
@@ -52,6 +56,7 @@ K8s:
 Examples:
   clanker credentials store aws --profile dev
   clanker credentials store gcp --project myproject
+  clanker credentials store hetzner
   clanker credentials store cloudflare
   clanker credentials store k8s --kubeconfig ~/.kube/config`,
 	Args: cobra.ExactArgs(1),
@@ -75,6 +80,7 @@ If no provider is specified, tests all stored credentials.
 Examples:
   clanker credentials test aws
   clanker credentials test gcp
+  clanker credentials test hetzner
   clanker credentials test cloudflare
   clanker credentials test k8s
   clanker credentials test`,
@@ -89,7 +95,8 @@ var credentialsDeleteCmd = &cobra.Command{
 
 Examples:
   clanker credentials delete aws
-  clanker credentials delete gcp`,
+  clanker credentials delete gcp
+  clanker credentials delete hetzner`,
 	Args: cobra.ExactArgs(1),
 	RunE: runCredentialsDelete,
 }
@@ -138,12 +145,14 @@ func runCredentialsStore(cmd *cobra.Command, args []string) error {
 		return storeAWSCredentials(ctx, cmd, client)
 	case "gcp":
 		return storeGCPCredentials(ctx, cmd, client)
+	case "hetzner":
+		return storeHetznerCredentials(ctx, cmd, client)
 	case "cloudflare", "cf":
 		return storeCloudflareCredentials(ctx, cmd, client)
 	case "k8s", "kubernetes":
 		return storeKubernetesCredentials(ctx, cmd, client)
 	default:
-		return fmt.Errorf("unsupported provider: %s (supported: aws, gcp, cloudflare, k8s)", provider)
+		return fmt.Errorf("unsupported provider: %s (supported: aws, gcp, hetzner, cloudflare, k8s)", provider)
 	}
 }
 
@@ -251,6 +260,24 @@ func storeGCPCredentials(ctx context.Context, cmd *cobra.Command, client *backen
 	return nil
 }
 
+func storeHetznerCredentials(ctx context.Context, cmd *cobra.Command, client *backend.Client) error {
+	apiToken := hetzner.ResolveAPIToken()
+	if apiToken == "" {
+		return fmt.Errorf("Hetzner API token required: set hetzner.api_token in config or HCLOUD_TOKEN env var")
+	}
+
+	creds := &backend.HetznerCredentials{
+		APIToken: apiToken,
+	}
+
+	if err := client.StoreHetznerCredentials(ctx, creds); err != nil {
+		return fmt.Errorf("failed to store Hetzner credentials: %w", err)
+	}
+
+	fmt.Println("Hetzner credentials stored successfully")
+	return nil
+}
+
 func storeCloudflareCredentials(ctx context.Context, cmd *cobra.Command, client *backend.Client) error {
 	apiToken := cloudflare.ResolveAPIToken()
 	accountID := cloudflare.ResolveAccountID()
@@ -337,6 +364,7 @@ func runCredentialsList(cmd *cobra.Command, args []string) error {
 		fmt.Println("\nTo store credentials, use:")
 		fmt.Println("  clanker credentials store aws --profile <profile>")
 		fmt.Println("  clanker credentials store gcp --project <project>")
+		fmt.Println("  clanker credentials store hetzner")
 		fmt.Println("  clanker credentials store cloudflare")
 		fmt.Println("  clanker credentials store k8s")
 		return nil
@@ -410,6 +438,8 @@ func testCredential(ctx context.Context, client *backend.Client, provider backen
 		return testAWSCredentials(ctx, client, debug)
 	case backend.ProviderGCP:
 		return testGCPCredentials(ctx, client, debug)
+	case backend.ProviderHetzner:
+		return testHetznerCredentials(ctx, client, debug)
 	case backend.ProviderCloudflare:
 		return testCloudflareCredentials(ctx, client, debug)
 	case backend.ProviderKubernetes:
@@ -518,6 +548,34 @@ func testGCPCredentials(ctx context.Context, client *backend.Client, debug bool)
 		}
 		fmt.Printf("  PASSED: Project %s\n", strings.TrimSpace(string(output)))
 	}
+	return nil
+}
+
+func testHetznerCredentials(ctx context.Context, client *backend.Client, debug bool) error {
+	creds, err := client.GetHetznerCredentials(ctx)
+	if err != nil {
+		fmt.Printf("  FAILED: %v\n", err)
+		return err
+	}
+
+	if creds.APIToken == "" {
+		fmt.Println("  FAILED: no API token stored")
+		return fmt.Errorf("no Hetzner API token")
+	}
+
+	cmd := exec.CommandContext(ctx, "hcloud", "server", "list", "--output", "json")
+	cmd.Env = append(os.Environ(), fmt.Sprintf("HCLOUD_TOKEN=%s", creds.APIToken))
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Printf("  FAILED: %v\n", err)
+		if debug {
+			fmt.Printf("  Output: %s\n", string(output))
+		}
+		return fmt.Errorf("Hetzner credential test failed")
+	}
+
+	fmt.Println("  PASSED: token accepted by hcloud")
 	return nil
 }
 
@@ -641,12 +699,14 @@ func runCredentialsDelete(cmd *cobra.Command, args []string) error {
 		credProvider = backend.ProviderAWS
 	case "gcp":
 		credProvider = backend.ProviderGCP
+	case "hetzner":
+		credProvider = backend.ProviderHetzner
 	case "cloudflare", "cf":
 		credProvider = backend.ProviderCloudflare
 	case "k8s", "kubernetes":
 		credProvider = backend.ProviderKubernetes
 	default:
-		return fmt.Errorf("unsupported provider: %s (supported: aws, gcp, cloudflare, k8s)", provider)
+		return fmt.Errorf("unsupported provider: %s (supported: aws, gcp, hetzner, cloudflare, k8s)", provider)
 	}
 
 	client := backend.NewClient(apiKey, debug)

--- a/internal/backend/client.go
+++ b/internal/backend/client.go
@@ -234,6 +234,32 @@ func (c *Client) GetAzureCredentials(ctx context.Context) (*AzureCredentials, er
 	return &response.Data.Credentials, nil
 }
 
+// GetHetznerCredentials retrieves Hetzner credentials from the backend
+func (c *Client) GetHetznerCredentials(ctx context.Context) (*HetznerCredentials, error) {
+	respBody, err := c.doRequest(ctx, http.MethodGet, "/api/v1/cli/credentials/hetzner", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Provider    string             `json:"provider"`
+			Credentials HetznerCredentials `json:"credentials"`
+		} `json:"data"`
+	}
+
+	if err := json.Unmarshal(respBody, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if !response.Success {
+		return nil, fmt.Errorf("failed to get Hetzner credentials")
+	}
+
+	return &response.Data.Credentials, nil
+}
+
 // StoreAWSCredentials stores AWS credentials in the backend
 func (c *Client) StoreAWSCredentials(ctx context.Context, creds *AWSCredentials) error {
 	body := map[string]interface{}{
@@ -351,6 +377,33 @@ func (c *Client) StoreAzureCredentials(ctx context.Context, creds *AzureCredenti
 	}
 
 	respBody, err := c.doRequest(ctx, http.MethodPut, "/api/v1/secrets/azure", body)
+	if err != nil {
+		return err
+	}
+
+	var response APIResponse
+	if err := json.Unmarshal(respBody, &response); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if !response.Success {
+		if response.Error != "" {
+			return fmt.Errorf("failed to store credentials: %s", response.Error)
+		}
+		return fmt.Errorf("failed to store credentials")
+	}
+
+	return nil
+}
+
+// StoreHetznerCredentials stores Hetzner credentials in the backend
+func (c *Client) StoreHetznerCredentials(ctx context.Context, creds *HetznerCredentials) error {
+	body := map[string]interface{}{
+		"provider":    "hetzner",
+		"credentials": creds,
+	}
+
+	respBody, err := c.doRequest(ctx, http.MethodPut, "/api/v1/secrets/hetzner", body)
 	if err != nil {
 		return err
 	}

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -35,10 +35,51 @@ type Classification struct {
 	Reason     string `json:"reason"`
 }
 
+// DefaultInfraProvider returns the configured default infrastructure provider.
+// Falls back to AWS for backward compatibility.
+func DefaultInfraProvider() string {
+	switch strings.ToLower(strings.TrimSpace(viper.GetString("infra.default_provider"))) {
+	case "aws", "gcp", "azure", "cloudflare", "digitalocean", "hetzner":
+		return strings.ToLower(strings.TrimSpace(viper.GetString("infra.default_provider")))
+	default:
+		return "aws"
+	}
+}
+
+func applyConfiguredDefaultContext(ctx *ServiceContext) {
+	ctx.AWS = false
+	ctx.GitHub = false
+	ctx.Terraform = false
+	ctx.K8s = false
+	ctx.GCP = false
+	ctx.Azure = false
+	ctx.Cloudflare = false
+	ctx.DigitalOcean = false
+	ctx.Hetzner = false
+	ctx.IAM = false
+
+	switch DefaultInfraProvider() {
+	case "gcp":
+		ctx.GCP = true
+	case "azure":
+		ctx.Azure = true
+	case "cloudflare":
+		ctx.Cloudflare = true
+	case "digitalocean":
+		ctx.DigitalOcean = true
+	case "hetzner":
+		ctx.Hetzner = true
+	default:
+		ctx.AWS = true
+		ctx.GitHub = true
+	}
+}
+
 // InferContext analyzes a question and determines which cloud service contexts are relevant.
 // Returns a ServiceContext with boolean flags for each detected service.
 func InferContext(question string) ServiceContext {
 	ctx := ServiceContext{}
+	defaultProvider := DefaultInfraProvider()
 
 	awsKeywords := []string{
 		// Core services
@@ -46,15 +87,20 @@ func InferContext(question string) ServiceContext {
 		"sqs", "sns", "dynamodb", "elasticache", "elb", "alb", "nlb", "route53",
 		"cloudfront", "api-gateway", "cognito", "iam", "vpc", "subnet",
 		"security-group", "nacl", "nat", "igw", "vpn", "direct-connect",
-		// General terms that strongly indicate AWS context
-		"instance", "bucket", "database", "aws", "resources", "infrastructure",
-		"running", "account", "error", "log", "job", "queue", "compute",
-		"storage", "network", "cdn", "load-balancer", "auto-scaling", "scaling",
-		"health", "metric", "alarm", "notification", "backup", "snapshot",
-		"ami", "volume", "ebs", "efs", "fsx",
+		// AWS-specific terms
+		"bucket", "aws", "ami", "ebs", "efs", "fsx",
 		// ML/GPU
 		"gpu", "cuda", "ml", "machine-learning", "training", "inference",
 		"p2", "p3", "p4", "g3", "g4", "g5", "spot", "reserved", "dedicated",
+	}
+
+	awsFallbackKeywords := []string{
+		// Generic infrastructure terms that should only imply AWS when AWS is
+		// the configured default provider.
+		"instance", "database", "resources", "infrastructure",
+		"running", "account", "error", "log", "job", "queue", "compute",
+		"storage", "network", "cdn", "load-balancer", "auto-scaling", "scaling",
+		"health", "metric", "alarm", "notification", "backup", "snapshot",
 		// Status keywords
 		"status", "state", "healthy", "unhealthy", "available", "pending",
 		"stopping", "stopped", "terminated", "creating", "deleting", "modifying",
@@ -214,6 +260,15 @@ func InferContext(question string) ServiceContext {
 		}
 	}
 
+	if !ctx.AWS && defaultProvider == "aws" {
+		for _, keyword := range awsFallbackKeywords {
+			if contains(questionLower, keyword) {
+				ctx.AWS = true
+				break
+			}
+		}
+	}
+
 	for _, keyword := range githubKeywords {
 		if contains(questionLower, keyword) {
 			ctx.GitHub = true
@@ -275,10 +330,10 @@ func InferContext(question string) ServiceContext {
 		}
 	}
 
-	// Default to AWS and GitHub context if nothing is detected
+	// Default to the configured provider if nothing is detected.
+	// AWS keeps GitHub enabled for backward compatibility.
 	if !ctx.AWS && !ctx.GitHub && !ctx.Terraform && !ctx.K8s && !ctx.GCP && !ctx.Azure && !ctx.Cloudflare && !ctx.DigitalOcean && !ctx.Hetzner && !ctx.IAM {
-		ctx.AWS = true
-		ctx.GitHub = true
+		applyConfiguredDefaultContext(&ctx)
 	}
 
 	return ctx
@@ -286,6 +341,7 @@ func InferContext(question string) ServiceContext {
 
 // GetClassificationPrompt returns a prompt for LLM to classify which service a query is about
 func GetClassificationPrompt(question string) string {
+	defaultProvider := DefaultInfraProvider()
 	return fmt.Sprintf(`Classify which cloud service or platform this user query is about.
 
 User Query: "%s"
@@ -305,19 +361,19 @@ Available services:
 
 IMPORTANT RULES:
 1. Only classify as "cloudflare" if the query EXPLICITLY mentions Cloudflare, wrangler, cloudflared, or Cloudflare-specific products
-2. Generic terms like "cdn", "cache", "dns", "worker", "waf", "rate limit", "tunnel" should default to AWS unless Cloudflare is explicitly mentioned
+2. Generic terms like "cdn", "cache", "dns", "worker", "waf", "rate limit", "tunnel" should prefer the configured default provider (%s) unless Cloudflare is explicitly mentioned
 3. If the query is specifically about IAM roles, policies, permissions, access keys, trust policies, or security analysis, classify as "iam"
 4. If the query mentions AWS services (EC2, Lambda, S3, CloudFront, Route53, etc.) but NOT IAM-specific topics, classify as "aws"
 5. Only classify as "digitalocean" if the query EXPLICITLY mentions Digital Ocean, doctl, droplets, DOKS, or Digital Ocean-specific products
 6. Only classify as "hetzner" if the query EXPLICITLY mentions Hetzner, hcloud, or Hetzner-specific products
-7. If uncertain, classify as "aws" (the default cloud provider)
+7. If uncertain, classify as "%s" (the configured default cloud provider)
 
 Respond with ONLY a JSON object:
 {
 	"service": "cloudflare|aws|iam|k8s|gcp|azure|digitalocean|hetzner|github|terraform|general",
     "confidence": "high|medium|low",
     "reason": "brief explanation of why this classification"
-}`, question)
+}`, question, defaultProvider, defaultProvider)
 }
 
 // ClassifyWithLLM uses the AI client to determine which service a query is about.
@@ -510,14 +566,8 @@ func ApplyLLMClassification(ctx *ServiceContext, llmService string) {
 		ctx.DigitalOcean = false
 		ctx.Hetzner = false
 	default:
-		// "general" - default to AWS
-		ctx.AWS = true
-		ctx.Cloudflare = false
-		ctx.K8s = false
-		ctx.Azure = false
-		ctx.DigitalOcean = false
-		ctx.Hetzner = false
-		ctx.IAM = false
+		// "general" - default to the configured infrastructure provider
+		applyConfiguredDefaultContext(ctx)
 	}
 }
 

--- a/internal/routing/routing_test.go
+++ b/internal/routing/routing_test.go
@@ -2,9 +2,71 @@ package routing
 
 import (
 	"testing"
+
+	"github.com/spf13/viper"
 )
 
+func useDefaultProvider(t *testing.T, provider string) {
+	t.Helper()
+	previous := viper.GetString("infra.default_provider")
+	viper.Set("infra.default_provider", provider)
+	t.Cleanup(func() {
+		viper.Set("infra.default_provider", previous)
+	})
+}
+
+func TestInferContext_DefaultBehavior_ConfiguredAWS(t *testing.T) {
+	useDefaultProvider(t, "")
+
+	// Unknown queries should default to AWS + GitHub
+	ctx := InferContext("random question about nothing")
+
+	if !ctx.AWS {
+		t.Error("Unknown query should default to AWS=true")
+	}
+	if !ctx.GitHub {
+		t.Error("Unknown query should default to GitHub=true")
+	}
+	if ctx.Cloudflare {
+		t.Error("Unknown query should not trigger Cloudflare")
+	}
+	if ctx.K8s {
+		t.Error("Unknown query should not trigger K8s")
+	}
+}
+
+func TestInferContext_DefaultBehavior_ConfiguredHetzner(t *testing.T) {
+	useDefaultProvider(t, "hetzner")
+
+	ctx := InferContext("random question about nothing")
+
+	if !ctx.Hetzner {
+		t.Error("Unknown query should default to Hetzner=true when configured")
+	}
+	if ctx.AWS {
+		t.Error("Unknown query should not default to AWS when Hetzner is configured")
+	}
+	if ctx.GitHub {
+		t.Error("Unknown query should not default to GitHub when Hetzner is configured")
+	}
+}
+
+func TestInferContext_GenericDiscoveryUsesConfiguredHetzner(t *testing.T) {
+	useDefaultProvider(t, "hetzner")
+
+	ctx := InferContext("what is running right now?")
+
+	if !ctx.Hetzner {
+		t.Error("Generic discovery query should use Hetzner when configured")
+	}
+	if ctx.AWS {
+		t.Error("Generic discovery query should not force AWS when Hetzner is configured")
+	}
+}
+
 func TestInferContext_CloudflareExplicit(t *testing.T) {
+	useDefaultProvider(t, "")
+
 	tests := []struct {
 		name             string
 		query            string
@@ -155,25 +217,9 @@ func TestInferContext_NoCloudflarefalsePositives(t *testing.T) {
 	}
 }
 
-func TestInferContext_DefaultBehavior(t *testing.T) {
-	// Unknown queries should default to AWS + GitHub
-	ctx := InferContext("random question about nothing")
-
-	if !ctx.AWS {
-		t.Error("Unknown query should default to AWS=true")
-	}
-	if !ctx.GitHub {
-		t.Error("Unknown query should default to GitHub=true")
-	}
-	if ctx.Cloudflare {
-		t.Error("Unknown query should not trigger Cloudflare")
-	}
-	if ctx.K8s {
-		t.Error("Unknown query should not trigger K8s")
-	}
-}
-
 func TestGetClassificationPrompt(t *testing.T) {
+	useDefaultProvider(t, "")
+
 	prompt := GetClassificationPrompt("list my cloudflare zones")
 
 	if prompt == "" {
@@ -240,6 +286,8 @@ func TestNeedsLLMClassification(t *testing.T) {
 }
 
 func TestApplyLLMClassification(t *testing.T) {
+	useDefaultProvider(t, "")
+
 	tests := []struct {
 		name       string
 		llmService string
@@ -308,6 +356,23 @@ func TestApplyLLMClassification(t *testing.T) {
 				t.Errorf("ApplyLLMClassification(%q) GCP = %v, want %v", tt.llmService, ctx.GCP, tt.expectGCP)
 			}
 		})
+	}
+}
+
+func TestApplyLLMClassification_GeneralUsesConfiguredDefault(t *testing.T) {
+	useDefaultProvider(t, "hetzner")
+
+	ctx := ServiceContext{}
+	ApplyLLMClassification(&ctx, "general")
+
+	if !ctx.Hetzner {
+		t.Error("general classification should use configured Hetzner default")
+	}
+	if ctx.AWS {
+		t.Error("general classification should not force AWS when Hetzner is configured")
+	}
+	if ctx.GitHub {
+		t.Error("general classification should not enable GitHub when Hetzner is configured")
 	}
 }
 


### PR DESCRIPTION
## Summary
- route generic infrastructure questions to the configured default provider instead of hard-coding AWS
- make discovery mode use the configured infra provider instead of unconditionally enabling AWS
- add Hetzner credential support to backend and CLI credential flows
- make explicit provider handlers honor command-level AI overrides such as `--ai-profile` and model flags

## Why
Hetzner-first setups could still fall into AWS initialization through multiple paths. Generic infrastructure questions could default to AWS, and discovery mode separately forced AWS context even when Hetzner was the configured default provider. That produced AWS profile errors in environments that were intentionally not using AWS. The explicit Hetzner path also was not consistent about credential fallback, and command-level AI overrides were not applied uniformly across explicit provider handlers.

## What changed
- use `infra.default_provider` for generic routing and maker defaults
- narrow AWS keyword inference so generic discovery terms only imply AWS when AWS is the configured default provider
- make `--discovery` preserve any explicit provider flags and otherwise enable the configured default provider alongside Terraform context
- share Hetzner token resolution across ask/apply paths
- add Hetzner support to backend credential storage and `clanker credentials`
- apply command-level AI overrides before routing and explicit handler execution
- add test coverage for configured Hetzner defaults in routing and discovery mode

## Impact
This makes generic and discovery-oriented infra questions behave correctly in Hetzner-first setups, removes unnecessary AWS coupling in those flows, and makes provider-specific commands respect the AI configuration the caller actually requested.

## Validation
- `go test ./...`
- `make install`
- `clanker ask --config ~/.clanker.yaml --debug "what is running right now?"`
- `clanker ask --config ~/.clanker.yaml --ai-profile openai --openai-model gpt-4o-mini --debug "what is running right now?"`
- `clanker ask --debug --discovery --terraform --github "Review my Hetzner infrastructure end-to-end and give me a prioritized improvement plan..."` run from `~/Projects/platform-infra`
