### PR TITLE
feat: add OpenAI Codex OAuth login and Responses API client

### DIFF
--- a/.clanker.example.yaml
+++ b/.clanker.example.yaml
@@ -18,6 +18,7 @@ ai:
     openai:
       model: gpt-5
       api_key: ""
+      auth_method: ""  # "apiKey" or "oauth" -- oauth uses ChatGPT account login
       # Optional for OpenAI-compatible local servers such as llama-server.
       # If the endpoint is localhost, api_key can stay empty.
       # local_model_inference_url: "http://127.0.0.1:8080/v1"

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -73,10 +73,10 @@ func runAuthLogin(_ *cobra.Command, _ []string) error {
 	// Build the authorization URL.
 	params := url.Values{
 		"client_id":             {oauthClientID},
-		"redirect_uri":         {oauthRedirectURI},
-		"response_type":        {"code"},
-		"scope":                {"openid profile email offline_access"},
-		"code_challenge":       {codeChallenge},
+		"redirect_uri":          {oauthRedirectURI},
+		"response_type":         {"code"},
+		"scope":                 {"openid profile email offline_access"},
+		"code_challenge":        {codeChallenge},
 		"code_challenge_method": {"S256"},
 	}
 	authURL := oauthAuthorizeURL + "?" + params.Encode()

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -104,7 +104,7 @@ func runAuthLogin(_ *cobra.Command, _ []string) error {
 	})
 
 	server := &http.Server{
-		Addr:    ":" + oauthCallbackPort,
+		Addr:    "127.0.0.1:" + oauthCallbackPort,
 		Handler: mux,
 	}
 

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,0 +1,247 @@
+package cmd
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/bgdnvk/clanker/internal/ai"
+	"github.com/spf13/cobra"
+)
+
+const (
+	oauthAuthorizeURL = "https://auth.openai.com/oauth/authorize"
+	oauthTokenURL     = "https://auth.openai.com/oauth/token"
+	oauthClientID     = "app_EMoamEEZ73f0CkXaXp7hrann"
+	oauthRedirectURI  = "http://localhost:1455/auth/callback"
+	oauthCallbackPort = "1455"
+)
+
+var authCmd = &cobra.Command{
+	Use:   "auth",
+	Short: "Manage OpenAI OAuth authentication",
+	Long:  "Login, logout, and check authentication status for OpenAI OAuth (ChatGPT account).",
+}
+
+var authLoginCmd = &cobra.Command{
+	Use:   "login",
+	Short: "Login with your OpenAI (ChatGPT) account via OAuth",
+	RunE:  runAuthLogin,
+}
+
+var authLogoutCmd = &cobra.Command{
+	Use:   "logout",
+	Short: "Remove saved OpenAI OAuth credentials",
+	RunE:  runAuthLogout,
+}
+
+var authStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show current OpenAI OAuth login status",
+	RunE:  runAuthStatus,
+}
+
+func init() {
+	authCmd.AddCommand(authLoginCmd)
+	authCmd.AddCommand(authLogoutCmd)
+	authCmd.AddCommand(authStatusCmd)
+	rootCmd.AddCommand(authCmd)
+}
+
+func runAuthLogin(_ *cobra.Command, _ []string) error {
+	// Generate PKCE code verifier (32 random bytes, base64url encoded).
+	verifierBytes := make([]byte, 32)
+	if _, err := rand.Read(verifierBytes); err != nil {
+		return fmt.Errorf("failed to generate code verifier: %w", err)
+	}
+	codeVerifier := base64.RawURLEncoding.EncodeToString(verifierBytes)
+
+	// Derive code challenge (SHA-256 of verifier, base64url encoded).
+	h := sha256.Sum256([]byte(codeVerifier))
+	codeChallenge := base64.RawURLEncoding.EncodeToString(h[:])
+
+	// Build the authorization URL.
+	params := url.Values{
+		"client_id":             {oauthClientID},
+		"redirect_uri":         {oauthRedirectURI},
+		"response_type":        {"code"},
+		"scope":                {"openid profile email offline_access"},
+		"code_challenge":       {codeChallenge},
+		"code_challenge_method": {"S256"},
+	}
+	authURL := oauthAuthorizeURL + "?" + params.Encode()
+
+	// Channel to receive the authorization code from the callback.
+	codeCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+
+	// Start local HTTP server to receive the OAuth callback.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/auth/callback", func(w http.ResponseWriter, r *http.Request) {
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			errMsg := r.URL.Query().Get("error")
+			if errMsg == "" {
+				errMsg = "no authorization code received"
+			}
+			http.Error(w, "Authorization failed: "+errMsg, http.StatusBadRequest)
+			errCh <- fmt.Errorf("authorization failed: %s", errMsg)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<html><body><h2>Login successful!</h2><p>You can close this window and return to the terminal.</p></body></html>`)
+		codeCh <- code
+	})
+
+	server := &http.Server{
+		Addr:    ":" + oauthCallbackPort,
+		Handler: mux,
+	}
+
+	go func() {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errCh <- fmt.Errorf("callback server failed: %w", err)
+		}
+	}()
+
+	// Open the authorization URL in the default browser.
+	fmt.Println("Opening browser for OpenAI login...")
+	fmt.Printf("If the browser does not open, visit this URL:\n%s\n\n", authURL)
+	openBrowser(authURL)
+
+	// Wait for the callback or an error.
+	var authCode string
+	select {
+	case authCode = <-codeCh:
+	case err := <-errCh:
+		server.Close()
+		return err
+	case <-time.After(5 * time.Minute):
+		server.Close()
+		return fmt.Errorf("login timed out after 5 minutes")
+	}
+
+	// Shut down the callback server.
+	server.Close()
+
+	// Exchange authorization code for tokens.
+	tokens, email, err := exchangeAuthCode(authCode, codeVerifier)
+	if err != nil {
+		return err
+	}
+
+	// Save tokens to disk.
+	if err := ai.SaveOAuthTokens(tokens); err != nil {
+		return fmt.Errorf("failed to save tokens: %w", err)
+	}
+
+	if email != "" {
+		fmt.Printf("Logged in as %s\n", email)
+	} else {
+		fmt.Println("Logged in successfully")
+	}
+	return nil
+}
+
+func exchangeAuthCode(code, codeVerifier string) (*ai.OAuthTokens, string, error) {
+	form := url.Values{
+		"grant_type":    {"authorization_code"},
+		"client_id":     {oauthClientID},
+		"code":          {code},
+		"code_verifier": {codeVerifier},
+		"redirect_uri":  {oauthRedirectURI},
+	}
+
+	resp, err := http.Post(oauthTokenURL, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, "", fmt.Errorf("token exchange request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to read token response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("token exchange failed (HTTP %d): %s", resp.StatusCode, string(body))
+	}
+
+	var raw struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		IDToken      string `json:"id_token"`
+		ExpiresIn    int64  `json:"expires_in"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, "", fmt.Errorf("failed to parse token response: %w", err)
+	}
+
+	email := ai.ExtractEmailFromIDToken(raw.IDToken)
+
+	tokens := &ai.OAuthTokens{
+		AccessToken:  raw.AccessToken,
+		RefreshToken: raw.RefreshToken,
+		ExpiresAt:    time.Now().Unix() + raw.ExpiresIn,
+		Email:        email,
+	}
+
+	return tokens, email, nil
+}
+
+func runAuthLogout(_ *cobra.Command, _ []string) error {
+	if err := ai.RemoveOAuthTokens(); err != nil {
+		return fmt.Errorf("failed to remove auth tokens: %w", err)
+	}
+	fmt.Println("Logged out")
+	return nil
+}
+
+func runAuthStatus(_ *cobra.Command, _ []string) error {
+	tokens, err := ai.LoadOAuthTokens()
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Println("Not logged in")
+			return nil
+		}
+		return fmt.Errorf("failed to read auth tokens: %w", err)
+	}
+
+	if tokens.Email != "" {
+		fmt.Printf("Logged in as %s\n", tokens.Email)
+	} else {
+		fmt.Println("Logged in (email not available)")
+	}
+
+	expiresAt := time.Unix(tokens.ExpiresAt, 0)
+	if time.Now().After(expiresAt) {
+		fmt.Println("Token expired (will be refreshed on next use)")
+	} else {
+		fmt.Printf("Token expires at %s\n", expiresAt.Format(time.RFC3339))
+	}
+
+	return nil
+}
+
+// openBrowser opens the given URL in the default browser.
+func openBrowser(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	_ = cmd.Start()
+}

--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -1075,6 +1075,11 @@ func (c *Client) resolveLocalModelInferenceURL(profile *awsclient.AIProfile) str
 }
 
 func (c *Client) askOpenAI(ctx context.Context, prompt string) (string, error) {
+	// If no API key is configured but OAuth is available, use the Codex Responses API.
+	if strings.TrimSpace(c.apiKey) == "" && IsOpenAIOAuthActive() {
+		return c.AskCodex(ctx, prompt)
+	}
+
 	// Get the AI profile configuration (this is the profileLLMCall for OpenAI API access)
 	profileLLMCall, err := c.getAIProfile(c.aiProfile)
 	if err != nil {

--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -1091,7 +1091,7 @@ func (c *Client) askOpenAI(ctx context.Context, prompt string) (string, error) {
 	}
 
 	if strings.TrimSpace(c.apiKey) == "" && !isLocalModelInferenceEndpoint(c.baseURL) {
-		return "", fmt.Errorf("OpenAI API key not configured")
+		return "", fmt.Errorf("OpenAI API key not configured (or run 'clanker auth login' for OAuth)")
 	}
 
 	request := OpenAIRequest{
@@ -2170,6 +2170,11 @@ func (c *Client) askMiniMaxWithHistory(ctx context.Context, conv *ConversationCo
 
 // askOpenAIWithHistory sends a multi-turn request to OpenAI API
 func (c *Client) askOpenAIWithHistory(ctx context.Context, conv *ConversationContext) (string, error) {
+	// If no API key but OAuth is available, use the Codex Responses API.
+	if strings.TrimSpace(c.apiKey) == "" && IsOpenAIOAuthActive() {
+		return c.askCodexWithHistory(ctx, conv)
+	}
+
 	// Build messages array
 	messages := make([]Message, 0, len(conv.Messages)+1)
 
@@ -2192,7 +2197,7 @@ func (c *Client) askOpenAIWithHistory(ctx context.Context, conv *ConversationCon
 		c.baseURL = localModelInferenceURL
 	}
 	if strings.TrimSpace(c.apiKey) == "" && !isLocalModelInferenceEndpoint(c.baseURL) {
-		return "", fmt.Errorf("OpenAI API key not configured")
+		return "", fmt.Errorf("OpenAI API key not configured (or run 'clanker auth login' for OAuth)")
 	}
 
 	model := strings.TrimSpace(profileLLMCall.Model)

--- a/internal/ai/codex_client.go
+++ b/internal/ai/codex_client.go
@@ -207,6 +207,39 @@ func AskCodexStream(ctx context.Context, oauthToken, model, prompt string) (<-ch
 	return textCh, errCh
 }
 
+// askCodexWithHistory sends a multi-turn conversation to the Codex Responses API.
+func (c *Client) askCodexWithHistory(ctx context.Context, conv *ConversationContext) (string, error) {
+	oauthToken, err := GetValidOAuthToken()
+	if err != nil {
+		return "", fmt.Errorf("failed to get oauth token: %w", err)
+	}
+
+	profileLLMCall, err := c.getAIProfile(c.aiProfile)
+	if err != nil {
+		return "", fmt.Errorf("failed to get AI profile: %w", err)
+	}
+	model := profileLLMCall.Model
+	if model == "" {
+		model = "gpt-5.4"
+	}
+
+	// Build messages: system prompt as instructions is handled by askCodexWithToken
+	// but we merge them into a single prompt for simplicity.
+	var sb strings.Builder
+	if conv.SystemPrompt != "" {
+		sb.WriteString(conv.SystemPrompt)
+		sb.WriteString("\n\n")
+	}
+	for _, m := range conv.Messages {
+		sb.WriteString(m.Role)
+		sb.WriteString(": ")
+		sb.WriteString(m.Content)
+		sb.WriteString("\n\n")
+	}
+
+	return askCodexWithToken(ctx, oauthToken, model, sb.String())
+}
+
 // IsOpenAIOAuthActive returns true if the user has a saved OAuth token
 // or an OPENAI_OAUTH_TOKEN environment variable.
 func IsOpenAIOAuthActive() bool {

--- a/internal/ai/codex_client.go
+++ b/internal/ai/codex_client.go
@@ -1,0 +1,221 @@
+package ai
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	codexResponsesURL = "https://chatgpt.com/backend-api/codex/responses"
+)
+
+// CodexRequest is the Responses API request format.
+type CodexRequest struct {
+	Model        string    `json:"model"`
+	Instructions string    `json:"instructions,omitempty"`
+	Input        []Message `json:"input"`
+	Stream       bool      `json:"stream"`
+}
+
+// AskCodex sends a non-streaming request to the Codex Responses API
+// and returns the full text response. This is used when the OpenAI auth
+// method is OAuth rather than API key.
+func (c *Client) AskCodex(ctx context.Context, prompt string) (string, error) {
+	oauthToken, err := GetValidOAuthToken()
+	if err != nil {
+		return "", fmt.Errorf("failed to get oauth token: %w", err)
+	}
+
+	profileLLMCall, err := c.getAIProfile(c.aiProfile)
+	if err != nil {
+		return "", fmt.Errorf("failed to get AI profile: %w", err)
+	}
+	model := profileLLMCall.Model
+	if model == "" {
+		model = "gpt-5.4"
+	}
+
+	return askCodexWithToken(ctx, oauthToken, model, prompt)
+}
+
+func askCodexWithToken(ctx context.Context, oauthToken, model, prompt string) (string, error) {
+	codexReq := CodexRequest{
+		Model:  model,
+		Input:  []Message{{Role: "user", Content: sanitizeASCII(prompt)}},
+		Stream: false,
+	}
+
+	body, err := json.Marshal(codexReq)
+	if err != nil {
+		return "", fmt.Errorf("marshal codex request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, codexResponsesURL, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("create codex request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+oauthToken)
+
+	client := &http.Client{Timeout: 120 * time.Second}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("codex request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read codex response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("codex returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		Output []struct {
+			Type    string `json:"type"`
+			Content []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"output"`
+		Error *struct {
+			Message string `json:"message"`
+			Code    string `json:"code"`
+		} `json:"error,omitempty"`
+	}
+
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", fmt.Errorf("decode codex response: %w", err)
+	}
+
+	if result.Error != nil {
+		return "", fmt.Errorf("codex api error (%s): %s", result.Error.Code, result.Error.Message)
+	}
+
+	var sb strings.Builder
+	for _, item := range result.Output {
+		if item.Type != "message" {
+			continue
+		}
+		for _, part := range item.Content {
+			if part.Type == "output_text" || part.Type == "text" {
+				sb.WriteString(part.Text)
+			}
+		}
+	}
+
+	return sb.String(), nil
+}
+
+// AskCodexStream sends a streaming request to the Codex Responses API
+// and returns text deltas on a channel.
+func AskCodexStream(ctx context.Context, oauthToken, model, prompt string) (<-chan string, <-chan error) {
+	textCh := make(chan string, 64)
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer close(textCh)
+		defer close(errCh)
+
+		codexReq := CodexRequest{
+			Model:  model,
+			Input:  []Message{{Role: "user", Content: prompt}},
+			Stream: true,
+		}
+
+		body, err := json.Marshal(codexReq)
+		if err != nil {
+			errCh <- fmt.Errorf("marshal codex request: %w", err)
+			return
+		}
+
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, codexResponsesURL, bytes.NewReader(body))
+		if err != nil {
+			errCh <- fmt.Errorf("create codex request: %w", err)
+			return
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("Authorization", "Bearer "+oauthToken)
+		httpReq.Header.Set("Accept", "text/event-stream")
+
+		client := &http.Client{Timeout: 120 * time.Second}
+		resp, err := client.Do(httpReq)
+		if err != nil {
+			errCh <- fmt.Errorf("codex request failed: %w", err)
+			return
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			respBody, _ := io.ReadAll(resp.Body)
+			errCh <- fmt.Errorf("codex returned status %d: %s", resp.StatusCode, string(respBody))
+			return
+		}
+
+		scanner := bufio.NewScanner(resp.Body)
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+		for scanner.Scan() {
+			line := scanner.Text()
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			data := strings.TrimPrefix(line, "data: ")
+			if data == "[DONE]" {
+				return
+			}
+
+			var event struct {
+				Type  string `json:"type"`
+				Delta string `json:"delta"`
+			}
+			if err := json.Unmarshal([]byte(data), &event); err != nil {
+				continue
+			}
+
+			switch event.Type {
+			case "response.output_text.delta":
+				if event.Delta != "" {
+					select {
+					case textCh <- event.Delta:
+					case <-ctx.Done():
+						errCh <- ctx.Err()
+						return
+					}
+				}
+			case "response.completed", "response.done":
+				return
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			errCh <- fmt.Errorf("reading codex stream: %w", err)
+		}
+	}()
+
+	return textCh, errCh
+}
+
+// IsOpenAIOAuthActive returns true if the user has a saved OAuth token
+// or an OPENAI_OAUTH_TOKEN environment variable.
+func IsOpenAIOAuthActive() bool {
+	if envToken := strings.TrimSpace(os.Getenv("OPENAI_OAUTH_TOKEN")); envToken != "" {
+		return true
+	}
+	tokens, err := LoadOAuthTokens()
+	if err != nil {
+		return false
+	}
+	return tokens.AccessToken != ""
+}

--- a/internal/ai/codex_client.go
+++ b/internal/ai/codex_client.go
@@ -205,7 +205,9 @@ func AskCodexStream(ctx context.Context, oauthToken, model, prompt string) (<-ch
 	return textCh, errCh
 }
 
-// askCodexWithHistory sends a multi-turn conversation to the Codex Responses API.
+// askCodexWithHistory sends a multi-turn conversation to the Codex Responses API
+// using structured message roles (system prompt becomes instructions, messages
+// become the input array).
 func (c *Client) askCodexWithHistory(ctx context.Context, conv *ConversationContext) (string, error) {
 	oauthToken, err := GetValidOAuthToken()
 	if err != nil {
@@ -221,21 +223,81 @@ func (c *Client) askCodexWithHistory(ctx context.Context, conv *ConversationCont
 		model = "gpt-5.4"
 	}
 
-	// Build messages: system prompt as instructions is handled by askCodexWithToken
-	// but we merge them into a single prompt for simplicity.
-	var sb strings.Builder
-	if conv.SystemPrompt != "" {
-		sb.WriteString(conv.SystemPrompt)
-		sb.WriteString("\n\n")
+	codexReq := CodexRequest{
+		Model:  model,
+		Stream: false,
 	}
-	for _, m := range conv.Messages {
-		sb.WriteString(m.Role)
-		sb.WriteString(": ")
-		sb.WriteString(m.Content)
-		sb.WriteString("\n\n")
+	if conv.SystemPrompt != "" {
+		codexReq.Instructions = conv.SystemPrompt
+	}
+	codexReq.Input = make([]Message, len(conv.Messages))
+	for i, m := range conv.Messages {
+		codexReq.Input[i] = Message{Role: m.Role, Content: sanitizeASCII(m.Content)}
+	}
+	if codexReq.Input == nil {
+		codexReq.Input = []Message{}
 	}
 
-	return askCodexWithToken(ctx, oauthToken, model, sb.String())
+	body, err := json.Marshal(codexReq)
+	if err != nil {
+		return "", fmt.Errorf("marshal codex request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, codexResponsesURL, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("create codex request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+oauthToken)
+
+	client := &http.Client{Timeout: 120 * time.Second}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("codex request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read codex response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("codex returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result struct {
+		Output []struct {
+			Type    string `json:"type"`
+			Content []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"output"`
+		Error *struct {
+			Message string `json:"message"`
+			Code    string `json:"code"`
+		} `json:"error,omitempty"`
+	}
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", fmt.Errorf("decode codex response: %w", err)
+	}
+	if result.Error != nil {
+		return "", fmt.Errorf("codex api error (%s): %s", result.Error.Code, result.Error.Message)
+	}
+
+	var sb strings.Builder
+	for _, item := range result.Output {
+		if item.Type != "message" {
+			continue
+		}
+		for _, part := range item.Content {
+			if part.Type == "output_text" || part.Type == "text" {
+				sb.WriteString(part.Text)
+			}
+		}
+	}
+	return sb.String(), nil
 }
 
 // IsOpenAIOAuthActive returns true if the user has a saved OAuth token

--- a/internal/ai/codex_client.go
+++ b/internal/ai/codex_client.go
@@ -13,9 +13,7 @@ import (
 	"time"
 )
 
-const (
-	codexResponsesURL = "https://chatgpt.com/backend-api/codex/responses"
-)
+var codexResponsesURL = "https://chatgpt.com/backend-api/codex/responses"
 
 // CodexRequest is the Responses API request format.
 type CodexRequest struct {

--- a/internal/ai/codex_client_test.go
+++ b/internal/ai/codex_client_test.go
@@ -1,0 +1,68 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIsOpenAIOAuthActive_EnvVar(t *testing.T) {
+	// Point HOME to a temp dir so no real token file is found.
+	t.Setenv("HOME", t.TempDir())
+
+	t.Run("with env var set", func(t *testing.T) {
+		t.Setenv("OPENAI_OAUTH_TOKEN", "some_token")
+		if !IsOpenAIOAuthActive() {
+			t.Error("expected IsOpenAIOAuthActive to return true when env var is set")
+		}
+	})
+
+	t.Run("without env var", func(t *testing.T) {
+		t.Setenv("OPENAI_OAUTH_TOKEN", "")
+		if IsOpenAIOAuthActive() {
+			t.Error("expected IsOpenAIOAuthActive to return false when no env var and no token file")
+		}
+	})
+}
+
+func TestAskCodexWithToken(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify the authorization header
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer test_token" {
+			t.Errorf("unexpected Authorization header: %q", auth)
+		}
+
+		resp := map[string]interface{}{
+			"output": []map[string]interface{}{
+				{
+					"type": "message",
+					"content": []map[string]interface{}{
+						{
+							"type": "output_text",
+							"text": "hello world",
+						},
+					},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer mockServer.Close()
+
+	origURL := codexResponsesURL
+	codexResponsesURL = mockServer.URL
+	t.Cleanup(func() { codexResponsesURL = origURL })
+
+	result, err := askCodexWithToken(context.Background(), "test_token", "test-model", "say hello")
+	if err != nil {
+		t.Fatalf("askCodexWithToken failed: %v", err)
+	}
+
+	if result != "hello world" {
+		t.Errorf("expected %q, got %q", "hello world", result)
+	}
+}

--- a/internal/ai/openai_oauth.go
+++ b/internal/ai/openai_oauth.go
@@ -112,9 +112,13 @@ func RefreshOAuthToken(refreshToken string) (*OAuthTokens, error) {
 		return nil, fmt.Errorf("failed to parse refresh response: %w", err)
 	}
 
+	newRefreshToken := raw.RefreshToken
+	if newRefreshToken == "" {
+		newRefreshToken = refreshToken // preserve original when server omits it
+	}
 	tokens := &OAuthTokens{
 		AccessToken:  raw.AccessToken,
-		RefreshToken: raw.RefreshToken,
+		RefreshToken: newRefreshToken,
 		ExpiresAt:    time.Now().Unix() + raw.ExpiresIn,
 	}
 
@@ -130,7 +134,13 @@ func RefreshOAuthToken(refreshToken string) (*OAuthTokens, error) {
 
 // GetValidOAuthToken loads the stored tokens, refreshes if they expire within
 // 5 minutes, saves updated tokens back to disk, and returns the access token.
+// If OPENAI_OAUTH_TOKEN is set in the environment (forwarded by the backend),
+// it takes precedence over the saved token file.
 func GetValidOAuthToken() (string, error) {
+	if envToken := strings.TrimSpace(os.Getenv("OPENAI_OAUTH_TOKEN")); envToken != "" {
+		return envToken, nil
+	}
+
 	tokens, err := LoadOAuthTokens()
 	if err != nil {
 		return "", err

--- a/internal/ai/openai_oauth.go
+++ b/internal/ai/openai_oauth.go
@@ -1,0 +1,176 @@
+package ai
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// OAuthTokens holds the persisted OpenAI OAuth token set.
+type OAuthTokens struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresAt    int64  `json:"expires_at"`
+	Email        string `json:"email"`
+}
+
+const (
+	openAIOAuthTokenEndpoint = "https://auth.openai.com/oauth/token"
+	openAIOAuthClientID      = "app_EMoamEEZ73f0CkXaXp7hrann"
+	oauthTokenFileName       = "openai-auth.json"
+)
+
+func oauthTokenFilePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	return filepath.Join(home, ".clanker", oauthTokenFileName), nil
+}
+
+// LoadOAuthTokens reads the saved OpenAI OAuth tokens from disk.
+func LoadOAuthTokens() (*OAuthTokens, error) {
+	p, err := oauthTokenFilePath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return nil, err
+	}
+	var tokens OAuthTokens
+	if err := json.Unmarshal(data, &tokens); err != nil {
+		return nil, fmt.Errorf("failed to parse oauth token file: %w", err)
+	}
+	return &tokens, nil
+}
+
+// SaveOAuthTokens writes the OpenAI OAuth tokens to disk.
+func SaveOAuthTokens(tokens *OAuthTokens) error {
+	p, err := oauthTokenFilePath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0700); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+	data, err := json.MarshalIndent(tokens, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(p, data, 0600)
+}
+
+// RemoveOAuthTokens deletes the saved token file.
+func RemoveOAuthTokens() error {
+	p, err := oauthTokenFilePath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// RefreshOAuthToken exchanges a refresh token for a new access token.
+func RefreshOAuthToken(refreshToken string) (*OAuthTokens, error) {
+	form := url.Values{
+		"grant_type":    {"refresh_token"},
+		"client_id":     {openAIOAuthClientID},
+		"refresh_token": {refreshToken},
+	}
+
+	resp, err := http.Post(openAIOAuthTokenEndpoint, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("token refresh request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read refresh response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("token refresh failed (HTTP %d): %s", resp.StatusCode, string(body))
+	}
+
+	var raw struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		IDToken      string `json:"id_token"`
+		ExpiresIn    int64  `json:"expires_in"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse refresh response: %w", err)
+	}
+
+	tokens := &OAuthTokens{
+		AccessToken:  raw.AccessToken,
+		RefreshToken: raw.RefreshToken,
+		ExpiresAt:    time.Now().Unix() + raw.ExpiresIn,
+	}
+
+	// Preserve email from the id_token if available.
+	if raw.IDToken != "" {
+		if email := ExtractEmailFromIDToken(raw.IDToken); email != "" {
+			tokens.Email = email
+		}
+	}
+
+	return tokens, nil
+}
+
+// GetValidOAuthToken loads the stored tokens, refreshes if they expire within
+// 5 minutes, saves updated tokens back to disk, and returns the access token.
+func GetValidOAuthToken() (string, error) {
+	tokens, err := LoadOAuthTokens()
+	if err != nil {
+		return "", err
+	}
+
+	const refreshMarginSeconds int64 = 300 // 5 minutes
+	if time.Now().Unix()+refreshMarginSeconds >= tokens.ExpiresAt {
+		refreshed, err := RefreshOAuthToken(tokens.RefreshToken)
+		if err != nil {
+			return "", fmt.Errorf("failed to refresh oauth token: %w", err)
+		}
+		// Keep the original email if the refresh didn't return one.
+		if refreshed.Email == "" {
+			refreshed.Email = tokens.Email
+		}
+		if err := SaveOAuthTokens(refreshed); err != nil {
+			return "", fmt.Errorf("failed to save refreshed tokens: %w", err)
+		}
+		return refreshed.AccessToken, nil
+	}
+
+	return tokens.AccessToken, nil
+}
+
+// ExtractEmailFromIDToken decodes the payload of a JWT id_token (without
+// verifying the signature) and returns the "email" claim if present.
+func ExtractEmailFromIDToken(idToken string) string {
+	parts := strings.Split(idToken, ".")
+	if len(parts) < 2 {
+		return ""
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return ""
+	}
+	var claims struct {
+		Email string `json:"email"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return ""
+	}
+	return claims.Email
+}

--- a/internal/ai/openai_oauth.go
+++ b/internal/ai/openai_oauth.go
@@ -21,10 +21,11 @@ type OAuthTokens struct {
 	Email        string `json:"email"`
 }
 
+var openAIOAuthTokenEndpoint = "https://auth.openai.com/oauth/token"
+
 const (
-	openAIOAuthTokenEndpoint = "https://auth.openai.com/oauth/token"
-	openAIOAuthClientID      = "app_EMoamEEZ73f0CkXaXp7hrann"
-	oauthTokenFileName       = "openai-auth.json"
+	openAIOAuthClientID = "app_EMoamEEZ73f0CkXaXp7hrann"
+	oauthTokenFileName  = "openai-auth.json"
 )
 
 func oauthTokenFilePath() (string, error) {

--- a/internal/ai/openai_oauth_test.go
+++ b/internal/ai/openai_oauth_test.go
@@ -1,0 +1,123 @@
+package ai
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestExtractEmailFromIDToken(t *testing.T) {
+	t.Run("valid JWT with email", func(t *testing.T) {
+		payload := `{"email":"user@test.com"}`
+		encoded := base64.RawURLEncoding.EncodeToString([]byte(payload))
+		fakeJWT := fmt.Sprintf("header.%s.signature", encoded)
+
+		email := ExtractEmailFromIDToken(fakeJWT)
+		if email != "user@test.com" {
+			t.Errorf("expected user@test.com, got %q", email)
+		}
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		email := ExtractEmailFromIDToken("")
+		if email != "" {
+			t.Errorf("expected empty string, got %q", email)
+		}
+	})
+
+	t.Run("no dots", func(t *testing.T) {
+		email := ExtractEmailFromIDToken("nodots")
+		if email != "" {
+			t.Errorf("expected empty string, got %q", email)
+		}
+	})
+
+	t.Run("missing email claim", func(t *testing.T) {
+		payload := `{"sub":"123"}`
+		encoded := base64.RawURLEncoding.EncodeToString([]byte(payload))
+		fakeJWT := fmt.Sprintf("header.%s.signature", encoded)
+
+		email := ExtractEmailFromIDToken(fakeJWT)
+		if email != "" {
+			t.Errorf("expected empty string, got %q", email)
+		}
+	})
+}
+
+func TestSaveAndLoadOAuthTokens(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	original := &OAuthTokens{
+		AccessToken:  "access_abc123",
+		RefreshToken: "refresh_xyz789",
+		ExpiresAt:    1700000000,
+		Email:        "test@example.com",
+	}
+
+	if err := SaveOAuthTokens(original); err != nil {
+		t.Fatalf("SaveOAuthTokens failed: %v", err)
+	}
+
+	loaded, err := LoadOAuthTokens()
+	if err != nil {
+		t.Fatalf("LoadOAuthTokens failed: %v", err)
+	}
+
+	if loaded.AccessToken != original.AccessToken {
+		t.Errorf("AccessToken: got %q, want %q", loaded.AccessToken, original.AccessToken)
+	}
+	if loaded.RefreshToken != original.RefreshToken {
+		t.Errorf("RefreshToken: got %q, want %q", loaded.RefreshToken, original.RefreshToken)
+	}
+	if loaded.ExpiresAt != original.ExpiresAt {
+		t.Errorf("ExpiresAt: got %d, want %d", loaded.ExpiresAt, original.ExpiresAt)
+	}
+	if loaded.Email != original.Email {
+		t.Errorf("Email: got %q, want %q", loaded.Email, original.Email)
+	}
+}
+
+func TestGetValidOAuthToken_EnvVar(t *testing.T) {
+	t.Setenv("OPENAI_OAUTH_TOKEN", "env_token_value")
+
+	token, err := GetValidOAuthToken()
+	if err != nil {
+		t.Fatalf("GetValidOAuthToken failed: %v", err)
+	}
+	if token != "env_token_value" {
+		t.Errorf("expected env_token_value, got %q", token)
+	}
+}
+
+func TestRefreshTokenPreservation(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"access_token":  "new_access",
+			"refresh_token": "",
+			"expires_in":    3600,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer mockServer.Close()
+
+	origEndpoint := openAIOAuthTokenEndpoint
+	openAIOAuthTokenEndpoint = mockServer.URL
+	t.Cleanup(func() { openAIOAuthTokenEndpoint = origEndpoint })
+
+	tokens, err := RefreshOAuthToken("original_refresh_token")
+	if err != nil {
+		t.Fatalf("RefreshOAuthToken failed: %v", err)
+	}
+
+	if tokens.AccessToken != "new_access" {
+		t.Errorf("AccessToken: got %q, want %q", tokens.AccessToken, "new_access")
+	}
+	if tokens.RefreshToken != "original_refresh_token" {
+		t.Errorf("RefreshToken should be preserved: got %q, want %q", tokens.RefreshToken, "original_refresh_token")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `clanker auth login/logout/status` commands for OpenAI OAuth (PKCE flow via auth.openai.com)
- Add Codex Responses API client for chatgpt.com/backend-api/codex/responses
- When no API key is set but OAuth tokens are available, route through Codex endpoint
- Support OPENAI_OAUTH_TOKEN env var for backend-forwarded tokens
- Update example config with auth_method field

## Details
Users can now run `clanker auth login` to authenticate with their ChatGPT Plus/Pro account. The CLI opens a browser for the OAuth flow, receives the callback on localhost:1455, exchanges the code for tokens, and stores them at ~/.clanker/openai-auth.json.

When the `openai` AI profile is selected but no API key is configured, the CLI automatically checks for stored OAuth tokens and routes requests through the Codex Responses API instead of api.openai.com.

## Test plan
- [ ] Run `clanker auth login` and complete the browser OAuth flow
- [ ] Run `clanker auth status` to verify logged-in state
- [ ] Run `clanker ask "hello"` with no API key, verify it uses Codex endpoint
- [ ] Run `clanker auth logout` to clear tokens
- [ ] Verify `clanker ask` with `--openai-key` still uses api.openai.com