### PR TITLE
feat(vercel): phase 1 — Vercel provider + routing

### DIFF
--- a/.clanker.example.yaml
+++ b/.clanker.example.yaml
@@ -181,6 +181,11 @@ infra:
 # hetzner:
 #   api_token: ""            # Hetzner Cloud API token (or set HCLOUD_TOKEN)
 
+# Vercel (for `clanker vercel ...` and `clanker ask --vercel ...`):
+# vercel:
+#   api_token: ""            # Vercel API token (or set VERCEL_TOKEN / VERCEL_API_TOKEN)
+#   team_id: ""              # Optional team ID for team-scoped accounts (or set VERCEL_TEAM_ID / VERCEL_ORG_ID)
+
 # Hermes Agent (for `clanker talk` and `clanker ask --agent hermes`):
 # hermes:
 #   path: "./vendor/hermes-agent"    # Auto-detected if omitted

--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -304,11 +304,10 @@ Examples:
 			}
 
 			if strings.EqualFold(strings.TrimSpace(makerPlan.Provider), "vercel") {
-				vcToken := vercel.ResolveAPIToken()
-				if vcToken == "" {
-					return fmt.Errorf("vercel api_token is required (set vercel.api_token, VERCEL_TOKEN, or --api-token)")
+				vcToken, vcTeamID, vcErr := resolveVercelToken(ctx, debug)
+				if vcErr != nil {
+					return vcErr
 				}
-				vcTeamID := vercel.ResolveTeamID()
 				return maker.ExecuteVercelPlan(ctx, makerPlan, maker.ExecOptions{
 					VercelAPIToken: vcToken,
 					VercelTeamID:   vcTeamID,
@@ -713,23 +712,27 @@ Format as a professional compliance table suitable for government security docum
 			includeTerraform = true
 		}
 
+		// Provider-specific Q&A paths.
+		// NOTE: makerMode returns above, so these only fire for
+		// plain --<provider> queries (not --maker --<provider>).
+
 		// Handle explicit --cloudflare flag
-		if includeCloudflare {
+		if includeCloudflare && !makerMode {
 			return handleCloudflareQuery(context.Background(), question, debug)
 		}
 
 		// Handle explicit --digitalocean flag
-		if includeDigitalOcean {
+		if includeDigitalOcean && !makerMode {
 			return handleDigitalOceanQuery(context.Background(), question, debug)
 		}
 
 		// Handle explicit --hetzner flag
-		if includeHetzner {
+		if includeHetzner && !makerMode {
 			return handleHetznerQuery(context.Background(), question, debug)
 		}
 
 		// Handle explicit --vercel flag
-		if includeVercel {
+		if includeVercel && !makerMode {
 			return handleVercelQuery(context.Background(), question, debug)
 		}
 
@@ -2149,6 +2152,33 @@ func resolveHetznerToken(ctx context.Context, debug bool) (string, error) {
 	return "", fmt.Errorf("hetzner api_token is required (set hetzner.api_token or HCLOUD_TOKEN)")
 }
 
+// resolveVercelToken resolves the Vercel API token from config, env, or the
+// backend credential store (same fallback chain as resolveHetznerToken).
+// The returned teamID may be empty for personal accounts.
+func resolveVercelToken(ctx context.Context, debug bool) (apiToken string, teamID string, err error) {
+	apiToken = vercel.ResolveAPIToken()
+	if apiToken != "" {
+		return apiToken, vercel.ResolveTeamID(), nil
+	}
+
+	backendAPIKey := backend.ResolveAPIKey("")
+	if backendAPIKey != "" {
+		backendClient := backend.NewClient(backendAPIKey, debug)
+		creds, backendErr := backendClient.GetVercelCredentials(ctx)
+		if backendErr == nil && strings.TrimSpace(creds.APIToken) != "" {
+			if debug {
+				fmt.Println("[backend] Using Vercel credentials from backend")
+			}
+			return strings.TrimSpace(creds.APIToken), strings.TrimSpace(creds.TeamID), nil
+		}
+		if debug {
+			fmt.Printf("[backend] No Vercel credentials available (%v), falling back to local\n", backendErr)
+		}
+	}
+
+	return "", "", fmt.Errorf("Vercel token not configured. Set vercel.api_token in ~/.clanker.yaml or export VERCEL_TOKEN")
+}
+
 // handleHetznerQuery delegates a Hetzner Cloud query to the Hetzner client
 func handleHetznerQuery(ctx context.Context, question string, debug bool) error {
 	if debug {
@@ -2223,11 +2253,10 @@ func handleVercelQuery(ctx context.Context, question string, debug bool) error {
 		fmt.Println("Delegating query to Vercel agent...")
 	}
 
-	apiToken := vercel.ResolveAPIToken()
-	if apiToken == "" {
-		return fmt.Errorf("Vercel token not configured. Set vercel.api_token in ~/.clanker.yaml or export VERCEL_TOKEN")
+	apiToken, teamID, err := resolveVercelToken(ctx, debug)
+	if err != nil {
+		return err
 	}
-	teamID := vercel.ResolveTeamID()
 
 	client, err := vercel.NewClient(apiToken, teamID, debug)
 	if err != nil {
@@ -2235,8 +2264,8 @@ func handleVercelQuery(ctx context.Context, question string, debug bool) error {
 	}
 
 	vercelContext, err := client.GetRelevantContext(ctx, question)
-	if err != nil && debug {
-		fmt.Printf("[debug] failed to get Vercel context: %v\n", err)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[vercel] warning: failed to fetch context: %v\n", err)
 	}
 
 	// Resolve AI provider + key using the same pattern as other handlers.

--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -34,6 +34,7 @@ import (
 	"github.com/bgdnvk/clanker/internal/resourcedb"
 	"github.com/bgdnvk/clanker/internal/routing"
 	tfclient "github.com/bgdnvk/clanker/internal/terraform"
+	"github.com/bgdnvk/clanker/internal/vercel"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -41,10 +42,10 @@ import (
 // askCmd represents the ask command
 const defaultGeminiModel = "gemini-2.5-flash"
 
-func applyDiscoveryContextDefaults(includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform bool) (bool, bool, bool, bool, bool, bool, bool) {
+func applyDiscoveryContextDefaults(includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel bool) (bool, bool, bool, bool, bool, bool, bool, bool) {
 	includeTerraform = true
-	if includeAWS || includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeHetzner {
-		return includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform
+	if includeAWS || includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeHetzner || includeVercel {
+		return includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel
 	}
 
 	switch routing.DefaultInfraProvider() {
@@ -58,11 +59,13 @@ func applyDiscoveryContextDefaults(includeAWS, includeGCP, includeAzure, include
 		includeDigitalOcean = true
 	case "hetzner":
 		includeHetzner = true
+	case "vercel":
+		includeVercel = true
 	default:
 		includeAWS = true
 	}
 
-	return includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform
+	return includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel
 }
 
 var askCmd = &cobra.Command{
@@ -104,6 +107,7 @@ Examples:
 		includeCloudflare, _ := cmd.Flags().GetBool("cloudflare")
 		includeDigitalOcean, _ := cmd.Flags().GetBool("digitalocean")
 		includeHetzner, _ := cmd.Flags().GetBool("hetzner")
+		includeVercel, _ := cmd.Flags().GetBool("vercel")
 		includeTerraform, _ := cmd.Flags().GetBool("terraform")
 		includeIAM, _ := cmd.Flags().GetBool("iam")
 		dbConnection, _ := cmd.Flags().GetString("db-connection")
@@ -433,6 +437,7 @@ Examples:
 			explicitDigitalOcean := cmd.Flags().Changed("digitalocean") && includeDigitalOcean
 			explicitHetzner := cmd.Flags().Changed("hetzner") && includeHetzner
 			explicitAzure := cmd.Flags().Changed("azure") && includeAzure
+			explicitVercel := cmd.Flags().Changed("vercel") && includeVercel
 			explicitCount := 0
 			if explicitGCP {
 				explicitCount++
@@ -452,8 +457,11 @@ Examples:
 			if explicitAzure {
 				explicitCount++
 			}
+			if explicitVercel {
+				explicitCount++
+			}
 			if explicitCount > 1 {
-				return fmt.Errorf("cannot use multiple provider flags (--aws, --gcp, --azure, --cloudflare, --digitalocean, --hetzner) together with --maker")
+				return fmt.Errorf("cannot use multiple provider flags (--aws, --gcp, --azure, --cloudflare, --digitalocean, --hetzner, --vercel) together with --maker")
 			}
 			switch {
 			case explicitHetzner:
@@ -474,6 +482,9 @@ Examples:
 			case explicitAWS:
 				makerProvider = "aws"
 				makerProviderReason = "explicit"
+			case explicitVercel:
+				makerProvider = "vercel"
+				makerProviderReason = "explicit"
 			default:
 				svcCtx := routing.InferContext(questionForRouting(question))
 				if svcCtx.Cloudflare {
@@ -490,6 +501,9 @@ Examples:
 					makerProviderReason = "inferred"
 				} else if svcCtx.GCP {
 					makerProvider = "gcp"
+					makerProviderReason = "inferred"
+				} else if svcCtx.Vercel {
+					makerProvider = "vercel"
 					makerProviderReason = "inferred"
 				}
 			}
@@ -510,6 +524,8 @@ Examples:
 				prompt = maker.AzurePlanPromptWithMode(question, destroyer)
 			case "gcp":
 				prompt = maker.GCPPlanPromptWithMode(question, destroyer)
+			case "vercel":
+				return fmt.Errorf("maker mode not yet supported for Vercel (planned for phase 2)")
 			default:
 				prompt = maker.PlanPromptWithMode(question, destroyer)
 			}
@@ -662,7 +678,7 @@ Format as a professional compliance table suitable for government security docum
 
 		// Discovery mode enables comprehensive infrastructure analysis
 		if discovery {
-			includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform = applyDiscoveryContextDefaults(
+			includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel = applyDiscoveryContextDefaults(
 				includeAWS,
 				includeGCP,
 				includeAzure,
@@ -670,6 +686,7 @@ Format as a professional compliance table suitable for government security docum
 				includeDigitalOcean,
 				includeHetzner,
 				includeTerraform,
+				includeVercel,
 			)
 			if debug {
 				fmt.Println("Discovery mode enabled: Terraform context activated alongside the selected infrastructure provider(s)")
@@ -696,7 +713,12 @@ Format as a professional compliance table suitable for government security docum
 			return handleHetznerQuery(context.Background(), question, debug)
 		}
 
-		if !includeAWS && !includeGitHub && !includeTerraform && !includeGCP && !includeAzure && !includeCloudflare && !includeDigitalOcean && !includeHetzner && !includeDB {
+		// Handle explicit --vercel flag
+		if includeVercel {
+			return handleVercelQuery(context.Background(), question, debug)
+		}
+
+		if !includeAWS && !includeGitHub && !includeTerraform && !includeGCP && !includeAzure && !includeCloudflare && !includeDigitalOcean && !includeHetzner && !includeVercel && !includeDB {
 			routingQuestion := questionForRouting(question)
 
 			// First, do quick keyword check for explicit terms
@@ -765,6 +787,11 @@ Format as a professional compliance table suitable for government security docum
 			// Handle Hetzner queries
 			if svcCtx.Hetzner {
 				return handleHetznerQuery(context.Background(), routingQuestion, debug)
+			}
+
+			// Handle Vercel queries
+			if svcCtx.Vercel {
+				return handleVercelQuery(context.Background(), routingQuestion, debug)
 			}
 
 			// Handle IAM queries by delegating to IAM agent
@@ -1250,6 +1277,7 @@ func init() {
 	askCmd.Flags().Bool("cloudflare", false, "Include Cloudflare infrastructure context")
 	askCmd.Flags().Bool("digitalocean", false, "Include Digital Ocean infrastructure context")
 	askCmd.Flags().Bool("hetzner", false, "Include Hetzner Cloud infrastructure context")
+	askCmd.Flags().Bool("vercel", false, "Include Vercel context")
 	askCmd.Flags().Bool("github", false, "Include GitHub repository context")
 	askCmd.Flags().Bool("cicd", false, "Include CI/CD context (currently GitHub Actions)")
 	askCmd.Flags().Bool("db", false, "Include configured database context")
@@ -2167,6 +2195,75 @@ Provide a clear, concise answer based on the data above. If the data doesn't con
 	response, err := aiClient.AskPrompt(ctx, prompt)
 	if err != nil {
 		return fmt.Errorf("failed to get AI response: %w", err)
+	}
+
+	fmt.Println(response)
+	return nil
+}
+
+// handleVercelQuery delegates a Vercel query to the Vercel agent.
+// One-shot Q&A (no conversation history) — full history lands in phase 4.
+func handleVercelQuery(ctx context.Context, question string, debug bool) error {
+	if debug {
+		fmt.Println("Delegating query to Vercel agent...")
+	}
+
+	apiToken := vercel.ResolveAPIToken()
+	if apiToken == "" {
+		return fmt.Errorf("Vercel token not configured. Set vercel.api_token in ~/.clanker.yaml or export VERCEL_TOKEN")
+	}
+	teamID := vercel.ResolveTeamID()
+
+	client, err := vercel.NewClient(apiToken, teamID, debug)
+	if err != nil {
+		return fmt.Errorf("failed to create Vercel client: %w", err)
+	}
+
+	vercelContext, err := client.GetRelevantContext(ctx, question)
+	if err != nil && debug {
+		fmt.Printf("[debug] failed to get Vercel context: %v\n", err)
+	}
+
+	// Resolve AI provider + key using the same pattern as other handlers.
+	provider := viper.GetString("ai.default_provider")
+	if provider == "" {
+		provider = "openai"
+	}
+
+	var apiKey string
+	switch provider {
+	case "bedrock", "claude":
+		apiKey = ""
+	case "gemini", "gemini-api":
+		apiKey = ""
+	case "openai":
+		apiKey = resolveOpenAIKey("")
+	case "anthropic":
+		apiKey = resolveAnthropicKey("")
+	case "cohere":
+		apiKey = resolveCohereKey("")
+	case "deepseek":
+		apiKey = resolveDeepSeekKey("")
+	case "minimax":
+		apiKey = resolveMiniMaxKey("")
+	default:
+		apiKey = viper.GetString(fmt.Sprintf("ai.providers.%s.api_key", provider))
+	}
+
+	aiClient := ai.NewClient(provider, apiKey, debug, provider)
+
+	prompt := fmt.Sprintf(`You are a Vercel infrastructure assistant. Answer questions about the user's Vercel account based on the provided context.
+
+Vercel Context:
+%s
+
+User Question: %s
+
+Provide a helpful, concise response in markdown format.`, vercelContext, question)
+
+	response, err := aiClient.AskPrompt(ctx, prompt)
+	if err != nil {
+		return fmt.Errorf("Vercel AI query failed: %w", err)
 	}
 
 	fmt.Println(response)

--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -2266,6 +2266,9 @@ func handleVercelQuery(ctx context.Context, question string, debug bool) error {
 	vercelContext, err := client.GetRelevantContext(ctx, question)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[vercel] warning: failed to fetch context: %v\n", err)
+		if strings.TrimSpace(vercelContext) == "" {
+			return fmt.Errorf("failed to fetch Vercel context: %w", err)
+		}
 	}
 
 	// Resolve AI provider + key using the same pattern as other handlers.

--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -303,6 +303,21 @@ Examples:
 				})
 			}
 
+			if strings.EqualFold(strings.TrimSpace(makerPlan.Provider), "vercel") {
+				vcToken := vercel.ResolveAPIToken()
+				if vcToken == "" {
+					return fmt.Errorf("vercel api_token is required (set vercel.api_token, VERCEL_TOKEN, or --api-token)")
+				}
+				vcTeamID := vercel.ResolveTeamID()
+				return maker.ExecuteVercelPlan(ctx, makerPlan, maker.ExecOptions{
+					VercelAPIToken: vcToken,
+					VercelTeamID:   vcTeamID,
+					Writer:         os.Stdout,
+					Destroyer:      destroyer,
+					Debug:          debug,
+				})
+			}
+
 			// Resolve AWS profile/region for execution.
 			targetProfile := resolveAWSProfile(profile)
 
@@ -525,7 +540,7 @@ Examples:
 			case "gcp":
 				prompt = maker.GCPPlanPromptWithMode(question, destroyer)
 			case "vercel":
-				return fmt.Errorf("maker mode not yet supported for Vercel (planned for phase 2)")
+				prompt = maker.VercelPlanPromptWithMode(question, destroyer)
 			default:
 				prompt = maker.PlanPromptWithMode(question, destroyer)
 			}
@@ -588,7 +603,7 @@ Examples:
 
 			// Handle GCP, Azure, Cloudflare, and Digital Ocean plans (output directly, no enrichment)
 			providerLower := strings.ToLower(strings.TrimSpace(plan.Provider))
-			if providerLower == "gcp" || providerLower == "azure" || providerLower == "cloudflare" || providerLower == "digitalocean" || providerLower == "hetzner" {
+			if providerLower == "gcp" || providerLower == "azure" || providerLower == "cloudflare" || providerLower == "digitalocean" || providerLower == "hetzner" || providerLower == "vercel" {
 				if plan.CreatedAt.IsZero() {
 					plan.CreatedAt = time.Now().UTC()
 				}

--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -2246,8 +2246,8 @@ Provide a clear, concise answer based on the data above. If the data doesn't con
 	return nil
 }
 
-// handleVercelQuery delegates a Vercel query to the Vercel agent.
-// One-shot Q&A (no conversation history) — full history lands in phase 4.
+// handleVercelQuery delegates a Vercel query to the Vercel agent with
+// per-team conversation history for multi-turn context.
 func handleVercelQuery(ctx context.Context, question string, debug bool) error {
 	if debug {
 		fmt.Println("Delegating query to Vercel agent...")
@@ -2261,6 +2261,16 @@ func handleVercelQuery(ctx context.Context, question string, debug bool) error {
 	client, err := vercel.NewClient(apiToken, teamID, debug)
 	if err != nil {
 		return fmt.Errorf("failed to create Vercel client: %w", err)
+	}
+
+	// Load conversation history keyed by team (or "personal" for non-team accounts).
+	conversationID := teamID
+	if conversationID == "" {
+		conversationID = "personal"
+	}
+	history := vercel.NewConversationHistory(conversationID)
+	if err := history.Load(); err != nil && debug {
+		fmt.Fprintf(os.Stderr, "[debug] conversation history: %v\n", err)
 	}
 
 	vercelContext, err := client.GetRelevantContext(ctx, question)
@@ -2299,14 +2309,8 @@ func handleVercelQuery(ctx context.Context, question string, debug bool) error {
 
 	aiClient := ai.NewClient(provider, apiKey, debug, provider)
 
-	prompt := fmt.Sprintf(`You are a Vercel infrastructure assistant. Answer questions about the user's Vercel account based on the provided context.
-
-Vercel Context:
-%s
-
-User Question: %s
-
-Provide a helpful, concise response in markdown format.`, vercelContext, question)
+	historyContext := history.GetRecentContext(5)
+	prompt := buildVercelPrompt(question, vercelContext, historyContext)
 
 	response, err := aiClient.AskPrompt(ctx, prompt)
 	if err != nil {
@@ -2314,7 +2318,37 @@ Provide a helpful, concise response in markdown format.`, vercelContext, questio
 	}
 
 	fmt.Println(response)
+
+	// Persist the exchange so subsequent invocations see the conversation.
+	history.AddEntry(question, response)
+	if err := history.Save(); err != nil && debug {
+		fmt.Fprintf(os.Stderr, "[debug] save history: %v\n", err)
+	}
+
 	return nil
+}
+
+// buildVercelPrompt assembles the system prompt for a Vercel ask query,
+// injecting infrastructure context and recent conversation history when
+// available.
+func buildVercelPrompt(question, vercelContext, historyContext string) string {
+	var sb strings.Builder
+	sb.WriteString("You are a Vercel infrastructure assistant. ")
+	sb.WriteString("Answer questions about the user's Vercel account based on the provided context.\n\n")
+	if vercelContext != "" {
+		sb.WriteString("Vercel Context:\n")
+		sb.WriteString(vercelContext)
+		sb.WriteString("\n\n")
+	}
+	if historyContext != "" {
+		sb.WriteString("Recent Conversation:\n")
+		sb.WriteString(historyContext)
+		sb.WriteString("\n\n")
+	}
+	sb.WriteString("User Question: ")
+	sb.WriteString(question)
+	sb.WriteString("\n\nProvide a helpful, concise response in markdown format.")
+	return sb.String()
 }
 
 // handleK8sQuery delegates a Kubernetes query to the K8s agent

--- a/cmd/ask_test.go
+++ b/cmd/ask_test.go
@@ -60,12 +60,12 @@ func TestApplyCommandAIOverrides_RespectsConfiguredProvider(t *testing.T) {
 func TestApplyDiscoveryContextDefaults_UsesConfiguredHetzner(t *testing.T) {
 	useDefaultInfraProvider(t, "hetzner")
 
-	includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform := applyDiscoveryContextDefaults(false, false, false, false, false, false, false)
+	includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel := applyDiscoveryContextDefaults(false, false, false, false, false, false, false, false)
 
 	if includeAWS {
 		t.Fatal("expected discovery defaults not to force AWS when Hetzner is configured")
 	}
-	if includeGCP || includeAzure || includeCloudflare || includeDigitalOcean {
+	if includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeVercel {
 		t.Fatal("expected discovery defaults to select only the configured provider")
 	}
 	if !includeHetzner {
@@ -79,9 +79,9 @@ func TestApplyDiscoveryContextDefaults_UsesConfiguredHetzner(t *testing.T) {
 func TestApplyDiscoveryContextDefaults_PreservesExplicitProviderSelection(t *testing.T) {
 	useDefaultInfraProvider(t, "hetzner")
 
-	includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform := applyDiscoveryContextDefaults(false, false, false, false, false, true, false)
+	includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel := applyDiscoveryContextDefaults(false, false, false, false, false, true, false, false)
 
-	if includeAWS || includeGCP || includeAzure || includeCloudflare || includeDigitalOcean {
+	if includeAWS || includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeVercel {
 		t.Fatal("expected explicit provider selection to be preserved without adding other providers")
 	}
 	if !includeHetzner {
@@ -89,5 +89,24 @@ func TestApplyDiscoveryContextDefaults_PreservesExplicitProviderSelection(t *tes
 	}
 	if !includeTerraform {
 		t.Fatal("expected discovery defaults to enable Terraform context when a provider is already selected")
+	}
+}
+
+func TestApplyDiscoveryContextDefaults_UsesConfiguredVercel(t *testing.T) {
+	useDefaultInfraProvider(t, "vercel")
+
+	includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel := applyDiscoveryContextDefaults(false, false, false, false, false, false, false, false)
+
+	if includeAWS {
+		t.Fatal("expected discovery defaults not to force AWS when Vercel is configured")
+	}
+	if includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeHetzner {
+		t.Fatal("expected discovery defaults to select only the configured provider")
+	}
+	if !includeVercel {
+		t.Fatal("expected discovery defaults to enable Vercel when configured")
+	}
+	if !includeTerraform {
+		t.Fatal("expected discovery defaults to enable Terraform context")
 	}
 }

--- a/cmd/credentials.go
+++ b/cmd/credentials.go
@@ -5,9 +5,11 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/bgdnvk/clanker/internal/backend"
 	"github.com/bgdnvk/clanker/internal/cloudflare"
@@ -688,10 +690,14 @@ func testVercelCredentials(ctx context.Context, client *backend.Client, debug bo
 		return fmt.Errorf("no Vercel API token")
 	}
 
+	// Use a bounded context so a hanging curl does not block forever.
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
 	// Verify the token by fetching the authenticated user.
 	endpoint := "https://api.vercel.com/v2/user"
 	if creds.TeamID != "" {
-		endpoint += "?teamId=" + creds.TeamID
+		endpoint += "?teamId=" + url.QueryEscape(creds.TeamID)
 	}
 
 	cmd := exec.CommandContext(ctx, "curl", "-s", "-o", "/dev/stdout", "-w", "\n%{http_code}",

--- a/cmd/credentials.go
+++ b/cmd/credentials.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bgdnvk/clanker/internal/backend"
 	"github.com/bgdnvk/clanker/internal/cloudflare"
 	"github.com/bgdnvk/clanker/internal/hetzner"
+	"github.com/bgdnvk/clanker/internal/vercel"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -26,6 +27,7 @@ your API key via --api-key flag or CLANKER_BACKEND_API_KEY environment variable.
 
 Examples:
   clanker credentials store aws --profile myaws
+  clanker credentials store vercel
   clanker credentials list
   clanker credentials test aws
   clanker credentials delete aws`,
@@ -36,7 +38,7 @@ var credentialsStoreCmd = &cobra.Command{
 	Short: "Store credentials in the backend",
 	Long: `Upload local credentials to the clanker backend.
 
-Supported providers: aws, gcp, hetzner, cloudflare, k8s
+Supported providers: aws, gcp, hetzner, cloudflare, vercel, k8s
 
 AWS:
   Exports credentials from local AWS CLI profile using 'aws configure export-credentials'.
@@ -50,6 +52,11 @@ Hetzner:
 Cloudflare:
   Uses api_token and account_id from config or environment variables.
 
+Vercel:
+  Uses api_token (vercel.api_token / VERCEL_TOKEN) and optional team_id
+  (vercel.team_id / VERCEL_TEAM_ID). Override either with --api-token /
+  --team-id flags.
+
 K8s:
   Uploads kubeconfig file content (base64 encoded).
 
@@ -58,6 +65,8 @@ Examples:
   clanker credentials store gcp --project myproject
   clanker credentials store hetzner
   clanker credentials store cloudflare
+  clanker credentials store vercel
+  clanker credentials store vercel --api-token ${VERCEL_TOKEN} --team-id team_abc
   clanker credentials store k8s --kubeconfig ~/.kube/config`,
 	Args: cobra.ExactArgs(1),
 	RunE: runCredentialsStore,
@@ -82,6 +91,7 @@ Examples:
   clanker credentials test gcp
   clanker credentials test hetzner
   clanker credentials test cloudflare
+  clanker credentials test vercel
   clanker credentials test k8s
   clanker credentials test`,
 	Args: cobra.MaximumNArgs(1),
@@ -96,7 +106,8 @@ var credentialsDeleteCmd = &cobra.Command{
 Examples:
   clanker credentials delete aws
   clanker credentials delete gcp
-  clanker credentials delete hetzner`,
+  clanker credentials delete hetzner
+  clanker credentials delete vercel`,
 	Args: cobra.ExactArgs(1),
 	RunE: runCredentialsDelete,
 }
@@ -114,6 +125,8 @@ func init() {
 	credentialsStoreCmd.Flags().String("service-account", "", "GCP service account JSON file path")
 	credentialsStoreCmd.Flags().String("kubeconfig", "", "Path to kubeconfig file (default: ~/.kube/config)")
 	credentialsStoreCmd.Flags().String("context", "", "Kubernetes context name to use")
+	credentialsStoreCmd.Flags().String("api-token", "", "Vercel API token (overrides vercel.api_token / VERCEL_TOKEN)")
+	credentialsStoreCmd.Flags().String("team-id", "", "Vercel team ID (overrides vercel.team_id / VERCEL_TEAM_ID)")
 }
 
 func requireAPIKey(cmd *cobra.Command) (string, error) {
@@ -149,10 +162,12 @@ func runCredentialsStore(cmd *cobra.Command, args []string) error {
 		return storeHetznerCredentials(ctx, cmd, client)
 	case "cloudflare", "cf":
 		return storeCloudflareCredentials(ctx, cmd, client)
+	case "vercel":
+		return storeVercelCredentials(ctx, cmd, client)
 	case "k8s", "kubernetes":
 		return storeKubernetesCredentials(ctx, cmd, client)
 	default:
-		return fmt.Errorf("unsupported provider: %s (supported: aws, gcp, hetzner, cloudflare, k8s)", provider)
+		return fmt.Errorf("unsupported provider: %s (supported: aws, gcp, hetzner, cloudflare, vercel, k8s)", provider)
 	}
 }
 
@@ -302,6 +317,36 @@ func storeCloudflareCredentials(ctx context.Context, cmd *cobra.Command, client 
 	return nil
 }
 
+func storeVercelCredentials(ctx context.Context, cmd *cobra.Command, client *backend.Client) error {
+	apiToken, _ := cmd.Flags().GetString("api-token")
+	if strings.TrimSpace(apiToken) == "" {
+		apiToken = vercel.ResolveAPIToken()
+	}
+	if strings.TrimSpace(apiToken) == "" {
+		return fmt.Errorf("Vercel API token required: use --api-token flag, set vercel.api_token in config, or export VERCEL_TOKEN")
+	}
+
+	teamID, _ := cmd.Flags().GetString("team-id")
+	if strings.TrimSpace(teamID) == "" {
+		teamID = vercel.ResolveTeamID()
+	}
+
+	creds := &backend.VercelCredentials{
+		APIToken: apiToken,
+		TeamID:   teamID,
+	}
+
+	if err := client.StoreVercelCredentials(ctx, creds); err != nil {
+		return fmt.Errorf("failed to store Vercel credentials: %w", err)
+	}
+
+	fmt.Println("Vercel credentials stored successfully")
+	if teamID != "" {
+		fmt.Printf("Team ID: %s\n", teamID)
+	}
+	return nil
+}
+
 func storeKubernetesCredentials(ctx context.Context, cmd *cobra.Command, client *backend.Client) error {
 	kubeconfigPath, _ := cmd.Flags().GetString("kubeconfig")
 	contextName, _ := cmd.Flags().GetString("context")
@@ -366,6 +411,7 @@ func runCredentialsList(cmd *cobra.Command, args []string) error {
 		fmt.Println("  clanker credentials store gcp --project <project>")
 		fmt.Println("  clanker credentials store hetzner")
 		fmt.Println("  clanker credentials store cloudflare")
+		fmt.Println("  clanker credentials store vercel")
 		fmt.Println("  clanker credentials store k8s")
 		return nil
 	}
@@ -442,6 +488,8 @@ func testCredential(ctx context.Context, client *backend.Client, provider backen
 		return testHetznerCredentials(ctx, client, debug)
 	case backend.ProviderCloudflare:
 		return testCloudflareCredentials(ctx, client, debug)
+	case backend.ProviderVercel:
+		return testVercelCredentials(ctx, client, debug)
 	case backend.ProviderKubernetes:
 		return testKubernetesCredentials(ctx, client, debug)
 	default:
@@ -628,6 +676,76 @@ func testCloudflareCredentials(ctx context.Context, client *backend.Client, debu
 	return nil
 }
 
+func testVercelCredentials(ctx context.Context, client *backend.Client, debug bool) error {
+	creds, err := client.GetVercelCredentials(ctx)
+	if err != nil {
+		fmt.Printf("  FAILED: %v\n", err)
+		return err
+	}
+
+	if creds.APIToken == "" {
+		fmt.Println("  FAILED: no API token stored")
+		return fmt.Errorf("no Vercel API token")
+	}
+
+	// Verify the token by fetching the authenticated user.
+	endpoint := "https://api.vercel.com/v2/user"
+	if creds.TeamID != "" {
+		endpoint += "?teamId=" + creds.TeamID
+	}
+
+	cmd := exec.CommandContext(ctx, "curl", "-s", "-o", "/dev/stdout", "-w", "\n%{http_code}",
+		endpoint,
+		"-H", fmt.Sprintf("Authorization: Bearer %s", creds.APIToken),
+	)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Printf("  FAILED: %v\n", err)
+		return err
+	}
+
+	// Split body from the trailing HTTP status line curl appended via -w.
+	raw := strings.TrimSpace(string(output))
+	lastNL := strings.LastIndex(raw, "\n")
+	var body, status string
+	if lastNL < 0 {
+		status = raw
+	} else {
+		body = raw[:lastNL]
+		status = strings.TrimSpace(raw[lastNL+1:])
+	}
+
+	if status != "200" {
+		if debug {
+			fmt.Printf("  Body: %s\n", body)
+		}
+		fmt.Printf("  FAILED: HTTP %s\n", status)
+		return fmt.Errorf("Vercel credential test failed (HTTP %s)", status)
+	}
+
+	var response struct {
+		User struct {
+			Username string `json:"username"`
+			Email    string `json:"email"`
+		} `json:"user"`
+	}
+	if err := json.Unmarshal([]byte(body), &response); err != nil {
+		fmt.Println("  PASSED: token accepted by Vercel")
+		return nil
+	}
+
+	switch {
+	case response.User.Username != "":
+		fmt.Printf("  PASSED: authenticated as %s\n", response.User.Username)
+	case response.User.Email != "":
+		fmt.Printf("  PASSED: authenticated as %s\n", response.User.Email)
+	default:
+		fmt.Println("  PASSED: token accepted by Vercel")
+	}
+	return nil
+}
+
 func testKubernetesCredentials(ctx context.Context, client *backend.Client, debug bool) error {
 	creds, err := client.GetKubernetesCredentials(ctx)
 	if err != nil {
@@ -708,10 +826,12 @@ func runCredentialsDelete(cmd *cobra.Command, args []string) error {
 		credProvider = backend.ProviderHetzner
 	case "cloudflare", "cf":
 		credProvider = backend.ProviderCloudflare
+	case "vercel":
+		credProvider = backend.ProviderVercel
 	case "k8s", "kubernetes":
 		credProvider = backend.ProviderKubernetes
 	default:
-		return fmt.Errorf("unsupported provider: %s (supported: aws, gcp, hetzner, cloudflare, k8s)", provider)
+		return fmt.Errorf("unsupported provider: %s (supported: aws, gcp, hetzner, cloudflare, vercel, k8s)", provider)
 	}
 
 	client := backend.NewClient(apiKey, debug)

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
+	"github.com/bgdnvk/clanker/internal/ai"
+	"github.com/bgdnvk/clanker/internal/vercel"
 	"github.com/mark3labs/mcp-go/mcp"
 	mcptransport "github.com/mark3labs/mcp-go/server"
 	"github.com/spf13/cobra"
@@ -26,6 +30,20 @@ type commandArgs struct {
 	BackendURL string   `json:"backendUrl,omitempty"`
 	BackendEnv string   `json:"backendEnv,omitempty"`
 	Debug      *bool    `json:"debug,omitempty"`
+}
+
+type vercelAskArgs struct {
+	Question string `json:"question" jsonschema:"description=Natural language question about Vercel infrastructure,required"`
+	Token    string `json:"token,omitempty" jsonschema:"description=Vercel API token (falls back to config/env)"`
+	TeamID   string `json:"teamId,omitempty" jsonschema:"description=Vercel team ID"`
+	Debug    bool   `json:"debug,omitempty" jsonschema:"description=Enable debug output"`
+}
+
+type vercelListArgs struct {
+	Resource string `json:"resource" jsonschema:"description=Resource type: projects|deployments|domains|env|teams|aliases|kv|blob|postgres|edge-configs,required"`
+	Token    string `json:"token,omitempty" jsonschema:"description=Vercel API token (falls back to config/env)"`
+	TeamID   string `json:"teamId,omitempty" jsonschema:"description=Vercel team ID"`
+	Project  string `json:"project,omitempty" jsonschema:"description=Project ID for scoped resources (deployments and env)"`
 }
 
 var mcpCmd = &cobra.Command{
@@ -98,7 +116,161 @@ func newClankerMCPServer() *mcptransport.MCPServer {
 		}),
 	)
 
+	server.AddTool(
+		mcp.NewTool(
+			"clanker_vercel_ask",
+			mcp.WithDescription("Ask a natural language question about your Vercel infrastructure. Gathers Vercel context (projects, deployments, domains) and uses the configured AI provider to answer."),
+			mcp.WithInputSchema[vercelAskArgs](),
+		),
+		mcp.NewTypedToolHandler(func(ctx context.Context, _ mcp.CallToolRequest, args vercelAskArgs) (*mcp.CallToolResult, error) {
+			return handleMCPVercelAsk(ctx, args)
+		}),
+	)
+
+	server.AddTool(
+		mcp.NewTool(
+			"clanker_vercel_list",
+			mcp.WithDescription("List Vercel resources (projects, deployments, domains, env vars, teams, aliases, kv, blob, postgres, edge-configs). Returns raw JSON from the Vercel API."),
+			mcp.WithInputSchema[vercelListArgs](),
+			mcp.WithReadOnlyHintAnnotation(true),
+		),
+		mcp.NewTypedToolHandler(func(ctx context.Context, _ mcp.CallToolRequest, args vercelListArgs) (*mcp.CallToolResult, error) {
+			return handleMCPVercelList(ctx, args)
+		}),
+	)
+
 	return server
+}
+
+// handleMCPVercelAsk resolves Vercel credentials, gathers context, and asks
+// the configured AI provider about the user's Vercel infrastructure.
+func handleMCPVercelAsk(ctx context.Context, args vercelAskArgs) (*mcp.CallToolResult, error) {
+	token := args.Token
+	if token == "" {
+		token = vercel.ResolveAPIToken()
+	}
+	if token == "" {
+		return mcp.NewToolResultError("Vercel token not configured. Set vercel.api_token in ~/.clanker.yaml or export VERCEL_TOKEN"), nil
+	}
+
+	teamID := args.TeamID
+	if teamID == "" {
+		teamID = vercel.ResolveTeamID()
+	}
+
+	client, err := vercel.NewClient(token, teamID, args.Debug)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to create Vercel client: %v", err)), nil
+	}
+
+	vercelContext, _ := client.GetRelevantContext(ctx, args.Question)
+
+	prompt := buildVercelPrompt(args.Question, vercelContext, "")
+
+	provider := viper.GetString("ai.default_provider")
+	if provider == "" {
+		provider = "openai"
+	}
+	apiKey := mcpResolveProviderKey(provider)
+
+	aiClient := ai.NewClient(provider, apiKey, args.Debug, provider)
+
+	response, err := aiClient.AskPrompt(ctx, prompt)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("AI query failed: %v", err)), nil
+	}
+
+	return mcp.NewToolResultText(response), nil
+}
+
+// handleMCPVercelList resolves Vercel credentials and lists the requested
+// resource type, returning raw JSON from the Vercel API.
+func handleMCPVercelList(ctx context.Context, args vercelListArgs) (*mcp.CallToolResult, error) {
+	token := args.Token
+	if token == "" {
+		token = vercel.ResolveAPIToken()
+	}
+	if token == "" {
+		return mcp.NewToolResultError("Vercel token not configured. Set vercel.api_token in ~/.clanker.yaml or export VERCEL_TOKEN"), nil
+	}
+
+	teamID := args.TeamID
+	if teamID == "" {
+		teamID = vercel.ResolveTeamID()
+	}
+
+	client, err := vercel.NewClient(token, teamID, false)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to create Vercel client: %v", err)), nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	resource := strings.ToLower(strings.TrimSpace(args.Resource))
+	endpoint := ""
+
+	switch resource {
+	case "projects", "project":
+		endpoint = "/v9/projects?limit=100"
+	case "deployments", "deployment":
+		endpoint = "/v6/deployments?limit=20"
+		if args.Project != "" {
+			endpoint += "&projectId=" + url.QueryEscape(args.Project)
+		}
+	case "domains", "domain":
+		endpoint = "/v5/domains?limit=100"
+	case "env", "envs", "env-vars", "environment":
+		if args.Project == "" {
+			return mcp.NewToolResultError("project is required to list env vars"), nil
+		}
+		endpoint = fmt.Sprintf("/v10/projects/%s/env", url.PathEscape(args.Project))
+	case "teams", "team":
+		endpoint = "/v2/teams?limit=50"
+	case "aliases", "alias":
+		endpoint = "/v4/aliases?limit=50"
+		if args.Project != "" {
+			endpoint += "&projectId=" + url.QueryEscape(args.Project)
+		}
+	case "kv":
+		endpoint = "/v1/storage/stores?storeType=kv"
+	case "blob":
+		endpoint = "/v1/storage/stores?storeType=blob"
+	case "postgres", "pg":
+		endpoint = "/v1/storage/stores?storeType=postgres"
+	case "edge-configs", "edge-config", "edge":
+		endpoint = "/v1/edge-config"
+	default:
+		return mcp.NewToolResultError(fmt.Sprintf("unknown resource type: %s (expected: projects, deployments, domains, env, teams, aliases, kv, blob, postgres, edge-configs)", resource)), nil
+	}
+
+	result, err := client.RunAPIWithContext(ctx, "GET", endpoint, "")
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Vercel API error: %v", err)), nil
+	}
+
+	return mcp.NewToolResultText(result), nil
+}
+
+// mcpResolveProviderKey resolves the API key for the given AI provider using
+// config and environment variables. Mirrors the resolution logic in ask.go.
+func mcpResolveProviderKey(provider string) string {
+	switch provider {
+	case "bedrock", "claude", "gemini", "gemini-api":
+		return ""
+	case "openai":
+		return resolveOpenAIKey("")
+	case "anthropic":
+		return resolveAnthropicKey("")
+	case "cohere":
+		return resolveCohereKey("")
+	case "deepseek":
+		return resolveDeepSeekKey("")
+	case "minimax":
+		return resolveMiniMaxKey("")
+	default:
+		return viper.GetString(fmt.Sprintf("ai.providers.%s.api_key", provider))
+	}
 }
 
 func runClankerCommand(ctx context.Context, args commandArgs) (map[string]any, error) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bgdnvk/clanker/internal/digitalocean"
 	"github.com/bgdnvk/clanker/internal/gcp"
 	"github.com/bgdnvk/clanker/internal/hetzner"
+	"github.com/bgdnvk/clanker/internal/vercel"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -110,6 +111,11 @@ func init() {
 	// Register Hetzner static commands
 	hetznerCmd := hetzner.CreateHetznerCommands()
 	rootCmd.AddCommand(hetznerCmd)
+
+	// Register Vercel static commands + ask stub (phase 1)
+	vercelCmd := vercel.CreateVercelCommands()
+	AddVercelAskCommand(vercelCmd)
+	rootCmd.AddCommand(vercelCmd)
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/vercel.go
+++ b/cmd/vercel.go
@@ -37,12 +37,5 @@ func runVercelAsk(cmd *cobra.Command, args []string) error {
 	if question == "" {
 		return fmt.Errorf("question cannot be empty")
 	}
-	fmt.Println("The dedicated Vercel ask subcommand (with conversation history) arrives in phase 4.")
-	fmt.Println("For one-shot queries today, use:")
-	fmt.Printf("  clanker ask --vercel %q\n", question)
-	fmt.Println("Or the raw data commands:")
-	fmt.Println("  clanker vercel list projects")
-	fmt.Println("  clanker vercel list deployments --project <id>")
-	fmt.Println("  clanker vercel analytics --period 30d")
-	return nil
+	return fmt.Errorf("vercel ask subcommand not yet implemented — use 'clanker ask --vercel %s' instead", question)
 }

--- a/cmd/vercel.go
+++ b/cmd/vercel.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// Phase-1 stub. The real LLM-powered ask-mode for Vercel lands in phase 4
+// (cost + AI ask-mode). Keeping the subcommand registered from day one means
+// existing `clanker cf ask` muscle memory carries over and docs can reference
+// it without a version gate.
+var vercelAskCmd = &cobra.Command{
+	Use:   "ask [question]",
+	Short: "Ask natural language questions about your Vercel account (phase 4+)",
+	Long: `Ask natural language questions about your Vercel account using AI.
+
+NOTE: the dedicated Vercel ask pipeline arrives in phase 4. Until then, use
+'clanker ask --vercel "..."' — the main ask command will include Vercel context
+when phase 4 ships. You can also run ` + "`clanker vercel list projects`" + ` today for
+raw data.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runVercelAsk,
+}
+
+// AddVercelAskCommand attaches the ask subcommand to the `vercel` tree.
+// Called from root.go after `vercel.CreateVercelCommands()` returns.
+func AddVercelAskCommand(vercelCmd *cobra.Command) {
+	vercelCmd.AddCommand(vercelAskCmd)
+}
+
+func runVercelAsk(cmd *cobra.Command, args []string) error {
+	question := strings.TrimSpace(args[0])
+	if question == "" {
+		return fmt.Errorf("question cannot be empty")
+	}
+	fmt.Println("Vercel ask-mode is not yet wired (planned for phase 4).")
+	fmt.Println("For now, try:")
+	fmt.Println("  clanker vercel list projects")
+	fmt.Println("  clanker vercel list deployments --project <id>")
+	fmt.Println("  clanker vercel analytics --period 30d")
+	return nil
+}

--- a/cmd/vercel.go
+++ b/cmd/vercel.go
@@ -7,19 +7,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Phase-1 stub. The real LLM-powered ask-mode for Vercel lands in phase 4
-// (cost + AI ask-mode). Keeping the subcommand registered from day one means
-// existing `clanker cf ask` muscle memory carries over and docs can reference
-// it without a version gate.
+// Phase-1 stub. The full conversational Vercel ask-mode (with history and
+// tool-use) lands in phase 4; for now one-shot queries are served by the
+// main `clanker ask --vercel "..."` flow. Keeping the subcommand registered
+// from day one means existing `clanker cf ask` muscle memory carries over
+// and docs can reference it without a version gate.
 var vercelAskCmd = &cobra.Command{
 	Use:   "ask [question]",
 	Short: "Ask natural language questions about your Vercel account (phase 4+)",
 	Long: `Ask natural language questions about your Vercel account using AI.
 
-NOTE: the dedicated Vercel ask pipeline arrives in phase 4. Until then, use
-'clanker ask --vercel "..."' — the main ask command will include Vercel context
-when phase 4 ships. You can also run ` + "`clanker vercel list projects`" + ` today for
-raw data.`,
+NOTE: conversational history and per-project tool-use arrive in phase 4.
+For one-shot queries today, use ` + "`clanker ask --vercel \"...\"`" + ` — it
+resolves your Vercel token/team, gathers context, and drives the configured
+AI provider. You can also run ` + "`clanker vercel list projects`" + ` for raw
+data.`,
 	Args: cobra.ExactArgs(1),
 	RunE: runVercelAsk,
 }
@@ -35,8 +37,10 @@ func runVercelAsk(cmd *cobra.Command, args []string) error {
 	if question == "" {
 		return fmt.Errorf("question cannot be empty")
 	}
-	fmt.Println("Vercel ask-mode is not yet wired (planned for phase 4).")
-	fmt.Println("For now, try:")
+	fmt.Println("The dedicated Vercel ask subcommand (with conversation history) arrives in phase 4.")
+	fmt.Println("For one-shot queries today, use:")
+	fmt.Printf("  clanker ask --vercel %q\n", question)
+	fmt.Println("Or the raw data commands:")
 	fmt.Println("  clanker vercel list projects")
 	fmt.Println("  clanker vercel list deployments --project <id>")
 	fmt.Println("  clanker vercel analytics --period 30d")

--- a/internal/backend/client.go
+++ b/internal/backend/client.go
@@ -423,6 +423,59 @@ func (c *Client) StoreHetznerCredentials(ctx context.Context, creds *HetznerCred
 	return nil
 }
 
+// GetVercelCredentials retrieves Vercel credentials from the backend
+func (c *Client) GetVercelCredentials(ctx context.Context) (*VercelCredentials, error) {
+	respBody, err := c.doRequest(ctx, http.MethodGet, "/api/v1/cli/credentials/vercel", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Provider    string            `json:"provider"`
+			Credentials VercelCredentials `json:"credentials"`
+		} `json:"data"`
+	}
+
+	if err := json.Unmarshal(respBody, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if !response.Success {
+		return nil, fmt.Errorf("failed to get Vercel credentials")
+	}
+
+	return &response.Data.Credentials, nil
+}
+
+// StoreVercelCredentials stores Vercel credentials in the backend
+func (c *Client) StoreVercelCredentials(ctx context.Context, creds *VercelCredentials) error {
+	body := map[string]interface{}{
+		"provider":    "vercel",
+		"credentials": creds,
+	}
+
+	respBody, err := c.doRequest(ctx, http.MethodPut, "/api/v1/secrets/vercel", body)
+	if err != nil {
+		return err
+	}
+
+	var response APIResponse
+	if err := json.Unmarshal(respBody, &response); err != nil {
+		return fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if !response.Success {
+		if response.Error != "" {
+			return fmt.Errorf("failed to store credentials: %s", response.Error)
+		}
+		return fmt.Errorf("failed to store credentials")
+	}
+
+	return nil
+}
+
 // ListCredentials lists all credentials stored in the backend
 func (c *Client) ListCredentials(ctx context.Context) ([]CredentialEntry, error) {
 	respBody, err := c.doRequest(ctx, http.MethodGet, "/api/v1/cli/credentials", nil)

--- a/internal/backend/types.go
+++ b/internal/backend/types.go
@@ -47,6 +47,13 @@ type HetznerCredentials struct {
 	APIToken string `json:"api_token"`
 }
 
+// VercelCredentials represents Vercel credentials stored in the backend.
+// TeamID is optional — personal accounts have no team scope.
+type VercelCredentials struct {
+	APIToken string `json:"api_token"`
+	TeamID   string `json:"team_id,omitempty"`
+}
+
 // CredentialProvider represents supported credential providers
 type CredentialProvider string
 
@@ -58,6 +65,7 @@ const (
 	ProviderDigitalOcean CredentialProvider = "digitalocean"
 	ProviderHetzner      CredentialProvider = "hetzner"
 	ProviderKubernetes   CredentialProvider = "kubernetes"
+	ProviderVercel       CredentialProvider = "vercel"
 )
 
 // CredentialEntry represents a stored credential in the backend

--- a/internal/maker/exec.go
+++ b/internal/maker/exec.go
@@ -231,6 +231,10 @@ type ExecOptions struct {
 	// Hetzner options
 	HetznerAPIToken string
 
+	// Vercel options
+	VercelAPIToken string
+	VercelTeamID   string
+
 	CheckpointKey            string
 	DisableDurableCheckpoint bool
 

--- a/internal/maker/exec_vercel.go
+++ b/internal/maker/exec_vercel.go
@@ -1,0 +1,145 @@
+package maker
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// ExecuteVercelPlan executes a Vercel infrastructure plan by shelling out to
+// the `vercel` CLI. The pattern mirrors ExecuteCloudflarePlan / ExecuteHetznerPlan.
+func ExecuteVercelPlan(ctx context.Context, plan *Plan, opts ExecOptions) error {
+	if plan == nil {
+		return fmt.Errorf("nil plan")
+	}
+	if opts.Writer == nil {
+		return fmt.Errorf("missing output writer")
+	}
+	if opts.VercelAPIToken == "" {
+		return fmt.Errorf("missing vercel API token")
+	}
+
+	bindings := make(map[string]string)
+
+	for idx, cmdSpec := range plan.Commands {
+		if err := validateVercelCommand(cmdSpec.Args, opts.Destroyer); err != nil {
+			return fmt.Errorf("command %d rejected: %w", idx+1, err)
+		}
+
+		args := make([]string, 0, len(cmdSpec.Args)+4)
+		args = append(args, cmdSpec.Args...)
+		args = applyPlanBindings(args, bindings)
+
+		if hasUnresolvedPlaceholders(args) {
+			return fmt.Errorf("command %d has unresolved placeholders after substitutions", idx+1)
+		}
+
+		_, _ = fmt.Fprintf(opts.Writer, "[maker] running %d/%d: %s\n", idx+1, len(plan.Commands), formatVercelArgsForLog(args))
+
+		out, runErr := runVercelCommandStreaming(ctx, args, opts, opts.Writer)
+		if runErr != nil {
+			return fmt.Errorf("vercel command %d failed: %w", idx+1, runErr)
+		}
+
+		learnPlanBindingsFromProduces(cmdSpec.Produces, out, bindings)
+	}
+
+	return nil
+}
+
+// validateVercelCommand validates that a command is a legitimate vercel CLI
+// invocation and not an attempt to escape into other tools.
+func validateVercelCommand(args []string, allowDestructive bool) error {
+	if len(args) == 0 {
+		return fmt.Errorf("empty args")
+	}
+
+	first := strings.ToLower(strings.TrimSpace(args[0]))
+
+	// Only allow vercel commands
+	if first != "vercel" {
+		blockedCommands := []string{
+			"aws", "gcloud", "az", "kubectl", "helm", "eksctl", "kubeadm",
+			"python", "node", "npm", "npx",
+			"bash", "sh", "zsh", "fish",
+			"terraform", "tofu", "make",
+			"wrangler", "cloudflared", "curl",
+			"doctl", "hcloud",
+		}
+		for _, blocked := range blockedCommands {
+			if first == blocked || strings.HasPrefix(first, blocked) {
+				return fmt.Errorf("non-vercel command is not allowed: %q", args[0])
+			}
+		}
+	}
+
+	// Check for shell operators
+	for _, a := range args {
+		lower := strings.ToLower(a)
+		if strings.Contains(lower, ";") || strings.Contains(lower, "|") || strings.Contains(lower, "&&") || strings.Contains(lower, "||") {
+			return fmt.Errorf("shell operators are not allowed")
+		}
+
+		// Block destructive operations unless destroyer mode is enabled
+		if !allowDestructive {
+			destructiveVerbs := []string{"delete", "remove", "destroy", "rm"}
+			for _, verb := range destructiveVerbs {
+				if lower == verb {
+					return fmt.Errorf("destructive verbs are blocked (use --destroyer to allow)")
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// runVercelCommandStreaming executes a vercel CLI command with streaming output.
+func runVercelCommandStreaming(ctx context.Context, args []string, opts ExecOptions, w io.Writer) (string, error) {
+	bin, err := exec.LookPath("vercel")
+	if err != nil {
+		return "", fmt.Errorf("vercel not found in PATH (install with: npm i -g vercel): %w", err)
+	}
+
+	// Strip "vercel" from args if present (the binary name is already the executable)
+	cmdArgs := args
+	if len(args) > 0 && strings.ToLower(strings.TrimSpace(args[0])) == "vercel" {
+		cmdArgs = args[1:]
+	}
+
+	cmd := exec.CommandContext(ctx, bin, cmdArgs...)
+
+	// Inject authentication via environment variables
+	cmd.Env = append(os.Environ(), fmt.Sprintf("VERCEL_TOKEN=%s", opts.VercelAPIToken))
+	if opts.VercelTeamID != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("VERCEL_ORG_ID=%s", opts.VercelTeamID))
+	}
+
+	var buf bytes.Buffer
+	mw := io.MultiWriter(w, &buf)
+	cmd.Stdout = mw
+	cmd.Stderr = mw
+
+	err = cmd.Run()
+	out := buf.String()
+	if err != nil {
+		return out, err
+	}
+	return out, nil
+}
+
+// formatVercelArgsForLog formats command args for logging, masking sensitive data.
+func formatVercelArgsForLog(args []string) string {
+	if len(args) == 0 {
+		return ""
+	}
+	// If the first arg is "vercel", show it as-is; otherwise prefix for clarity.
+	if strings.ToLower(strings.TrimSpace(args[0])) == "vercel" {
+		return strings.Join(args, " ")
+	}
+	return "vercel " + strings.Join(args, " ")
+}

--- a/internal/maker/exec_vercel.go
+++ b/internal/maker/exec_vercel.go
@@ -26,13 +26,13 @@ func ExecuteVercelPlan(ctx context.Context, plan *Plan, opts ExecOptions) error 
 	bindings := make(map[string]string)
 
 	for idx, cmdSpec := range plan.Commands {
-		if err := validateVercelCommand(cmdSpec.Args, opts.Destroyer); err != nil {
-			return fmt.Errorf("command %d rejected: %w", idx+1, err)
-		}
-
 		args := make([]string, 0, len(cmdSpec.Args)+4)
 		args = append(args, cmdSpec.Args...)
 		args = applyPlanBindings(args, bindings)
+
+		if err := validateVercelCommand(args, opts.Destroyer); err != nil {
+			return fmt.Errorf("command %d rejected after binding: %w", idx+1, err)
+		}
 
 		stdinData := cmdSpec.Stdin
 		// Auto-detect env add commands that need stdin piping even
@@ -75,7 +75,8 @@ func validateVercelCommand(args []string, allowDestructive bool) error {
 	// Check for shell operators and destructive verbs.
 	for _, a := range args {
 		lower := strings.ToLower(a)
-		if strings.Contains(lower, ";") || strings.Contains(lower, "|") || strings.Contains(lower, "&&") || strings.Contains(lower, "||") {
+		if strings.Contains(lower, ";") || strings.Contains(lower, "|") || strings.Contains(lower, "&&") || strings.Contains(lower, "||") ||
+			strings.ContainsAny(a, "\n\r") {
 			return fmt.Errorf("shell operators are not allowed")
 		}
 

--- a/internal/maker/exec_vercel.go
+++ b/internal/maker/exec_vercel.go
@@ -34,13 +34,25 @@ func ExecuteVercelPlan(ctx context.Context, plan *Plan, opts ExecOptions) error 
 		args = append(args, cmdSpec.Args...)
 		args = applyPlanBindings(args, bindings)
 
+		stdinData := cmdSpec.Stdin
+		// Auto-detect env add commands that need stdin piping even
+		// when the plan was generated without the stdin field.
+		if stdinData == "" && isVercelEnvAddCommand(args) && len(args) >= 5 {
+			// Legacy format: ["vercel", "env", "add", KEY, VALUE, ...]
+			// Extract the value and rewrite args to remove it.
+			stdinData = args[4] + "\n"
+			args = append(args[:4], args[5:]...)
+		} else if stdinData != "" && !strings.HasSuffix(stdinData, "\n") {
+			stdinData += "\n"
+		}
+
 		if hasUnresolvedPlaceholders(args) {
 			return fmt.Errorf("command %d has unresolved placeholders after substitutions", idx+1)
 		}
 
 		_, _ = fmt.Fprintf(opts.Writer, "[maker] running %d/%d: %s\n", idx+1, len(plan.Commands), formatVercelArgsForLog(args))
 
-		out, runErr := runVercelCommandStreaming(ctx, args, opts, opts.Writer)
+		out, runErr := runVercelCommandStreamingWithStdin(ctx, args, stdinData, opts, opts.Writer)
 		if runErr != nil {
 			return fmt.Errorf("vercel command %d failed: %w", idx+1, runErr)
 		}
@@ -52,32 +64,15 @@ func ExecuteVercelPlan(ctx context.Context, plan *Plan, opts ExecOptions) error 
 }
 
 // validateVercelCommand validates that a command is a legitimate vercel CLI
-// invocation and not an attempt to escape into other tools.
+// invocation and not an attempt to escape into other tools. Only commands
+// whose first token is literally "vercel" are allowed — everything else is
+// rejected unconditionally.
 func validateVercelCommand(args []string, allowDestructive bool) error {
-	if len(args) == 0 {
-		return fmt.Errorf("empty args")
+	if len(args) == 0 || strings.ToLower(strings.TrimSpace(args[0])) != "vercel" {
+		return fmt.Errorf("only vercel commands are allowed, got: %q", args)
 	}
 
-	first := strings.ToLower(strings.TrimSpace(args[0]))
-
-	// Only allow vercel commands
-	if first != "vercel" {
-		blockedCommands := []string{
-			"aws", "gcloud", "az", "kubectl", "helm", "eksctl", "kubeadm",
-			"python", "node", "npm", "npx",
-			"bash", "sh", "zsh", "fish",
-			"terraform", "tofu", "make",
-			"wrangler", "cloudflared", "curl",
-			"doctl", "hcloud",
-		}
-		for _, blocked := range blockedCommands {
-			if first == blocked || strings.HasPrefix(first, blocked) {
-				return fmt.Errorf("non-vercel command is not allowed: %q", args[0])
-			}
-		}
-	}
-
-	// Check for shell operators
+	// Check for shell operators and destructive verbs.
 	for _, a := range args {
 		lower := strings.ToLower(a)
 		if strings.Contains(lower, ";") || strings.Contains(lower, "|") || strings.Contains(lower, "&&") || strings.Contains(lower, "||") {
@@ -98,8 +93,9 @@ func validateVercelCommand(args []string, allowDestructive bool) error {
 	return nil
 }
 
-// runVercelCommandStreaming executes a vercel CLI command with streaming output.
-func runVercelCommandStreaming(ctx context.Context, args []string, opts ExecOptions, w io.Writer) (string, error) {
+// runVercelCommandStreamingWithStdin executes a vercel CLI command with
+// streaming output and optional stdin data.
+func runVercelCommandStreamingWithStdin(ctx context.Context, args []string, stdinData string, opts ExecOptions, w io.Writer) (string, error) {
 	bin, err := exec.LookPath("vercel")
 	if err != nil {
 		return "", fmt.Errorf("vercel not found in PATH (install with: npm i -g vercel): %w", err)
@@ -119,6 +115,10 @@ func runVercelCommandStreaming(ctx context.Context, args []string, opts ExecOpti
 		cmd.Env = append(cmd.Env, fmt.Sprintf("VERCEL_ORG_ID=%s", opts.VercelTeamID))
 	}
 
+	if stdinData != "" {
+		cmd.Stdin = strings.NewReader(stdinData)
+	}
+
 	var buf bytes.Buffer
 	mw := io.MultiWriter(w, &buf)
 	cmd.Stdout = mw
@@ -132,14 +132,36 @@ func runVercelCommandStreaming(ctx context.Context, args []string, opts ExecOpti
 	return out, nil
 }
 
-// formatVercelArgsForLog formats command args for logging, masking sensitive data.
+// isVercelEnvAddCommand returns true if the args represent a `vercel env add` command.
+func isVercelEnvAddCommand(args []string) bool {
+	if len(args) < 4 {
+		return false
+	}
+	lower := make([]string, 0, 3)
+	for _, a := range args[:3] {
+		lower = append(lower, strings.ToLower(strings.TrimSpace(a)))
+	}
+	return lower[0] == "vercel" && lower[1] == "env" && lower[2] == "add"
+}
+
+// formatVercelArgsForLog formats command args for logging, masking env variable
+// values and other sensitive data so they don't appear in plan logs.
 func formatVercelArgsForLog(args []string) string {
 	if len(args) == 0 {
 		return ""
 	}
-	// If the first arg is "vercel", show it as-is; otherwise prefix for clarity.
-	if strings.ToLower(strings.TrimSpace(args[0])) == "vercel" {
-		return strings.Join(args, " ")
+
+	// Mask: for `env add KEY VALUE ...` never log the value.
+	// The value is piped via stdin now, but legacy plans might still have it
+	// as a positional arg.
+	masked := make([]string, len(args))
+	copy(masked, args)
+	if isVercelEnvAddCommand(masked) && len(masked) >= 5 {
+		masked[4] = "***"
 	}
-	return "vercel " + strings.Join(args, " ")
+
+	if strings.ToLower(strings.TrimSpace(masked[0])) == "vercel" {
+		return strings.Join(masked, " ")
+	}
+	return "vercel " + strings.Join(masked, " ")
 }

--- a/internal/maker/plan.go
+++ b/internal/maker/plan.go
@@ -38,6 +38,9 @@ type Command struct {
 	Args     []string          `json:"args"`
 	Reason   string            `json:"reason,omitempty"`
 	Produces map[string]string `json:"produces,omitempty"`
+	// Stdin is optional data piped to the command's standard input.
+	// Used by commands like `vercel env add` that read values from stdin.
+	Stdin string `json:"stdin,omitempty"`
 }
 
 func ParsePlan(raw string) (*Plan, error) {

--- a/internal/maker/plan.go
+++ b/internal/maker/plan.go
@@ -76,7 +76,7 @@ func ParsePlan(raw string) (*Plan, error) {
 	}
 
 	if strings.TrimSpace(p.Provider) == "" {
-		p.Provider = "aws"
+		p.Provider = inferProviderFromCommands(p.Commands)
 	}
 
 	if len(p.Commands) == 0 {
@@ -106,7 +106,7 @@ func parsePlanFromAlternativeShapes(trimmed string) (*Plan, error) {
 				out := &Plan{
 					Version:   CurrentPlanVersion,
 					CreatedAt: time.Now().UTC(),
-					Provider:  "aws",
+					Provider:  inferProviderFromCommands([]Command{cmd}),
 					Question:  "",
 					Summary:   "generated plan",
 					Commands:  []Command{cmd},
@@ -135,7 +135,7 @@ func parsePlanFromAlternativeShapes(trimmed string) (*Plan, error) {
 				out := &Plan{
 					Version:   CurrentPlanVersion,
 					CreatedAt: time.Now().UTC(),
-					Provider:  "aws",
+					Provider:  inferProviderFromCommands(filtered),
 					Question:  "",
 					Summary:   "generated plan",
 					Commands:  filtered,
@@ -146,6 +146,35 @@ func parsePlanFromAlternativeShapes(trimmed string) (*Plan, error) {
 	}
 
 	return nil, fmt.Errorf("unrecognized plan shape")
+}
+
+// inferProviderFromCommands inspects the first arg of each command to infer the
+// target provider. When the plan was generated for a non-AWS provider (vercel,
+// cloudflare, hetzner, etc.) but arrives as a bare Command or []Command without
+// a provider field, we need to avoid defaulting to "aws" which would route the
+// plan to the wrong executor.
+func inferProviderFromCommands(cmds []Command) string {
+	for _, cmd := range cmds {
+		if len(cmd.Args) == 0 {
+			continue
+		}
+		first := strings.ToLower(strings.TrimSpace(cmd.Args[0]))
+		switch first {
+		case "vercel":
+			return "vercel"
+		case "wrangler":
+			return "cloudflare"
+		case "hcloud":
+			return "hetzner"
+		case "doctl":
+			return "digitalocean"
+		case "gcloud":
+			return "gcp"
+		case "az":
+			return "azure"
+		}
+	}
+	return "aws"
 }
 
 func normalizeArgs(args []string) []string {

--- a/internal/maker/vercel_prompts.go
+++ b/internal/maker/vercel_prompts.go
@@ -114,9 +114,10 @@ Inspect a deployment:
   "reason": "Show details about a deployment"
 }
 
-Add environment variable:
+Add environment variable (value piped via stdin by the executor):
 {
   "args": ["vercel", "env", "add", "DATABASE_URL", "production"],
+  "stdin": "postgres://user:pass@host/db",
   "reason": "Add DATABASE_URL env var for production target"
 }
 

--- a/internal/maker/vercel_prompts.go
+++ b/internal/maker/vercel_prompts.go
@@ -1,0 +1,173 @@
+package maker
+
+import "fmt"
+
+// VercelPlanPrompt returns a system prompt instructing the LLM to produce a
+// Vercel CLI execution plan for the given user question.
+func VercelPlanPrompt(question string) string {
+	return VercelPlanPromptWithMode(question, false)
+}
+
+// VercelPlanPromptWithMode returns a Vercel plan prompt with optional
+// destructive-operation support (destroyer mode).
+func VercelPlanPromptWithMode(question string, destroyer bool) string {
+	destructiveRule := "- Avoid any destructive operations (delete/remove/destroy/rm)."
+	if destroyer {
+		destructiveRule = "- Destructive operations are allowed ONLY if the user explicitly asked for deletion."
+	}
+
+	return fmt.Sprintf(`You are an infrastructure maker planner for Vercel.
+
+Your job: produce a concrete, minimal Vercel CLI execution plan to satisfy the user request.
+
+Constraints:
+- Output ONLY valid JSON.
+- Use this schema exactly:
+{
+  "version": 1,
+  "createdAt": "RFC3339 timestamp",
+  "provider": "vercel",
+  "question": "original user question",
+  "summary": "short summary of what will be created/changed",
+  "commands": [
+    {
+      "args": ["vercel", "subcommand", "arg1", "..."],
+      "reason": "why this command is needed",
+      "produces": {
+        "OPTIONAL_BINDING_NAME": "$.json.path.to.value"
+      }
+    }
+  ],
+  "notes": ["optional notes"]
+}
+
+Rules for commands:
+- The "commands" array MUST contain at least 1 command.
+- Provide args as an array; do NOT provide a single string.
+- Commands MUST be vercel CLI only. Every command args MUST start with "vercel".
+- Do NOT include any non-vercel programs (no aws/gcloud/az/python/node/bash/curl/terraform/npm/doctl/hcloud/etc).
+- Do NOT include shell operators, pipes, redirects, or subshells.
+- Prefer idempotent operations where possible.
+- If the user request is ambiguous or missing required details, output a DISCOVERY-ONLY plan:
+  - Still output a NON-EMPTY commands array.
+  - Use READ-ONLY commands to gather missing inputs (examples: ["vercel", "list"], ["vercel", "env", "ls"], ["vercel", "domains", "ls"]).
+
+%s
+
+Placeholders and bindings:
+- You MAY use placeholder tokens like "<PROJECT_ID>" or "<DEPLOYMENT_URL>".
+- If you use ANY placeholder, ensure an earlier command includes "produces" mapping.
+
+Common Vercel operations:
+
+Deploy to production:
+{
+  "args": ["vercel", "deploy", "--prod"],
+  "reason": "Deploy the current project to production"
+}
+
+Preview deploy:
+{
+  "args": ["vercel", "deploy"],
+  "reason": "Create a preview deployment"
+}
+
+Deploy specific directory:
+{
+  "args": ["vercel", "deploy", "./dist", "--prod"],
+  "reason": "Deploy the dist directory to production"
+}
+
+Deploy with project scope:
+{
+  "args": ["vercel", "deploy", "--prod", "--scope", "<TEAM_SLUG>"],
+  "reason": "Deploy to production under a specific team scope"
+}
+
+Redeploy an existing deployment:
+{
+  "args": ["vercel", "redeploy", "<DEPLOYMENT_URL>"],
+  "reason": "Redeploy an existing deployment"
+}
+
+Rollback to previous production deployment:
+{
+  "args": ["vercel", "rollback"],
+  "reason": "Rollback to the previous production deployment"
+}
+
+Cancel a running deployment:
+{
+  "args": ["vercel", "cancel", "<DEPLOYMENT_ID>"],
+  "reason": "Cancel an in-progress deployment"
+}
+
+List projects:
+{
+  "args": ["vercel", "list"],
+  "reason": "List recent deployments"
+}
+
+Inspect a deployment:
+{
+  "args": ["vercel", "inspect", "<DEPLOYMENT_URL>"],
+  "reason": "Show details about a deployment"
+}
+
+Add environment variable:
+{
+  "args": ["vercel", "env", "add", "DATABASE_URL", "production"],
+  "reason": "Add DATABASE_URL env var for production target"
+}
+
+Remove environment variable:
+{
+  "args": ["vercel", "env", "rm", "DATABASE_URL", "production", "--yes"],
+  "reason": "Remove DATABASE_URL env var from production target"
+}
+
+List environment variables:
+{
+  "args": ["vercel", "env", "ls"],
+  "reason": "List all environment variables"
+}
+
+Pull environment variables:
+{
+  "args": ["vercel", "env", "pull", ".env.local"],
+  "reason": "Pull environment variables to local file"
+}
+
+Add domain:
+{
+  "args": ["vercel", "domains", "add", "example.com"],
+  "reason": "Add custom domain"
+}
+
+Remove domain:
+{
+  "args": ["vercel", "domains", "rm", "example.com", "--yes"],
+  "reason": "Remove custom domain"
+}
+
+List domains:
+{
+  "args": ["vercel", "domains", "ls"],
+  "reason": "List custom domains"
+}
+
+Link project:
+{
+  "args": ["vercel", "link"],
+  "reason": "Link current directory to a Vercel project"
+}
+
+Promote a deployment to production:
+{
+  "args": ["vercel", "promote", "<DEPLOYMENT_URL>"],
+  "reason": "Promote a preview deployment to production"
+}
+
+User request:
+%q`, destructiveRule, question)
+}

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -650,9 +650,11 @@ func ApplyLLMClassification(ctx *ServiceContext, llmService string) {
 	}
 }
 
-// contains checks if s contains substr (case-insensitive)
+// contains checks if s contains substr (case-insensitive). Callers are expected
+// to pass an already-lowercased `s` — keyword-match paths in InferContext
+// lowercase the question once up front — so we only normalize `substr`.
 func contains(s, substr string) bool {
-	return strings.Contains(strings.ToLower(s), strings.ToLower(substr))
+	return strings.Contains(s, strings.ToLower(substr))
 }
 
 func containsAzureSignal(questionLower string, phraseKeywords []string, tokenKeywords []string) bool {

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -24,6 +24,7 @@ type ServiceContext struct {
 	Cloudflare   bool
 	DigitalOcean bool
 	Hetzner      bool
+	Vercel       bool
 	IAM          bool
 	Code         bool
 }
@@ -40,7 +41,7 @@ type Classification struct {
 func DefaultInfraProvider() string {
 	p := strings.ToLower(strings.TrimSpace(viper.GetString("infra.default_provider")))
 	switch p {
-	case "aws", "gcp", "azure", "cloudflare", "digitalocean", "hetzner":
+	case "aws", "gcp", "azure", "cloudflare", "digitalocean", "hetzner", "vercel":
 		return p
 	default:
 		return "aws"
@@ -57,6 +58,7 @@ func applyConfiguredDefaultContext(ctx *ServiceContext) {
 	ctx.Cloudflare = false
 	ctx.DigitalOcean = false
 	ctx.Hetzner = false
+	ctx.Vercel = false
 	ctx.IAM = false
 
 	switch DefaultInfraProvider() {
@@ -70,6 +72,8 @@ func applyConfiguredDefaultContext(ctx *ServiceContext) {
 		ctx.DigitalOcean = true
 	case "hetzner":
 		ctx.Hetzner = true
+	case "vercel":
+		ctx.Vercel = true
 	default:
 		ctx.AWS = true
 		ctx.GitHub = true
@@ -240,6 +244,23 @@ func InferContext(question string) ServiceContext {
 		"hetzner load balancer",
 	}
 
+	vercelKeywords := []string{
+		// Only match when Vercel is explicitly referenced — we do not want to
+		// catch generic "deploy" / "preview" / "edge function" phrasing.
+		"vercel",
+		"vercel.app",
+		"vercel project",
+		"vercel deployment",
+		"vercel domain",
+		"vercel env",
+		"next.js deployment",
+		"nextjs deployment",
+		"preview url",
+		"production deployment on vercel",
+		"edge function on vercel",
+		"edge middleware",
+	}
+
 	iamKeywords := []string{
 		// IAM specific queries
 		"iam role", "iam roles", "iam policy", "iam policies",
@@ -323,6 +344,13 @@ func InferContext(question string) ServiceContext {
 		}
 	}
 
+	for _, keyword := range vercelKeywords {
+		if contains(questionLower, keyword) {
+			ctx.Vercel = true
+			break
+		}
+	}
+
 	// Check for IAM-specific queries (takes precedence over general AWS)
 	for _, keyword := range iamKeywords {
 		if contains(questionLower, keyword) {
@@ -333,7 +361,7 @@ func InferContext(question string) ServiceContext {
 
 	// Default to the configured provider if nothing is detected.
 	// AWS keeps GitHub enabled for backward compatibility.
-	if !ctx.AWS && !ctx.GitHub && !ctx.Terraform && !ctx.K8s && !ctx.GCP && !ctx.Azure && !ctx.Cloudflare && !ctx.DigitalOcean && !ctx.Hetzner && !ctx.IAM {
+	if !ctx.AWS && !ctx.GitHub && !ctx.Terraform && !ctx.K8s && !ctx.GCP && !ctx.Azure && !ctx.Cloudflare && !ctx.DigitalOcean && !ctx.Hetzner && !ctx.Vercel && !ctx.IAM {
 		applyConfiguredDefaultContext(&ctx)
 	}
 
@@ -356,6 +384,7 @@ Available services:
 - azure: Microsoft Azure (VMs, AKS, App Service, Storage, Key Vault, Cosmos DB, VNets, etc.)
 - digitalocean: Digital Ocean (Droplets, DOKS, Managed Databases, Spaces, App Platform, Load Balancers, VPCs, etc.)
 - hetzner: Hetzner Cloud (Servers, Load Balancers, Volumes, Networks, Firewalls, Floating IPs, Primary IPs, etc.)
+- vercel: Vercel projects, deployments, domains, env vars, edge functions, KV/Blob/Postgres/Edge Config, analytics
 - github: GitHub repositories, PRs, issues, actions, workflows
 - terraform: Infrastructure as code, Terraform plans, state, modules
 - general: General questions not specific to any cloud platform
@@ -367,11 +396,12 @@ IMPORTANT RULES:
 4. If the query mentions AWS services (EC2, Lambda, S3, CloudFront, Route53, etc.) but NOT IAM-specific topics, classify as "aws"
 5. Only classify as "digitalocean" if the query EXPLICITLY mentions Digital Ocean, doctl, droplets, DOKS, or Digital Ocean-specific products
 6. Only classify as "hetzner" if the query EXPLICITLY mentions Hetzner, hcloud, or Hetzner-specific products
-7. If uncertain, classify as "%s" (the configured default cloud provider)
+7. Only classify as "vercel" if the query EXPLICITLY mentions Vercel, vercel.app, a Vercel deployment/project, or Vercel-specific products (Edge Config, Vercel KV / Blob / Postgres)
+8. If uncertain, classify as "%s" (the configured default cloud provider)
 
 Respond with ONLY a JSON object:
 {
-	"service": "cloudflare|aws|iam|k8s|gcp|azure|digitalocean|hetzner|github|terraform|general",
+	"service": "cloudflare|aws|iam|k8s|gcp|azure|digitalocean|hetzner|vercel|github|terraform|general",
     "confidence": "high|medium|low",
     "reason": "brief explanation of why this classification"
 }`, question, defaultProvider, defaultProvider)
@@ -470,6 +500,9 @@ func NeedsLLMClassification(ctx ServiceContext) bool {
 	if ctx.Hetzner {
 		count++
 	}
+	if ctx.Vercel {
+		count++
+	}
 	if ctx.IAM {
 		count++
 	}
@@ -479,8 +512,9 @@ func NeedsLLMClassification(ctx ServiceContext) bool {
 	// 2. Cloudflare was inferred (verify it's actually Cloudflare-related)
 	// 3. Digital Ocean was inferred (verify it's actually DO-related)
 	// 4. Hetzner was inferred (verify it's actually Hetzner-related)
-	// 5. IAM was inferred (verify it's actually IAM-related for disambiguation)
-	return count > 1 || ctx.Cloudflare || ctx.DigitalOcean || ctx.Hetzner || ctx.IAM
+	// 5. Vercel was inferred (verify it's actually Vercel-related)
+	// 6. IAM was inferred (verify it's actually IAM-related for disambiguation)
+	return count > 1 || ctx.Cloudflare || ctx.DigitalOcean || ctx.Hetzner || ctx.Vercel || ctx.IAM
 }
 
 // ApplyLLMClassification updates the ServiceContext based on LLM classification result
@@ -494,6 +528,7 @@ func ApplyLLMClassification(ctx *ServiceContext, llmService string) {
 		ctx.AWS = false
 		ctx.DigitalOcean = false
 		ctx.Hetzner = false
+		ctx.Vercel = false
 		ctx.IAM = false
 	case "k8s":
 		ctx.K8s = true
@@ -502,6 +537,7 @@ func ApplyLLMClassification(ctx *ServiceContext, llmService string) {
 		ctx.Azure = false
 		ctx.DigitalOcean = false
 		ctx.Hetzner = false
+		ctx.Vercel = false
 		ctx.IAM = false
 	case "gcp":
 		ctx.GCP = true
@@ -510,6 +546,7 @@ func ApplyLLMClassification(ctx *ServiceContext, llmService string) {
 		ctx.Azure = false
 		ctx.DigitalOcean = false
 		ctx.Hetzner = false
+		ctx.Vercel = false
 		ctx.IAM = false
 	case "azure":
 		ctx.Azure = true
@@ -519,6 +556,7 @@ func ApplyLLMClassification(ctx *ServiceContext, llmService string) {
 		ctx.AWS = false
 		ctx.DigitalOcean = false
 		ctx.Hetzner = false
+		ctx.Vercel = false
 		ctx.IAM = false
 	case "digitalocean":
 		ctx.DigitalOcean = true
@@ -528,6 +566,7 @@ func ApplyLLMClassification(ctx *ServiceContext, llmService string) {
 		ctx.K8s = false
 		ctx.Azure = false
 		ctx.Hetzner = false
+		ctx.Vercel = false
 		ctx.IAM = false
 	case "hetzner":
 		ctx.Hetzner = true
@@ -537,6 +576,17 @@ func ApplyLLMClassification(ctx *ServiceContext, llmService string) {
 		ctx.K8s = false
 		ctx.Azure = false
 		ctx.DigitalOcean = false
+		ctx.Vercel = false
+		ctx.IAM = false
+	case "vercel":
+		ctx.Vercel = true
+		ctx.AWS = false
+		ctx.GCP = false
+		ctx.Cloudflare = false
+		ctx.K8s = false
+		ctx.Azure = false
+		ctx.DigitalOcean = false
+		ctx.Hetzner = false
 		ctx.IAM = false
 	case "aws":
 		ctx.AWS = true
@@ -546,6 +596,7 @@ func ApplyLLMClassification(ctx *ServiceContext, llmService string) {
 		ctx.Azure = false
 		ctx.DigitalOcean = false
 		ctx.Hetzner = false
+		ctx.Vercel = false
 		ctx.IAM = false
 	case "iam":
 		ctx.IAM = true
@@ -556,22 +607,26 @@ func ApplyLLMClassification(ctx *ServiceContext, llmService string) {
 		ctx.Azure = false
 		ctx.DigitalOcean = false
 		ctx.Hetzner = false
+		ctx.Vercel = false
 	case "terraform":
 		ctx.Terraform = true
 		ctx.Cloudflare = false
 		ctx.DigitalOcean = false
 		ctx.Hetzner = false
+		ctx.Vercel = false
 	case "github":
 		ctx.GitHub = true
 		ctx.Cloudflare = false
 		ctx.DigitalOcean = false
 		ctx.Hetzner = false
+		ctx.Vercel = false
 	default:
 		// "general" - default to the configured infrastructure provider
 		// Only zero cloud provider flags, preserving GitHub/Terraform/K8s context
 		ctx.Cloudflare = false
 		ctx.DigitalOcean = false
 		ctx.Hetzner = false
+		ctx.Vercel = false
 		ctx.Azure = false
 		ctx.GCP = false
 		ctx.IAM = false
@@ -586,6 +641,8 @@ func ApplyLLMClassification(ctx *ServiceContext, llmService string) {
 			ctx.DigitalOcean = true
 		case "hetzner":
 			ctx.Hetzner = true
+		case "vercel":
+			ctx.Vercel = true
 		default:
 			ctx.AWS = true
 			ctx.GitHub = true

--- a/internal/routing/routing_test.go
+++ b/internal/routing/routing_test.go
@@ -1,6 +1,7 @@
 package routing
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -235,8 +236,10 @@ func TestGetClassificationPrompt(t *testing.T) {
 		"service",
 	}
 
+	// contains expects an already-lowercased haystack.
+	lowerPrompt := strings.ToLower(prompt)
 	for _, phrase := range expectedPhrases {
-		if !contains(prompt, phrase) {
+		if !contains(lowerPrompt, phrase) {
 			t.Errorf("GetClassificationPrompt missing expected phrase: %s", phrase)
 		}
 	}
@@ -416,13 +419,16 @@ func TestApplyLLMClassification_GeneralPreservesK8sContext(t *testing.T) {
 }
 
 func TestContains(t *testing.T) {
+	// contains expects its first argument to already be lowercased — callers
+	// in InferContext normalize the question once up front. Only the keyword
+	// argument is lowercased defensively.
 	tests := []struct {
 		s      string
 		substr string
 		expect bool
 	}{
-		{"Hello World", "world", true},
-		{"Hello World", "WORLD", true},
+		{"hello world", "world", true},
+		{"hello world", "WORLD", true},
 		{"cloudflare zones", "cloudflare", true},
 		{"list ec2", "EC2", true},
 		{"kubernetes pods", "k8s", false},

--- a/internal/vercel/client.go
+++ b/internal/vercel/client.go
@@ -24,6 +24,9 @@ type Client struct {
 	apiToken string
 	teamID   string
 	debug    bool
+	// raw, when set, causes the static CLI commands to print unformatted JSON
+	// responses instead of pretty-printed summaries.
+	raw bool
 }
 
 // ResolveAPIToken returns the Vercel API token from config or environment.

--- a/internal/vercel/client.go
+++ b/internal/vercel/client.go
@@ -1,0 +1,416 @@
+// Package vercel provides a client for the Vercel REST API and related CLI
+// tooling (the `vercel` CLI for deploys). Mirrors the shape of the Cloudflare
+// package so wiring into cmd/, routing, ask-mode and the desktop backend
+// stays uniform.
+package vercel
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+const baseURL = "https://api.vercel.com"
+
+// Client wraps the Vercel REST API and the official `vercel` CLI.
+type Client struct {
+	apiToken string
+	teamID   string
+	debug    bool
+}
+
+// ResolveAPIToken returns the Vercel API token from config or environment.
+// Resolution order: `vercel.api_token` → VERCEL_TOKEN → VERCEL_API_TOKEN.
+func ResolveAPIToken() string {
+	if t := strings.TrimSpace(viper.GetString("vercel.api_token")); t != "" {
+		return t
+	}
+	if env := strings.TrimSpace(os.Getenv("VERCEL_TOKEN")); env != "" {
+		return env
+	}
+	if env := strings.TrimSpace(os.Getenv("VERCEL_API_TOKEN")); env != "" {
+		return env
+	}
+	return ""
+}
+
+// ResolveTeamID returns the Vercel team ID from config or environment.
+// Resolution order: `vercel.team_id` → VERCEL_TEAM_ID → VERCEL_ORG_ID.
+// Team scoping is optional — personal accounts have no team ID.
+func ResolveTeamID() string {
+	if t := strings.TrimSpace(viper.GetString("vercel.team_id")); t != "" {
+		return t
+	}
+	if env := strings.TrimSpace(os.Getenv("VERCEL_TEAM_ID")); env != "" {
+		return env
+	}
+	if env := strings.TrimSpace(os.Getenv("VERCEL_ORG_ID")); env != "" {
+		return env
+	}
+	return ""
+}
+
+// NewClient creates a new Vercel client.
+func NewClient(apiToken, teamID string, debug bool) (*Client, error) {
+	if strings.TrimSpace(apiToken) == "" {
+		return nil, fmt.Errorf("vercel api_token is required")
+	}
+	return &Client{
+		apiToken: apiToken,
+		teamID:   teamID,
+		debug:    debug,
+	}, nil
+}
+
+// BackendVercelCredentials represents Vercel credentials retrieved from the
+// backend credential store (clanker-backend).
+type BackendVercelCredentials struct {
+	APIToken string
+	TeamID   string
+}
+
+// NewClientWithCredentials creates a new Vercel client using backend credentials.
+func NewClientWithCredentials(creds *BackendVercelCredentials, debug bool) (*Client, error) {
+	if creds == nil {
+		return nil, fmt.Errorf("credentials cannot be nil")
+	}
+	if strings.TrimSpace(creds.APIToken) == "" {
+		return nil, fmt.Errorf("vercel api_token is required")
+	}
+	return &Client{
+		apiToken: creds.APIToken,
+		teamID:   creds.TeamID,
+		debug:    debug,
+	}, nil
+}
+
+// GetAPIToken returns the API token.
+func (c *Client) GetAPIToken() string { return c.apiToken }
+
+// GetTeamID returns the team ID (may be empty for personal accounts).
+func (c *Client) GetTeamID() string { return c.teamID }
+
+// withTeam appends `teamId=<id>` to the endpoint when the client is team-scoped
+// and the endpoint does not already carry a teamId parameter.
+func (c *Client) withTeam(endpoint string) string {
+	if c.teamID == "" || strings.Contains(endpoint, "teamId=") {
+		return endpoint
+	}
+	sep := "?"
+	if strings.Contains(endpoint, "?") {
+		sep = "&"
+	}
+	return endpoint + sep + "teamId=" + c.teamID
+}
+
+// RunAPI executes a Vercel REST call with exponential backoff.
+func (c *Client) RunAPI(method, endpoint, body string) (string, error) {
+	return c.RunAPIWithContext(context.Background(), method, endpoint, body)
+}
+
+// RunAPIWithContext executes a Vercel REST call with a caller-controlled context.
+func (c *Client) RunAPIWithContext(ctx context.Context, method, endpoint, body string) (string, error) {
+	if _, err := exec.LookPath("curl"); err != nil {
+		return "", fmt.Errorf("curl not found in PATH")
+	}
+
+	endpoint = c.withTeam(endpoint)
+
+	backoffs := []time.Duration{200 * time.Millisecond, 500 * time.Millisecond, 1200 * time.Millisecond}
+	var lastErr error
+	var lastStderr string
+	var lastBody string
+
+	for attempt := 0; attempt < len(backoffs); attempt++ {
+		args := []string{
+			"-s",
+			"-X", method,
+			baseURL + endpoint,
+			"-H", fmt.Sprintf("Authorization: Bearer %s", c.apiToken),
+			"-H", "Content-Type: application/json",
+		}
+
+		if body != "" {
+			args = append(args, "-d", body)
+		}
+
+		if c.debug {
+			fmt.Printf("[vercel] curl -X %s %s%s\n", method, baseURL, endpoint)
+		}
+
+		cmd := exec.CommandContext(ctx, "curl", args...)
+
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+
+		err := cmd.Run()
+		if err == nil {
+			result := stdout.String()
+			if apiErr := checkAPIError(result); apiErr != nil {
+				// Retry once on 429 / 5xx style responses (detected via the error body).
+				if isRetryableError(apiErr.Error()) && attempt < len(backoffs)-1 {
+					lastBody = result
+					time.Sleep(backoffs[attempt])
+					continue
+				}
+				return result, apiErr
+			}
+			return result, nil
+		}
+
+		lastErr = err
+		lastStderr = strings.TrimSpace(stderr.String())
+
+		if ctx.Err() != nil {
+			break
+		}
+
+		if !isRetryableError(lastStderr) {
+			break
+		}
+
+		time.Sleep(backoffs[attempt])
+	}
+
+	if lastErr == nil && lastBody != "" {
+		return "", fmt.Errorf("vercel API call failed after retries: %s", lastBody)
+	}
+	if lastErr == nil {
+		return "", fmt.Errorf("vercel API call failed")
+	}
+	return "", fmt.Errorf("vercel API call failed: %w, stderr: %s%s", lastErr, lastStderr, errorHint(lastStderr))
+}
+
+// RunVercelCLI executes the official `vercel` CLI tool for operations the REST
+// API does not model well (source upload, prebuilt output, etc.). Phase 2+
+// callers shell out here; phase 1 clients just rely on REST.
+func (c *Client) RunVercelCLI(args ...string) (string, error) {
+	return c.RunVercelCLIWithContext(context.Background(), args...)
+}
+
+// RunVercelCLIWithContext executes the Vercel CLI with a caller-controlled context.
+func (c *Client) RunVercelCLIWithContext(ctx context.Context, args ...string) (string, error) {
+	if _, err := exec.LookPath("vercel"); err != nil {
+		return "", fmt.Errorf("vercel not found in PATH (required for deploy operations, install with: npm install -g vercel)")
+	}
+
+	cmd := exec.CommandContext(ctx, "vercel", args...)
+	cmd.Env = append(os.Environ(), fmt.Sprintf("VERCEL_TOKEN=%s", c.apiToken))
+	if c.teamID != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("VERCEL_ORG_ID=%s", c.teamID))
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if c.debug {
+		fmt.Printf("[vercel] vercel %s\n", strings.Join(args, " "))
+	}
+
+	if err := cmd.Run(); err != nil {
+		stderrStr := strings.TrimSpace(stderr.String())
+		return "", fmt.Errorf("vercel CLI failed: %w, stderr: %s%s", err, stderrStr, errorHint(stderrStr))
+	}
+
+	return stdout.String(), nil
+}
+
+// GetRelevantContext gathers Vercel context for LLM queries. The output is a
+// best-effort dump of the resources most likely to be relevant to the user's
+// question. Sections are keyword-gated to keep the context compact.
+func (c *Client) GetRelevantContext(ctx context.Context, question string) (string, error) {
+	questionLower := strings.ToLower(strings.TrimSpace(question))
+
+	type section struct {
+		name     string
+		endpoint string
+		keys     []string
+	}
+
+	// Team-scoped endpoints are only added when a team ID is available.
+	sections := []section{
+		{name: "Projects", endpoint: "/v9/projects?limit=50", keys: []string{"project", "vercel", "deploy", "site", "app", "next", "nextjs"}},
+		{name: "Deployments", endpoint: "/v6/deployments?limit=20", keys: []string{"deployment", "deploy", "preview", "production", "build", "rollback", "promote"}},
+		{name: "Domains", endpoint: "/v5/domains?limit=50", keys: []string{"domain", "dns", "alias", "custom", "vercel.app"}},
+	}
+	if c.teamID != "" {
+		sections = append(sections, section{
+			name:     "Usage",
+			endpoint: fmt.Sprintf("/v1/teams/%s/analytics/usage?period=30d", c.teamID),
+			keys:     []string{"usage", "bandwidth", "cost", "invocation", "function", "edge", "analytics", "speed"},
+		})
+	}
+
+	// Default sections: always include the project list so the LLM has a
+	// baseline view of what exists.
+	defaultSections := map[string]bool{
+		"Projects": true,
+	}
+
+	var out strings.Builder
+	var warnings []string
+
+	for _, s := range sections {
+		if questionLower != "" && len(s.keys) > 0 {
+			matched := false
+			for _, key := range s.keys {
+				if strings.Contains(questionLower, key) {
+					matched = true
+					break
+				}
+			}
+			if !matched && !defaultSections[s.name] {
+				continue
+			}
+		}
+
+		result, err := c.RunAPIWithContext(ctx, "GET", s.endpoint, "")
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("%s: %v", s.name, err))
+			continue
+		}
+
+		formatted := formatAPIResponse(s.name, result)
+		if formatted != "" {
+			out.WriteString(formatted)
+			out.WriteString("\n")
+		}
+	}
+
+	if len(warnings) > 0 {
+		out.WriteString("Vercel Warnings:\n")
+		for i, warn := range warnings {
+			if i >= 8 {
+				out.WriteString("- (additional warnings omitted)\n")
+				break
+			}
+			out.WriteString("- ")
+			out.WriteString(warn)
+			out.WriteString("\n")
+		}
+		out.WriteString("\n")
+	}
+
+	if strings.TrimSpace(out.String()) == "" {
+		return "No Vercel data available (missing permissions or no resources).", nil
+	}
+
+	return out.String(), nil
+}
+
+// checkAPIError inspects a Vercel JSON response for a top-level `error` object.
+// Vercel errors have the shape: {"error":{"code":"...", "message":"..."}}
+// Successful responses never carry that field, so its absence means "ok".
+func checkAPIError(response string) error {
+	trimmed := strings.TrimSpace(response)
+	if trimmed == "" {
+		return nil
+	}
+	// Non-JSON responses (rare, mostly CLI outputs) bubble up unchanged.
+	if !strings.HasPrefix(trimmed, "{") && !strings.HasPrefix(trimmed, "[") {
+		return nil
+	}
+
+	var apiResp struct {
+		Error *struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+
+	if err := json.Unmarshal([]byte(trimmed), &apiResp); err != nil {
+		return nil
+	}
+
+	if apiResp.Error != nil && (apiResp.Error.Code != "" || apiResp.Error.Message != "") {
+		return fmt.Errorf("API error: [%s] %s", apiResp.Error.Code, apiResp.Error.Message)
+	}
+	return nil
+}
+
+// isRetryableError determines whether to retry a Vercel API failure.
+func isRetryableError(s string) bool {
+	lower := strings.ToLower(s)
+	if strings.Contains(lower, "rate") && strings.Contains(lower, "limit") {
+		return true
+	}
+	if strings.Contains(lower, "rate_limit") || strings.Contains(lower, "too_many_requests") {
+		return true
+	}
+	if strings.Contains(lower, "timeout") || strings.Contains(lower, "timed out") {
+		return true
+	}
+	if strings.Contains(lower, "temporarily unavailable") || strings.Contains(lower, "internal error") {
+		return true
+	}
+	if strings.Contains(lower, "bad_gateway") || strings.Contains(lower, "service_unavailable") || strings.Contains(lower, "gateway_timeout") {
+		return true
+	}
+	if strings.Contains(lower, "connection refused") || strings.Contains(lower, "connection reset") {
+		return true
+	}
+	return false
+}
+
+// errorHint returns an actionable hint for common Vercel error messages.
+func errorHint(stderr string) string {
+	lower := strings.ToLower(stderr)
+	switch {
+	case strings.Contains(lower, "forbidden") || strings.Contains(lower, "not_authorized"):
+		return " (hint: your Vercel token may be missing scope for this operation)"
+	case strings.Contains(lower, "unauthorized") || strings.Contains(lower, "invalid_token") || strings.Contains(lower, "invalid token"):
+		return " (hint: check your VERCEL_TOKEN is valid)"
+	case strings.Contains(lower, "not_found") || strings.Contains(lower, "404"):
+		return " (hint: resource not found — check project/deployment ID and team scope)"
+	case strings.Contains(lower, "rate") && strings.Contains(lower, "limit"):
+		return " (hint: rate limited, retrying with backoff)"
+	case strings.Contains(lower, "team_not_found"):
+		return " (hint: check your VERCEL_TEAM_ID / vercel.team_id is correct)"
+	default:
+		return ""
+	}
+}
+
+// formatAPIResponse formats a Vercel JSON response for display in LLM prompts.
+// Vercel returns two common shapes:
+//   - { "<collection>": [ ... ], "pagination": {...} }
+//   - [ ... ]  (rare)
+//
+// We pretty-print whichever shape we find under the expected collection key.
+func formatAPIResponse(name, response string) string {
+	trimmed := strings.TrimSpace(response)
+	if trimmed == "" {
+		return ""
+	}
+
+	// Try pretty-printing a collection keyed by the lowercase section name.
+	var generic map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(trimmed), &generic); err == nil {
+		if raw, ok := generic[strings.ToLower(name)]; ok {
+			var decoded interface{}
+			if err := json.Unmarshal(raw, &decoded); err == nil {
+				if pretty, err := json.MarshalIndent(decoded, "", "  "); err == nil {
+					return fmt.Sprintf("%s:\n%s", name, string(pretty))
+				}
+			}
+		}
+	}
+
+	// Fallback: pretty-print the whole body.
+	var root interface{}
+	if err := json.Unmarshal([]byte(trimmed), &root); err == nil {
+		if pretty, err := json.MarshalIndent(root, "", "  "); err == nil {
+			return fmt.Sprintf("%s:\n%s", name, string(pretty))
+		}
+	}
+	return fmt.Sprintf("%s:\n%s", name, trimmed)
+}

--- a/internal/vercel/client.go
+++ b/internal/vercel/client.go
@@ -98,9 +98,17 @@ func (c *Client) GetAPIToken() string { return c.apiToken }
 func (c *Client) GetTeamID() string { return c.teamID }
 
 // withTeam appends `teamId=<id>` to the endpoint when the client is team-scoped
-// and the endpoint does not already carry a teamId parameter.
+// and the endpoint does not already carry a teamId parameter. Endpoints that
+// already encode the team in the path (e.g. `/v1/teams/{teamID}/...`) are
+// returned unchanged so we don't double-scope the request.
 func (c *Client) withTeam(endpoint string) string {
-	if c.teamID == "" || strings.Contains(endpoint, "teamId=") {
+	if c.teamID == "" {
+		return endpoint
+	}
+	if strings.Contains(endpoint, "teamId=") {
+		return endpoint
+	}
+	if strings.Contains(endpoint, "/teams/"+c.teamID) {
 		return endpoint
 	}
 	sep := "?"
@@ -123,6 +131,8 @@ func (c *Client) RunAPIWithContext(ctx context.Context, method, endpoint, body s
 
 	endpoint = c.withTeam(endpoint)
 
+	// backoffs has three entries, meaning we make up to 3 total attempts
+	// (the initial try + 2 retries) before giving up.
 	backoffs := []time.Duration{200 * time.Millisecond, 500 * time.Millisecond, 1200 * time.Millisecond}
 	var lastErr error
 	var lastStderr string
@@ -155,13 +165,13 @@ func (c *Client) RunAPIWithContext(ctx context.Context, method, endpoint, body s
 		if err == nil {
 			result := stdout.String()
 			if apiErr := checkAPIError(result); apiErr != nil {
-				// Retry once on 429 / 5xx style responses (detected via the error body).
+				// Retry on 429 / 5xx style responses (detected via the error body).
 				if isRetryableError(apiErr.Error()) && attempt < len(backoffs)-1 {
 					lastBody = result
 					time.Sleep(backoffs[attempt])
 					continue
 				}
-				return result, apiErr
+				return result, fmt.Errorf("%w%s", apiErr, errorHint(apiErr.Error()))
 			}
 			return result, nil
 		}
@@ -337,22 +347,36 @@ func checkAPIError(response string) error {
 	return nil
 }
 
-// isRetryableError determines whether to retry a Vercel API failure.
+// isRetryableError determines whether to retry a Vercel API failure. The input
+// may be either a raw stderr string from curl or an API error body — both the
+// Vercel-documented error codes and common transport failure phrases are
+// matched here.
 func isRetryableError(s string) bool {
 	lower := strings.ToLower(s)
+	// Vercel API error codes surfaced in the error body.
+	retryableCodes := []string{
+		"rate_limited",
+		"too_many_requests",
+		"internal_server_error",
+		"bad_gateway",
+		"service_unavailable",
+		"gateway_timeout",
+	}
+	for _, code := range retryableCodes {
+		if strings.Contains(lower, code) {
+			return true
+		}
+	}
 	if strings.Contains(lower, "rate") && strings.Contains(lower, "limit") {
 		return true
 	}
-	if strings.Contains(lower, "rate_limit") || strings.Contains(lower, "too_many_requests") {
+	if strings.Contains(lower, "rate_limit") {
 		return true
 	}
 	if strings.Contains(lower, "timeout") || strings.Contains(lower, "timed out") {
 		return true
 	}
 	if strings.Contains(lower, "temporarily unavailable") || strings.Contains(lower, "internal error") {
-		return true
-	}
-	if strings.Contains(lower, "bad_gateway") || strings.Contains(lower, "service_unavailable") || strings.Contains(lower, "gateway_timeout") {
 		return true
 	}
 	if strings.Contains(lower, "connection refused") || strings.Contains(lower, "connection reset") {

--- a/internal/vercel/client.go
+++ b/internal/vercel/client.go
@@ -237,12 +237,47 @@ func (c *Client) RunVercelCLIWithContext(ctx context.Context, args ...string) (s
 	return stdout.String(), nil
 }
 
+// RunVercelCLIWithStdin executes the Vercel CLI piping stdinData to the
+// process's standard input. Used for commands like `env add` where the CLI
+// reads values from stdin rather than from positional arguments.
+func (c *Client) RunVercelCLIWithStdin(ctx context.Context, stdinData string, args ...string) (string, error) {
+	if _, err := exec.LookPath("vercel"); err != nil {
+		return "", fmt.Errorf("vercel not found in PATH (required for deploy operations, install with: npm install -g vercel)")
+	}
+
+	cmd := exec.CommandContext(ctx, "vercel", args...)
+	cmd.Env = append(os.Environ(), fmt.Sprintf("VERCEL_TOKEN=%s", c.apiToken))
+	if c.teamID != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("VERCEL_ORG_ID=%s", c.teamID))
+	}
+
+	cmd.Stdin = strings.NewReader(stdinData)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if c.debug {
+		fmt.Printf("[vercel] vercel %s (stdin piped)\n", strings.Join(args, " "))
+	}
+
+	if err := cmd.Run(); err != nil {
+		stderrStr := strings.TrimSpace(stderr.String())
+		return "", fmt.Errorf("vercel CLI failed: %w, stderr: %s%s", err, stderrStr, errorHint(stderrStr))
+	}
+
+	return stdout.String(), nil
+}
+
 // PromoteDeployment promotes a deployment to production using the Vercel REST API.
 // This is equivalent to `vercel promote <deploymentId>` but uses the API directly
 // for programmatic use (maker plans, backend handlers, etc.).
+//
+// Vercel API: POST /v10/projects/{projectID}/promote  body: {"id":"<deploymentID>"}
 func (c *Client) PromoteDeployment(ctx context.Context, projectID, deploymentID string) error {
-	endpoint := fmt.Sprintf("/v10/projects/%s/promote/%s", projectID, deploymentID)
-	_, err := c.RunAPIWithContext(ctx, "POST", endpoint, "")
+	endpoint := fmt.Sprintf("/v10/projects/%s/promote", projectID)
+	body := fmt.Sprintf(`{"id":%q}`, deploymentID)
+	_, err := c.RunAPIWithContext(ctx, "POST", endpoint, body)
 	if err != nil {
 		return fmt.Errorf("promote deployment %s: %w", deploymentID, err)
 	}
@@ -250,14 +285,14 @@ func (c *Client) PromoteDeployment(ctx context.Context, projectID, deploymentID 
 }
 
 // CancelDeployment cancels an in-progress deployment using the Vercel REST API.
-func (c *Client) CancelDeployment(ctx context.Context, deploymentID string) error {
+// Returns the raw API response so the caller can decide how to present it.
+func (c *Client) CancelDeployment(ctx context.Context, deploymentID string) (string, error) {
 	endpoint := fmt.Sprintf("/v12/deployments/%s/cancel", deploymentID)
 	result, err := c.RunAPIWithContext(ctx, "PATCH", endpoint, "")
 	if err != nil {
-		return fmt.Errorf("cancel deployment %s: %w", deploymentID, err)
+		return "", fmt.Errorf("cancel deployment %s: %w", deploymentID, err)
 	}
-	fmt.Println(result)
-	return nil
+	return result, nil
 }
 
 // GetRelevantContext gathers Vercel context for LLM queries. The output is a
@@ -335,6 +370,11 @@ func (c *Client) GetRelevantContext(ctx context.Context, question string) (strin
 		}
 		out.WriteString("\n")
 	}
+
+	// TODO(phase3): When the question mentions a specific project, fetch its
+	// env var keys (never values) via GET /v10/projects/{id}/env and include
+	// a "Environment Variables (keys only)" section. Requires lightweight
+	// project-name-to-ID inference from the projects list above.
 
 	if strings.TrimSpace(out.String()) == "" {
 		return "No Vercel data available (missing permissions or no resources).", nil

--- a/internal/vercel/client.go
+++ b/internal/vercel/client.go
@@ -237,6 +237,29 @@ func (c *Client) RunVercelCLIWithContext(ctx context.Context, args ...string) (s
 	return stdout.String(), nil
 }
 
+// PromoteDeployment promotes a deployment to production using the Vercel REST API.
+// This is equivalent to `vercel promote <deploymentId>` but uses the API directly
+// for programmatic use (maker plans, backend handlers, etc.).
+func (c *Client) PromoteDeployment(ctx context.Context, projectID, deploymentID string) error {
+	endpoint := fmt.Sprintf("/v10/projects/%s/promote/%s", projectID, deploymentID)
+	_, err := c.RunAPIWithContext(ctx, "POST", endpoint, "")
+	if err != nil {
+		return fmt.Errorf("promote deployment %s: %w", deploymentID, err)
+	}
+	return nil
+}
+
+// CancelDeployment cancels an in-progress deployment using the Vercel REST API.
+func (c *Client) CancelDeployment(ctx context.Context, deploymentID string) error {
+	endpoint := fmt.Sprintf("/v12/deployments/%s/cancel", deploymentID)
+	result, err := c.RunAPIWithContext(ctx, "PATCH", endpoint, "")
+	if err != nil {
+		return fmt.Errorf("cancel deployment %s: %w", deploymentID, err)
+	}
+	fmt.Println(result)
+	return nil
+}
+
 // GetRelevantContext gathers Vercel context for LLM queries. The output is a
 // best-effort dump of the resources most likely to be relevant to the user's
 // question. Sections are keyword-gated to keep the context compact.

--- a/internal/vercel/client.go
+++ b/internal/vercel/client.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -118,7 +119,7 @@ func (c *Client) withTeam(endpoint string) string {
 	if strings.Contains(endpoint, "?") {
 		sep = "&"
 	}
-	return endpoint + sep + "teamId=" + c.teamID
+	return endpoint + sep + "teamId=" + url.QueryEscape(c.teamID)
 }
 
 // RunAPI executes a Vercel REST call with exponential backoff.
@@ -142,6 +143,8 @@ func (c *Client) RunAPIWithContext(ctx context.Context, method, endpoint, body s
 	var lastBody string
 
 	for attempt := 0; attempt < len(backoffs); attempt++ {
+		lastBody = ""
+
 		args := []string{
 			"-s",
 			"-X", method,
@@ -275,7 +278,7 @@ func (c *Client) RunVercelCLIWithStdin(ctx context.Context, stdinData string, ar
 //
 // Vercel API: POST /v10/projects/{projectID}/promote  body: {"id":"<deploymentID>"}
 func (c *Client) PromoteDeployment(ctx context.Context, projectID, deploymentID string) error {
-	endpoint := fmt.Sprintf("/v10/projects/%s/promote", projectID)
+	endpoint := fmt.Sprintf("/v10/projects/%s/promote", url.PathEscape(projectID))
 	body := fmt.Sprintf(`{"id":%q}`, deploymentID)
 	_, err := c.RunAPIWithContext(ctx, "POST", endpoint, body)
 	if err != nil {
@@ -287,7 +290,7 @@ func (c *Client) PromoteDeployment(ctx context.Context, projectID, deploymentID 
 // CancelDeployment cancels an in-progress deployment using the Vercel REST API.
 // Returns the raw API response so the caller can decide how to present it.
 func (c *Client) CancelDeployment(ctx context.Context, deploymentID string) (string, error) {
-	endpoint := fmt.Sprintf("/v12/deployments/%s/cancel", deploymentID)
+	endpoint := fmt.Sprintf("/v12/deployments/%s/cancel", url.PathEscape(deploymentID))
 	result, err := c.RunAPIWithContext(ctx, "PATCH", endpoint, "")
 	if err != nil {
 		return "", fmt.Errorf("cancel deployment %s: %w", deploymentID, err)
@@ -316,7 +319,7 @@ func (c *Client) GetRelevantContext(ctx context.Context, question string) (strin
 	if c.teamID != "" {
 		sections = append(sections, section{
 			name:     "Usage",
-			endpoint: fmt.Sprintf("/v1/teams/%s/analytics/usage?period=30d", c.teamID),
+			endpoint: fmt.Sprintf("/v1/teams/%s/analytics/usage?period=30d", url.PathEscape(c.teamID)),
 			keys:     []string{"usage", "bandwidth", "cost", "invocation", "function", "edge", "analytics", "speed"},
 		})
 	}

--- a/internal/vercel/conversation.go
+++ b/internal/vercel/conversation.go
@@ -1,0 +1,193 @@
+package vercel
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ConversationEntry represents a single Q&A exchange.
+type ConversationEntry struct {
+	Timestamp time.Time `json:"timestamp"`
+	Question  string    `json:"question"`
+	Answer    string    `json:"answer"`
+}
+
+// ConversationHistory maintains conversation state for Vercel ask mode.
+type ConversationHistory struct {
+	Entries []ConversationEntry `json:"entries"`
+	TeamID  string              `json:"team_id"`
+	mu      sync.RWMutex
+}
+
+// MaxHistoryEntries limits the conversation history size.
+const MaxHistoryEntries = 20
+
+// MaxAnswerLengthInContext limits how much of previous answers to include in context.
+const MaxAnswerLengthInContext = 500
+
+// NewConversationHistory creates a new conversation history for a team (or personal account).
+func NewConversationHistory(teamID string) *ConversationHistory {
+	return &ConversationHistory{
+		Entries: make([]ConversationEntry, 0),
+		TeamID:  teamID,
+	}
+}
+
+// AddEntry adds a new conversation entry and prunes old entries.
+func (h *ConversationHistory) AddEntry(question, answer string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	entry := ConversationEntry{
+		Timestamp: time.Now(),
+		Question:  question,
+		Answer:    answer,
+	}
+
+	h.Entries = append(h.Entries, entry)
+
+	if len(h.Entries) > MaxHistoryEntries {
+		h.Entries = h.Entries[len(h.Entries)-MaxHistoryEntries:]
+	}
+}
+
+// GetRecentContext returns recent conversation context as a formatted string
+// for inclusion in LLM prompts.
+func (h *ConversationHistory) GetRecentContext(maxEntries int) string {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	if len(h.Entries) == 0 {
+		return ""
+	}
+
+	start := 0
+	if len(h.Entries) > maxEntries {
+		start = len(h.Entries) - maxEntries
+	}
+
+	var sb strings.Builder
+	for i, entry := range h.Entries[start:] {
+		if i > 0 {
+			sb.WriteString("\n")
+		}
+		sb.WriteString(fmt.Sprintf("Q: %s\n", entry.Question))
+		sb.WriteString(fmt.Sprintf("A: %s\n", truncateAnswer(entry.Answer, MaxAnswerLengthInContext)))
+	}
+
+	return sb.String()
+}
+
+// Save persists the conversation history to disk using atomic write (temp + rename).
+func (h *ConversationHistory) Save() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	dir, err := conversationDir()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create conversation directory: %w", err)
+	}
+
+	// Prune before persisting.
+	if len(h.Entries) > MaxHistoryEntries {
+		h.Entries = h.Entries[len(h.Entries)-MaxHistoryEntries:]
+	}
+
+	data, err := json.MarshalIndent(h, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal conversation history: %w", err)
+	}
+
+	filename := h.filePath()
+
+	// Atomic write: write to temp file first, then rename.
+	tmp := filename + ".tmp"
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		return fmt.Errorf("failed to write temp conversation file: %w", err)
+	}
+	if err := os.Rename(tmp, filename); err != nil {
+		// Best-effort cleanup of the temp file on rename failure.
+		_ = os.Remove(tmp)
+		return fmt.Errorf("failed to rename conversation file: %w", err)
+	}
+
+	return nil
+}
+
+// Load loads conversation history from disk.
+func (h *ConversationHistory) Load() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	data, err := os.ReadFile(h.filePath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // No history yet — that is fine.
+		}
+		return fmt.Errorf("failed to read conversation file: %w", err)
+	}
+
+	// Unmarshal into a temporary struct so we don't clobber the mutex.
+	var loaded struct {
+		Entries []ConversationEntry `json:"entries"`
+		TeamID  string              `json:"team_id"`
+	}
+
+	if err := json.Unmarshal(data, &loaded); err != nil {
+		return fmt.Errorf("failed to parse conversation history: %w", err)
+	}
+
+	h.Entries = loaded.Entries
+	h.TeamID = loaded.TeamID
+
+	return nil
+}
+
+// filePath returns the on-disk path for this history file.
+func (h *ConversationHistory) filePath() string {
+	dir, _ := conversationDir()
+	return filepath.Join(dir, fmt.Sprintf("vercel_%s.json", sanitizeID(h.TeamID)))
+}
+
+// conversationDir returns ~/.clanker/conversations.
+func conversationDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	return filepath.Join(home, ".clanker", "conversations"), nil
+}
+
+// sanitizeID replaces characters that are invalid in filenames.
+func sanitizeID(s string) string {
+	replacer := strings.NewReplacer(
+		"/", "_",
+		"\\", "_",
+		":", "_",
+		"*", "_",
+		"?", "_",
+		"\"", "_",
+		"<", "_",
+		">", "_",
+		"|", "_",
+		" ", "_",
+	)
+	return replacer.Replace(s)
+}
+
+// truncateAnswer truncates text to maxLen characters, adding ellipsis if truncated.
+func truncateAnswer(text string, maxLen int) string {
+	if len(text) <= maxLen {
+		return text
+	}
+	return text[:maxLen] + "..."
+}

--- a/internal/vercel/conversation.go
+++ b/internal/vercel/conversation.go
@@ -107,7 +107,10 @@ func (h *ConversationHistory) Save() error {
 		return fmt.Errorf("failed to marshal conversation history: %w", err)
 	}
 
-	filename := h.filePath()
+	filename, err := h.filePath()
+	if err != nil {
+		return err
+	}
 
 	// Atomic write: write to temp file first, then rename.
 	tmp := filename + ".tmp"
@@ -128,7 +131,11 @@ func (h *ConversationHistory) Load() error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	data, err := os.ReadFile(h.filePath())
+	path, err := h.filePath()
+	if err != nil {
+		return err
+	}
+	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil // No history yet — that is fine.
@@ -153,9 +160,12 @@ func (h *ConversationHistory) Load() error {
 }
 
 // filePath returns the on-disk path for this history file.
-func (h *ConversationHistory) filePath() string {
-	dir, _ := conversationDir()
-	return filepath.Join(dir, fmt.Sprintf("vercel_%s.json", sanitizeID(h.TeamID)))
+func (h *ConversationHistory) filePath() (string, error) {
+	dir, err := conversationDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, fmt.Sprintf("vercel_%s.json", sanitizeID(h.TeamID))), nil
 }
 
 // conversationDir returns ~/.clanker/conversations.

--- a/internal/vercel/static_commands.go
+++ b/internal/vercel/static_commands.go
@@ -29,6 +29,12 @@ func CreateVercelCommands() *cobra.Command {
 	vercelCmd.AddCommand(createVercelGetCmd())
 	vercelCmd.AddCommand(createVercelLogsCmd())
 	vercelCmd.AddCommand(createVercelAnalyticsCmd())
+	vercelCmd.AddCommand(createVercelDeployCmd())
+	vercelCmd.AddCommand(createVercelRedeployCmd())
+	vercelCmd.AddCommand(createVercelRollbackCmd())
+	vercelCmd.AddCommand(createVercelCancelCmd())
+	vercelCmd.AddCommand(createVercelEnvCmd())
+	vercelCmd.AddCommand(createVercelDomainCmd())
 
 	return vercelCmd
 }
@@ -647,4 +653,315 @@ func getUsage(ctx context.Context, client *Client, period string) error {
 	}
 	fmt.Println(out)
 	return nil
+}
+
+// --- Deploy / Redeploy / Rollback / Cancel ---
+
+func createVercelDeployCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "deploy [path]",
+		Short: "Deploy the current directory (or a specific path) to Vercel",
+		Long: `Deploy a project to Vercel. By default creates a preview deployment.
+Use --prod to deploy directly to production.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newClientFromFlags(cmd)
+			if err != nil {
+				return err
+			}
+
+			cliArgs := []string{"deploy"}
+			if len(args) > 0 {
+				cliArgs = append(cliArgs, args[0])
+			}
+			if prod, _ := cmd.Flags().GetBool("prod"); prod {
+				cliArgs = append(cliArgs, "--prod")
+			}
+			if project, _ := cmd.Flags().GetString("project"); project != "" {
+				cliArgs = append(cliArgs, "--scope", project)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+			defer cancel()
+
+			out, err := client.RunVercelCLIWithContext(ctx, cliArgs...)
+			if err != nil {
+				return err
+			}
+			fmt.Print(out)
+			return nil
+		},
+	}
+	cmd.Flags().Bool("prod", false, "Deploy to production")
+	cmd.Flags().String("project", "", "Project ID or team scope")
+	return cmd
+}
+
+func createVercelRedeployCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "redeploy <deployment-url-or-id>",
+		Short: "Redeploy an existing Vercel deployment",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newClientFromFlags(cmd)
+			if err != nil {
+				return err
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+			defer cancel()
+
+			out, err := client.RunVercelCLIWithContext(ctx, "redeploy", args[0])
+			if err != nil {
+				return err
+			}
+			fmt.Print(out)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func createVercelRollbackCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rollback",
+		Short: "Rollback to the previous production deployment",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newClientFromFlags(cmd)
+			if err != nil {
+				return err
+			}
+
+			cliArgs := []string{"rollback"}
+			if project, _ := cmd.Flags().GetString("project"); project != "" {
+				cliArgs = append(cliArgs, "--scope", project)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			defer cancel()
+
+			out, err := client.RunVercelCLIWithContext(ctx, cliArgs...)
+			if err != nil {
+				return err
+			}
+			fmt.Print(out)
+			return nil
+		},
+	}
+	cmd.Flags().String("project", "", "Project ID or team scope")
+	return cmd
+}
+
+func createVercelCancelCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cancel <deployment-id>",
+		Short: "Cancel an in-progress Vercel deployment",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newClientFromFlags(cmd)
+			if err != nil {
+				return err
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			defer cancel()
+
+			return client.CancelDeployment(ctx, args[0])
+		},
+	}
+	return cmd
+}
+
+// --- Env subcommands ---
+
+func createVercelEnvCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "env",
+		Short: "Manage Vercel environment variables",
+	}
+	cmd.AddCommand(createVercelEnvAddCmd())
+	cmd.AddCommand(createVercelEnvRmCmd())
+	cmd.AddCommand(createVercelEnvPullCmd())
+	return cmd
+}
+
+func createVercelEnvAddCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add <key> <value>",
+		Short: "Add an environment variable",
+		Long: `Add an environment variable to a Vercel project.
+
+By default targets all environments (production, preview, development).
+Use --target to restrict to specific environments.`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newClientFromFlags(cmd)
+			if err != nil {
+				return err
+			}
+
+			cliArgs := []string{"env", "add", args[0], args[1]}
+			if target, _ := cmd.Flags().GetString("target"); target != "" {
+				cliArgs = append(cliArgs, target)
+			}
+			if project, _ := cmd.Flags().GetString("project"); project != "" {
+				cliArgs = append(cliArgs, "--scope", project)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			out, err := client.RunVercelCLIWithContext(ctx, cliArgs...)
+			if err != nil {
+				return err
+			}
+			fmt.Print(out)
+			return nil
+		},
+	}
+	cmd.Flags().String("target", "", "Comma-separated targets: production,preview,development")
+	cmd.Flags().String("project", "", "Project ID or team scope")
+	return cmd
+}
+
+func createVercelEnvRmCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rm <key>",
+		Short: "Remove an environment variable",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newClientFromFlags(cmd)
+			if err != nil {
+				return err
+			}
+
+			cliArgs := []string{"env", "rm", args[0]}
+			if target, _ := cmd.Flags().GetString("target"); target != "" {
+				cliArgs = append(cliArgs, target)
+			}
+			cliArgs = append(cliArgs, "--yes")
+			if project, _ := cmd.Flags().GetString("project"); project != "" {
+				cliArgs = append(cliArgs, "--scope", project)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			out, err := client.RunVercelCLIWithContext(ctx, cliArgs...)
+			if err != nil {
+				return err
+			}
+			fmt.Print(out)
+			return nil
+		},
+	}
+	cmd.Flags().String("target", "production", "Target environment: production, preview, or development")
+	cmd.Flags().String("project", "", "Project ID or team scope")
+	return cmd
+}
+
+func createVercelEnvPullCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pull",
+		Short: "Pull environment variables to a local .env file",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newClientFromFlags(cmd)
+			if err != nil {
+				return err
+			}
+
+			cliArgs := []string{"env", "pull"}
+			if project, _ := cmd.Flags().GetString("project"); project != "" {
+				cliArgs = append(cliArgs, "--scope", project)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			out, err := client.RunVercelCLIWithContext(ctx, cliArgs...)
+			if err != nil {
+				return err
+			}
+			fmt.Print(out)
+			return nil
+		},
+	}
+	cmd.Flags().String("project", "", "Project ID or team scope")
+	return cmd
+}
+
+// --- Domain subcommands ---
+
+func createVercelDomainCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "domain",
+		Short: "Manage Vercel domains",
+	}
+	cmd.AddCommand(createVercelDomainAddCmd())
+	cmd.AddCommand(createVercelDomainRmCmd())
+	return cmd
+}
+
+func createVercelDomainAddCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add <domain>",
+		Short: "Add a custom domain to a Vercel project",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newClientFromFlags(cmd)
+			if err != nil {
+				return err
+			}
+
+			cliArgs := []string{"domains", "add", args[0]}
+			if project, _ := cmd.Flags().GetString("project"); project != "" {
+				cliArgs = append(cliArgs, "--scope", project)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			out, err := client.RunVercelCLIWithContext(ctx, cliArgs...)
+			if err != nil {
+				return err
+			}
+			fmt.Print(out)
+			return nil
+		},
+	}
+	cmd.Flags().String("project", "", "Project ID or team scope")
+	return cmd
+}
+
+func createVercelDomainRmCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rm <domain>",
+		Short: "Remove a custom domain from Vercel",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newClientFromFlags(cmd)
+			if err != nil {
+				return err
+			}
+
+			cliArgs := []string{"domains", "rm", args[0], "--yes"}
+			if project, _ := cmd.Flags().GetString("project"); project != "" {
+				cliArgs = append(cliArgs, "--scope", project)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			out, err := client.RunVercelCLIWithContext(ctx, cliArgs...)
+			if err != nil {
+				return err
+			}
+			fmt.Print(out)
+			return nil
+		},
+	}
+	cmd.Flags().String("project", "", "Project ID or team scope")
+	return cmd
 }

--- a/internal/vercel/static_commands.go
+++ b/internal/vercel/static_commands.go
@@ -1,0 +1,427 @@
+package vercel
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// CreateVercelCommands creates the Vercel command tree for static commands.
+// Registered from cmd/root.go as a sibling of `cf`, `do`, `hetzner`, etc.
+func CreateVercelCommands() *cobra.Command {
+	vercelCmd := &cobra.Command{
+		Use:     "vercel",
+		Short:   "Query Vercel projects and deployments directly",
+		Long:    "Query your Vercel account without AI interpretation. Useful for getting raw data.",
+		Aliases: []string{"vc"},
+	}
+
+	vercelCmd.PersistentFlags().String("api-token", "", "Vercel API token (overrides VERCEL_TOKEN)")
+	vercelCmd.PersistentFlags().String("team-id", "", "Vercel team ID (overrides VERCEL_TEAM_ID)")
+
+	vercelCmd.AddCommand(createVercelListCmd())
+	vercelCmd.AddCommand(createVercelGetCmd())
+	vercelCmd.AddCommand(createVercelLogsCmd())
+	vercelCmd.AddCommand(createVercelAnalyticsCmd())
+
+	return vercelCmd
+}
+
+func createVercelListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list [resource]",
+		Short: "List Vercel resources",
+		Long: `List Vercel resources of a specific type.
+
+Supported resources:
+  projects       - Vercel projects
+  deployments    - Project deployments (supports --project)
+  domains        - Custom domains
+  env            - Environment variables (requires --project)
+  teams          - Teams you belong to
+  aliases        - Deployment aliases
+  kv             - Vercel KV (Redis) stores
+  blob           - Vercel Blob stores
+  postgres       - Vercel Postgres databases
+  edge-configs   - Edge Config stores`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resource := strings.ToLower(args[0])
+			projectID, _ := cmd.Flags().GetString("project")
+
+			client, err := newClientFromFlags(cmd)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
+
+			switch resource {
+			case "projects", "project":
+				return listProjects(ctx, client)
+			case "deployments", "deployment":
+				return listDeployments(ctx, client, projectID)
+			case "domains", "domain":
+				return listDomains(ctx, client)
+			case "env", "envs", "env-vars", "environment":
+				if projectID == "" {
+					return fmt.Errorf("--project is required to list env vars")
+				}
+				return listEnvVars(ctx, client, projectID)
+			case "teams", "team":
+				return listTeams(ctx, client)
+			case "aliases", "alias":
+				return listAliases(ctx, client, projectID)
+			case "kv":
+				return listKV(ctx, client)
+			case "blob":
+				return listBlob(ctx, client)
+			case "postgres", "pg":
+				return listPostgres(ctx, client)
+			case "edge-configs", "edge-config", "edge":
+				return listEdgeConfigs(ctx, client)
+			default:
+				return fmt.Errorf("unknown resource type: %s", resource)
+			}
+		},
+	}
+	cmd.Flags().String("project", "", "Project ID or name (scopes deployments / env listings)")
+	return cmd
+}
+
+func createVercelGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <project|deployment> <id>",
+		Short: "Get a single Vercel resource",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			kind := strings.ToLower(args[0])
+			id := args[1]
+
+			client, err := newClientFromFlags(cmd)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			switch kind {
+			case "project":
+				return getProject(ctx, client, id)
+			case "deployment":
+				return getDeployment(ctx, client, id)
+			default:
+				return fmt.Errorf("unknown resource kind: %s (expected project|deployment)", kind)
+			}
+		},
+	}
+	return cmd
+}
+
+func createVercelLogsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "logs <deploymentId>",
+		Short: "Fetch build + runtime events for a deployment",
+		Long: `Fetch events for a deployment. By default returns a one-shot snapshot of recent events.
+Use --follow (phase 3+) to stream events continuously.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			deploymentID := args[0]
+			follow, _ := cmd.Flags().GetBool("follow")
+
+			client, err := newClientFromFlags(cmd)
+			if err != nil {
+				return err
+			}
+			if follow {
+				fmt.Fprintln(cmd.OutOrStderr(), "[vercel] --follow is not wired in phase 1 — returning the latest snapshot instead.")
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
+
+			return getDeploymentEventsSnapshot(ctx, client, deploymentID)
+		},
+	}
+	cmd.Flags().Bool("follow", false, "Stream events live (enabled in phase 3)")
+	return cmd
+}
+
+func createVercelAnalyticsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "analytics",
+		Short: "Show recent usage summary (bandwidth, invocations, build minutes)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			period, _ := cmd.Flags().GetString("period")
+
+			client, err := newClientFromFlags(cmd)
+			if err != nil {
+				return err
+			}
+			if client.GetTeamID() == "" {
+				return fmt.Errorf("analytics requires --team-id (or vercel.team_id / VERCEL_TEAM_ID)")
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
+
+			return getUsage(ctx, client, period)
+		},
+	}
+	cmd.Flags().String("period", "30d", "Time window (e.g. 7d, 30d, 90d)")
+	cmd.Flags().String("project", "", "Optional project filter")
+	return cmd
+}
+
+// newClientFromFlags resolves credentials from flags > config > env and builds a Client.
+func newClientFromFlags(cmd *cobra.Command) (*Client, error) {
+	apiToken, _ := cmd.Flags().GetString("api-token")
+	if apiToken == "" {
+		apiToken = ResolveAPIToken()
+	}
+	if apiToken == "" {
+		return nil, fmt.Errorf("vercel api_token is required (set vercel.api_token, VERCEL_TOKEN, or --api-token)")
+	}
+
+	teamID, _ := cmd.Flags().GetString("team-id")
+	if teamID == "" {
+		teamID = ResolveTeamID()
+	}
+
+	debug := viper.GetBool("debug")
+	return NewClient(apiToken, teamID, debug)
+}
+
+// --- Listers ---
+
+func listProjects(ctx context.Context, client *Client) error {
+	out, err := client.RunAPIWithContext(ctx, "GET", "/v9/projects?limit=100", "")
+	if err != nil {
+		return err
+	}
+	var resp struct {
+		Projects []Project `json:"projects"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		return fmt.Errorf("failed to parse projects response: %w", err)
+	}
+	if len(resp.Projects) == 0 {
+		fmt.Println("No Vercel projects found.")
+		return nil
+	}
+	fmt.Printf("Vercel Projects (%d):\n\n", len(resp.Projects))
+	for _, p := range resp.Projects {
+		fmt.Printf("  %s\n", p.Name)
+		fmt.Printf("    ID: %s\n", p.ID)
+		if p.Framework != "" {
+			fmt.Printf("    Framework: %s\n", p.Framework)
+		}
+		if p.Link != nil && p.Link.Repo != "" {
+			fmt.Printf("    Repo: %s (%s)\n", p.Link.Repo, p.Link.Type)
+		}
+		fmt.Println()
+	}
+	return nil
+}
+
+func listDeployments(ctx context.Context, client *Client, projectID string) error {
+	endpoint := "/v6/deployments?limit=20"
+	if projectID != "" {
+		endpoint += "&projectId=" + projectID
+	}
+	out, err := client.RunAPIWithContext(ctx, "GET", endpoint, "")
+	if err != nil {
+		return err
+	}
+	var resp struct {
+		Deployments []Deployment `json:"deployments"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		return fmt.Errorf("failed to parse deployments response: %w", err)
+	}
+	if len(resp.Deployments) == 0 {
+		fmt.Println("No deployments found.")
+		return nil
+	}
+	fmt.Printf("Vercel Deployments (%d):\n\n", len(resp.Deployments))
+	for _, d := range resp.Deployments {
+		state := d.State
+		if state == "" {
+			state = d.ReadyState
+		}
+		target := d.Target
+		if target == "" {
+			target = "preview"
+		}
+		fmt.Printf("  %s  [%s / %s]\n", d.UID, state, target)
+		if d.URL != "" {
+			fmt.Printf("    URL: https://%s\n", d.URL)
+		}
+		if d.Creator != nil {
+			fmt.Printf("    Creator: %s\n", d.Creator.Username)
+		}
+		fmt.Println()
+	}
+	return nil
+}
+
+func listDomains(ctx context.Context, client *Client) error {
+	out, err := client.RunAPIWithContext(ctx, "GET", "/v5/domains?limit=100", "")
+	if err != nil {
+		return err
+	}
+	var resp struct {
+		Domains []Domain `json:"domains"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		return fmt.Errorf("failed to parse domains response: %w", err)
+	}
+	if len(resp.Domains) == 0 {
+		fmt.Println("No custom domains found.")
+		return nil
+	}
+	fmt.Printf("Vercel Domains (%d):\n\n", len(resp.Domains))
+	for _, d := range resp.Domains {
+		fmt.Printf("  %s  verified=%v\n", d.Name, d.Verified)
+	}
+	return nil
+}
+
+func listEnvVars(ctx context.Context, client *Client, projectID string) error {
+	out, err := client.RunAPIWithContext(ctx, "GET", fmt.Sprintf("/v10/projects/%s/env", projectID), "")
+	if err != nil {
+		return err
+	}
+	var resp struct {
+		Envs []EnvVar `json:"envs"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		return fmt.Errorf("failed to parse env response: %w", err)
+	}
+	if len(resp.Envs) == 0 {
+		fmt.Printf("No env vars found for project %s.\n", projectID)
+		return nil
+	}
+	fmt.Printf("Env vars for project %s (%d):\n\n", projectID, len(resp.Envs))
+	for _, e := range resp.Envs {
+		targets := strings.Join(e.Target, ",")
+		if targets == "" {
+			targets = "-"
+		}
+		fmt.Printf("  %s  [%s]  targets=%s\n", e.Key, e.Type, targets)
+	}
+	return nil
+}
+
+func listTeams(ctx context.Context, client *Client) error {
+	out, err := client.RunAPIWithContext(ctx, "GET", "/v2/teams?limit=50", "")
+	if err != nil {
+		return err
+	}
+	var resp struct {
+		Teams []Team `json:"teams"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		return fmt.Errorf("failed to parse teams response: %w", err)
+	}
+	if len(resp.Teams) == 0 {
+		fmt.Println("No teams found (personal account).")
+		return nil
+	}
+	fmt.Printf("Vercel Teams (%d):\n\n", len(resp.Teams))
+	for _, t := range resp.Teams {
+		fmt.Printf("  %s  (%s)\n    ID: %s\n\n", t.Name, t.Slug, t.ID)
+	}
+	return nil
+}
+
+func listAliases(ctx context.Context, client *Client, projectID string) error {
+	endpoint := "/v4/aliases?limit=50"
+	if projectID != "" {
+		endpoint += "&projectId=" + projectID
+	}
+	out, err := client.RunAPIWithContext(ctx, "GET", endpoint, "")
+	if err != nil {
+		return err
+	}
+	fmt.Println(out)
+	return nil
+}
+
+func listKV(ctx context.Context, client *Client) error {
+	// Vercel Storage API: GET /v1/storage/stores?storeType=kv
+	return listStorage(ctx, client, "kv")
+}
+
+func listBlob(ctx context.Context, client *Client) error {
+	return listStorage(ctx, client, "blob")
+}
+
+func listPostgres(ctx context.Context, client *Client) error {
+	return listStorage(ctx, client, "postgres")
+}
+
+func listStorage(ctx context.Context, client *Client, storeType string) error {
+	endpoint := fmt.Sprintf("/v1/storage/stores?storeType=%s", storeType)
+	out, err := client.RunAPIWithContext(ctx, "GET", endpoint, "")
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Vercel %s stores:\n%s\n", storeType, out)
+	return nil
+}
+
+func listEdgeConfigs(ctx context.Context, client *Client) error {
+	out, err := client.RunAPIWithContext(ctx, "GET", "/v1/edge-config", "")
+	if err != nil {
+		return err
+	}
+	fmt.Println("Vercel Edge Configs:")
+	fmt.Println(out)
+	return nil
+}
+
+// --- Getters ---
+
+func getProject(ctx context.Context, client *Client, idOrName string) error {
+	out, err := client.RunAPIWithContext(ctx, "GET", "/v9/projects/"+idOrName, "")
+	if err != nil {
+		return err
+	}
+	fmt.Println(out)
+	return nil
+}
+
+func getDeployment(ctx context.Context, client *Client, id string) error {
+	out, err := client.RunAPIWithContext(ctx, "GET", "/v13/deployments/"+id, "")
+	if err != nil {
+		return err
+	}
+	fmt.Println(out)
+	return nil
+}
+
+func getDeploymentEventsSnapshot(ctx context.Context, client *Client, id string) error {
+	out, err := client.RunAPIWithContext(ctx, "GET", "/v2/deployments/"+id+"/events?limit=200", "")
+	if err != nil {
+		return err
+	}
+	fmt.Println(out)
+	return nil
+}
+
+func getUsage(ctx context.Context, client *Client, period string) error {
+	if period == "" {
+		period = "30d"
+	}
+	endpoint := fmt.Sprintf("/v1/teams/%s/analytics/usage?period=%s", client.GetTeamID(), period)
+	out, err := client.RunAPIWithContext(ctx, "GET", endpoint, "")
+	if err != nil {
+		return err
+	}
+	fmt.Println(out)
+	return nil
+}

--- a/internal/vercel/static_commands.go
+++ b/internal/vercel/static_commands.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -224,6 +225,10 @@ func listProjects(ctx context.Context, client *Client) error {
 	if err != nil {
 		return err
 	}
+	if rawOutput(client) {
+		fmt.Println(out)
+		return nil
+	}
 	var resp struct {
 		Projects []Project `json:"projects"`
 	}
@@ -252,11 +257,15 @@ func listProjects(ctx context.Context, client *Client) error {
 func listDeployments(ctx context.Context, client *Client, projectID string) error {
 	endpoint := "/v6/deployments?limit=20"
 	if projectID != "" {
-		endpoint += "&projectId=" + projectID
+		endpoint += "&projectId=" + url.QueryEscape(projectID)
 	}
 	out, err := client.RunAPIWithContext(ctx, "GET", endpoint, "")
 	if err != nil {
 		return err
+	}
+	if rawOutput(client) {
+		fmt.Println(out)
+		return nil
 	}
 	var resp struct {
 		Deployments []Deployment `json:"deployments"`
@@ -295,6 +304,10 @@ func listDomains(ctx context.Context, client *Client) error {
 	if err != nil {
 		return err
 	}
+	if rawOutput(client) {
+		fmt.Println(out)
+		return nil
+	}
 	var resp struct {
 		Domains []Domain `json:"domains"`
 	}
@@ -313,9 +326,13 @@ func listDomains(ctx context.Context, client *Client) error {
 }
 
 func listEnvVars(ctx context.Context, client *Client, projectID string) error {
-	out, err := client.RunAPIWithContext(ctx, "GET", fmt.Sprintf("/v10/projects/%s/env", projectID), "")
+	out, err := client.RunAPIWithContext(ctx, "GET", fmt.Sprintf("/v10/projects/%s/env", url.PathEscape(projectID)), "")
 	if err != nil {
 		return err
+	}
+	if rawOutput(client) {
+		fmt.Println(out)
+		return nil
 	}
 	var resp struct {
 		Envs []EnvVar `json:"envs"`
@@ -343,6 +360,10 @@ func listTeams(ctx context.Context, client *Client) error {
 	if err != nil {
 		return err
 	}
+	if rawOutput(client) {
+		fmt.Println(out)
+		return nil
+	}
 	var resp struct {
 		Teams []Team `json:"teams"`
 	}
@@ -363,7 +384,7 @@ func listTeams(ctx context.Context, client *Client) error {
 func listAliases(ctx context.Context, client *Client, projectID string) error {
 	endpoint := "/v4/aliases?limit=50"
 	if projectID != "" {
-		endpoint += "&projectId=" + projectID
+		endpoint += "&projectId=" + url.QueryEscape(projectID)
 	}
 	out, err := client.RunAPIWithContext(ctx, "GET", endpoint, "")
 	if err != nil {
@@ -506,7 +527,7 @@ func listEdgeConfigs(ctx context.Context, client *Client) error {
 // --- Getters ---
 
 func getProject(ctx context.Context, client *Client, idOrName string) error {
-	out, err := client.RunAPIWithContext(ctx, "GET", "/v9/projects/"+idOrName, "")
+	out, err := client.RunAPIWithContext(ctx, "GET", "/v9/projects/"+url.PathEscape(idOrName), "")
 	if err != nil {
 		return err
 	}
@@ -548,7 +569,7 @@ func getProject(ctx context.Context, client *Client, idOrName string) error {
 }
 
 func getDeployment(ctx context.Context, client *Client, id string) error {
-	out, err := client.RunAPIWithContext(ctx, "GET", "/v13/deployments/"+id, "")
+	out, err := client.RunAPIWithContext(ctx, "GET", "/v13/deployments/"+url.PathEscape(id), "")
 	if err != nil {
 		return err
 	}
@@ -589,7 +610,7 @@ func getDeployment(ctx context.Context, client *Client, id string) error {
 }
 
 func getDeploymentEventsSnapshot(ctx context.Context, client *Client, id string) error {
-	out, err := client.RunAPIWithContext(ctx, "GET", "/v2/deployments/"+id+"/events?limit=200", "")
+	out, err := client.RunAPIWithContext(ctx, "GET", "/v2/deployments/"+url.PathEscape(id)+"/events?limit=200", "")
 	if err != nil {
 		return err
 	}
@@ -646,7 +667,7 @@ func getUsage(ctx context.Context, client *Client, period string) error {
 	if period == "" {
 		period = "30d"
 	}
-	endpoint := fmt.Sprintf("/v1/teams/%s/analytics/usage?period=%s", client.GetTeamID(), period)
+	endpoint := fmt.Sprintf("/v1/teams/%s/analytics/usage?period=%s", url.PathEscape(client.GetTeamID()), url.QueryEscape(period))
 	out, err := client.RunAPIWithContext(ctx, "GET", endpoint, "")
 	if err != nil {
 		return err

--- a/internal/vercel/static_commands.go
+++ b/internal/vercel/static_commands.go
@@ -23,6 +23,7 @@ func CreateVercelCommands() *cobra.Command {
 
 	vercelCmd.PersistentFlags().String("api-token", "", "Vercel API token (overrides VERCEL_TOKEN)")
 	vercelCmd.PersistentFlags().String("team-id", "", "Vercel team ID (overrides VERCEL_TEAM_ID)")
+	vercelCmd.PersistentFlags().Bool("raw", false, "Output raw JSON instead of formatted")
 
 	vercelCmd.AddCommand(createVercelListCmd())
 	vercelCmd.AddCommand(createVercelGetCmd())
@@ -192,7 +193,22 @@ func newClientFromFlags(cmd *cobra.Command) (*Client, error) {
 	}
 
 	debug := viper.GetBool("debug")
-	return NewClient(apiToken, teamID, debug)
+	client, err := NewClient(apiToken, teamID, debug)
+	if err != nil {
+		return nil, err
+	}
+	if raw, _ := cmd.Flags().GetBool("raw"); raw {
+		client.raw = true
+	}
+	return client, nil
+}
+
+// rawOutput reports whether the user asked to print unformatted JSON.
+func rawOutput(c *Client) bool {
+	if c == nil {
+		return false
+	}
+	return c.raw
 }
 
 // --- Listers ---
@@ -347,7 +363,36 @@ func listAliases(ctx context.Context, client *Client, projectID string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println(out)
+	if rawOutput(client) {
+		fmt.Println(out)
+		return nil
+	}
+	var resp struct {
+		Aliases []Alias `json:"aliases"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		return fmt.Errorf("failed to parse aliases response: %w", err)
+	}
+	if len(resp.Aliases) == 0 {
+		fmt.Println("No aliases found.")
+		return nil
+	}
+	fmt.Printf("Vercel Aliases (%d):\n\n", len(resp.Aliases))
+	for _, a := range resp.Aliases {
+		fmt.Printf("  %s\n", a.Alias)
+		if a.UID != "" {
+			fmt.Printf("    UID: %s\n", a.UID)
+		}
+		if a.ProjectID != "" {
+			fmt.Printf("    Project: %s\n", a.ProjectID)
+		}
+		if a.Deployment != nil && a.Deployment.URL != "" {
+			fmt.Printf("    Deployment: https://%s\n", a.Deployment.URL)
+		} else if a.DeploymentID != "" {
+			fmt.Printf("    Deployment: %s\n", a.DeploymentID)
+		}
+		fmt.Println()
+	}
 	return nil
 }
 
@@ -364,13 +409,49 @@ func listPostgres(ctx context.Context, client *Client) error {
 	return listStorage(ctx, client, "postgres")
 }
 
+// storageStore is the shape returned by Vercel's unified storage list endpoint.
+type storageStore struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Type      string `json:"type,omitempty"`
+	Status    string `json:"status,omitempty"`
+	CreatedAt int64  `json:"createdAt,omitempty"`
+}
+
 func listStorage(ctx context.Context, client *Client, storeType string) error {
 	endpoint := fmt.Sprintf("/v1/storage/stores?storeType=%s", storeType)
 	out, err := client.RunAPIWithContext(ctx, "GET", endpoint, "")
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Vercel %s stores:\n%s\n", storeType, out)
+	if rawOutput(client) {
+		fmt.Println(out)
+		return nil
+	}
+	var resp struct {
+		Stores []storageStore `json:"stores"`
+	}
+	if err := json.Unmarshal([]byte(out), &resp); err != nil {
+		return fmt.Errorf("failed to parse %s stores response: %w", storeType, err)
+	}
+	if len(resp.Stores) == 0 {
+		fmt.Printf("No Vercel %s stores found.\n", storeType)
+		return nil
+	}
+	fmt.Printf("Vercel %s stores (%d):\n\n", storeType, len(resp.Stores))
+	for _, s := range resp.Stores {
+		fmt.Printf("  %s\n", s.Name)
+		if s.ID != "" {
+			fmt.Printf("    ID: %s\n", s.ID)
+		}
+		if s.Status != "" {
+			fmt.Printf("    Status: %s\n", s.Status)
+		}
+		if s.Type != "" {
+			fmt.Printf("    Type: %s\n", s.Type)
+		}
+		fmt.Println()
+	}
 	return nil
 }
 
@@ -379,8 +460,40 @@ func listEdgeConfigs(ctx context.Context, client *Client) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println("Vercel Edge Configs:")
-	fmt.Println(out)
+	if rawOutput(client) {
+		fmt.Println(out)
+		return nil
+	}
+	// Vercel returns either a raw array or `{"edgeConfigs":[...]}` depending on the account shape.
+	var configs []EdgeConfig
+	if err := json.Unmarshal([]byte(out), &configs); err != nil {
+		var envelope struct {
+			EdgeConfigs []EdgeConfig `json:"edgeConfigs"`
+		}
+		if err2 := json.Unmarshal([]byte(out), &envelope); err2 != nil {
+			return fmt.Errorf("failed to parse edge configs response: %w", err)
+		}
+		configs = envelope.EdgeConfigs
+	}
+	if len(configs) == 0 {
+		fmt.Println("No Vercel Edge Configs found.")
+		return nil
+	}
+	fmt.Printf("Vercel Edge Configs (%d):\n\n", len(configs))
+	for _, cfg := range configs {
+		label := cfg.Slug
+		if label == "" {
+			label = cfg.ID
+		}
+		fmt.Printf("  %s\n", label)
+		if cfg.ID != "" {
+			fmt.Printf("    ID: %s\n", cfg.ID)
+		}
+		if cfg.Slug != "" && cfg.Slug != label {
+			fmt.Printf("    Slug: %s\n", cfg.Slug)
+		}
+		fmt.Println()
+	}
 	return nil
 }
 
@@ -391,7 +504,40 @@ func getProject(ctx context.Context, client *Client, idOrName string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println(out)
+	if rawOutput(client) {
+		fmt.Println(out)
+		return nil
+	}
+	var p Project
+	if err := json.Unmarshal([]byte(out), &p); err != nil {
+		return fmt.Errorf("failed to parse project response: %w", err)
+	}
+	fmt.Printf("Vercel Project: %s\n\n", p.Name)
+	if p.ID != "" {
+		fmt.Printf("  ID: %s\n", p.ID)
+	}
+	if p.Framework != "" {
+		fmt.Printf("  Framework: %s\n", p.Framework)
+	}
+	if p.NodeVersion != "" {
+		fmt.Printf("  Node: %s\n", p.NodeVersion)
+	}
+	if p.AccountID != "" {
+		fmt.Printf("  Account: %s\n", p.AccountID)
+	}
+	if p.Link != nil && p.Link.Repo != "" {
+		fmt.Printf("  Repo: %s (%s)\n", p.Link.Repo, p.Link.Type)
+		if p.Link.ProductionBranch != "" {
+			fmt.Printf("  Production branch: %s\n", p.Link.ProductionBranch)
+		}
+	}
+	if len(p.LatestDeployments) > 0 {
+		latest := p.LatestDeployments[0]
+		fmt.Printf("  Latest deployment: %s (%s)\n", latest.UID, latest.State)
+		if latest.URL != "" {
+			fmt.Printf("    URL: https://%s\n", latest.URL)
+		}
+	}
 	return nil
 }
 
@@ -400,7 +546,39 @@ func getDeployment(ctx context.Context, client *Client, id string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Println(out)
+	if rawOutput(client) {
+		fmt.Println(out)
+		return nil
+	}
+	var d Deployment
+	if err := json.Unmarshal([]byte(out), &d); err != nil {
+		return fmt.Errorf("failed to parse deployment response: %w", err)
+	}
+	state := d.State
+	if state == "" {
+		state = d.ReadyState
+	}
+	target := d.Target
+	if target == "" {
+		target = "preview"
+	}
+	name := d.Name
+	if name == "" {
+		name = d.UID
+	}
+	fmt.Printf("Vercel Deployment: %s\n\n", name)
+	fmt.Printf("  UID: %s\n", d.UID)
+	fmt.Printf("  State: %s\n", state)
+	fmt.Printf("  Target: %s\n", target)
+	if d.URL != "" {
+		fmt.Printf("  URL: https://%s\n", d.URL)
+	}
+	if d.ProjectID != "" {
+		fmt.Printf("  Project: %s\n", d.ProjectID)
+	}
+	if d.Creator != nil && d.Creator.Username != "" {
+		fmt.Printf("  Creator: %s\n", d.Creator.Username)
+	}
 	return nil
 }
 
@@ -409,7 +587,52 @@ func getDeploymentEventsSnapshot(ctx context.Context, client *Client, id string)
 	if err != nil {
 		return err
 	}
-	fmt.Println(out)
+	if rawOutput(client) {
+		fmt.Println(out)
+		return nil
+	}
+	// Events come back either as a bare array or an envelope; handle both.
+	type eventPayload struct {
+		Text string `json:"text,omitempty"`
+		Info struct {
+			Name string `json:"name,omitempty"`
+		} `json:"info,omitempty"`
+	}
+	type event struct {
+		Type    string       `json:"type"`
+		Created int64        `json:"created,omitempty"`
+		Payload eventPayload `json:"payload,omitempty"`
+	}
+	var events []event
+	if err := json.Unmarshal([]byte(out), &events); err != nil {
+		var envelope struct {
+			Events []event `json:"events"`
+		}
+		if err2 := json.Unmarshal([]byte(out), &envelope); err2 != nil {
+			return fmt.Errorf("failed to parse events response: %w", err)
+		}
+		events = envelope.Events
+	}
+	if len(events) == 0 {
+		fmt.Println("No deployment events found.")
+		return nil
+	}
+	fmt.Printf("Deployment events (%d):\n\n", len(events))
+	for _, e := range events {
+		ts := ""
+		if e.Created > 0 {
+			ts = time.UnixMilli(e.Created).UTC().Format(time.RFC3339)
+		}
+		text := strings.TrimSpace(e.Payload.Text)
+		if text == "" {
+			text = e.Payload.Info.Name
+		}
+		if ts != "" {
+			fmt.Printf("  [%s] %-10s %s\n", ts, e.Type, text)
+		} else {
+			fmt.Printf("  %-10s %s\n", e.Type, text)
+		}
+	}
 	return nil
 }
 

--- a/internal/vercel/static_commands.go
+++ b/internal/vercel/static_commands.go
@@ -678,7 +678,7 @@ Use --prod to deploy directly to production.`,
 				cliArgs = append(cliArgs, "--prod")
 			}
 			if project, _ := cmd.Flags().GetString("project"); project != "" {
-				cliArgs = append(cliArgs, "--scope", project)
+				cliArgs = append(cliArgs, "--project", project)
 			}
 
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
@@ -693,7 +693,7 @@ Use --prod to deploy directly to production.`,
 		},
 	}
 	cmd.Flags().Bool("prod", false, "Deploy to production")
-	cmd.Flags().String("project", "", "Project ID or team scope")
+	cmd.Flags().String("project", "", "Project name or ID")
 	return cmd
 }
 
@@ -735,7 +735,7 @@ func createVercelRollbackCmd() *cobra.Command {
 
 			cliArgs := []string{"rollback"}
 			if project, _ := cmd.Flags().GetString("project"); project != "" {
-				cliArgs = append(cliArgs, "--scope", project)
+				cliArgs = append(cliArgs, "--project", project)
 			}
 
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
@@ -749,7 +749,7 @@ func createVercelRollbackCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().String("project", "", "Project ID or team scope")
+	cmd.Flags().String("project", "", "Project name or ID")
 	return cmd
 }
 
@@ -767,7 +767,12 @@ func createVercelCancelCmd() *cobra.Command {
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 			defer cancel()
 
-			return client.CancelDeployment(ctx, args[0])
+			result, err := client.CancelDeployment(ctx, args[0])
+			if err != nil {
+				return err
+			}
+			fmt.Print(result)
+			return nil
 		},
 	}
 	return cmd
@@ -793,7 +798,10 @@ func createVercelEnvAddCmd() *cobra.Command {
 		Long: `Add an environment variable to a Vercel project.
 
 By default targets all environments (production, preview, development).
-Use --target to restrict to specific environments.`,
+Use --target to restrict to specific environments.
+
+The Vercel CLI reads the variable value from stdin, so this command
+pipes the value automatically.`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := newClientFromFlags(cmd)
@@ -801,18 +809,23 @@ Use --target to restrict to specific environments.`,
 				return err
 			}
 
-			cliArgs := []string{"env", "add", args[0], args[1]}
+			key := args[0]
+			value := args[1]
+
+			// The Vercel CLI `env add <key> [environment]` reads the value
+			// from stdin — it cannot be passed as a positional argument.
+			cliArgs := []string{"env", "add", key}
 			if target, _ := cmd.Flags().GetString("target"); target != "" {
 				cliArgs = append(cliArgs, target)
 			}
 			if project, _ := cmd.Flags().GetString("project"); project != "" {
-				cliArgs = append(cliArgs, "--scope", project)
+				cliArgs = append(cliArgs, "--project", project)
 			}
 
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 
-			out, err := client.RunVercelCLIWithContext(ctx, cliArgs...)
+			out, err := client.RunVercelCLIWithStdin(ctx, value+"\n", cliArgs...)
 			if err != nil {
 				return err
 			}
@@ -821,7 +834,7 @@ Use --target to restrict to specific environments.`,
 		},
 	}
 	cmd.Flags().String("target", "", "Comma-separated targets: production,preview,development")
-	cmd.Flags().String("project", "", "Project ID or team scope")
+	cmd.Flags().String("project", "", "Project name or ID")
 	return cmd
 }
 
@@ -842,7 +855,7 @@ func createVercelEnvRmCmd() *cobra.Command {
 			}
 			cliArgs = append(cliArgs, "--yes")
 			if project, _ := cmd.Flags().GetString("project"); project != "" {
-				cliArgs = append(cliArgs, "--scope", project)
+				cliArgs = append(cliArgs, "--project", project)
 			}
 
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -857,7 +870,7 @@ func createVercelEnvRmCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().String("target", "production", "Target environment: production, preview, or development")
-	cmd.Flags().String("project", "", "Project ID or team scope")
+	cmd.Flags().String("project", "", "Project name or ID")
 	return cmd
 }
 
@@ -874,7 +887,7 @@ func createVercelEnvPullCmd() *cobra.Command {
 
 			cliArgs := []string{"env", "pull"}
 			if project, _ := cmd.Flags().GetString("project"); project != "" {
-				cliArgs = append(cliArgs, "--scope", project)
+				cliArgs = append(cliArgs, "--project", project)
 			}
 
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -888,7 +901,7 @@ func createVercelEnvPullCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().String("project", "", "Project ID or team scope")
+	cmd.Flags().String("project", "", "Project name or ID")
 	return cmd
 }
 
@@ -917,7 +930,7 @@ func createVercelDomainAddCmd() *cobra.Command {
 
 			cliArgs := []string{"domains", "add", args[0]}
 			if project, _ := cmd.Flags().GetString("project"); project != "" {
-				cliArgs = append(cliArgs, "--scope", project)
+				cliArgs = append(cliArgs, "--project", project)
 			}
 
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -931,7 +944,7 @@ func createVercelDomainAddCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().String("project", "", "Project ID or team scope")
+	cmd.Flags().String("project", "", "Project name or ID")
 	return cmd
 }
 
@@ -948,7 +961,7 @@ func createVercelDomainRmCmd() *cobra.Command {
 
 			cliArgs := []string{"domains", "rm", args[0], "--yes"}
 			if project, _ := cmd.Flags().GetString("project"); project != "" {
-				cliArgs = append(cliArgs, "--scope", project)
+				cliArgs = append(cliArgs, "--project", project)
 			}
 
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -962,6 +975,6 @@ func createVercelDomainRmCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().String("project", "", "Project ID or team scope")
+	cmd.Flags().String("project", "", "Project name or ID")
 	return cmd
 }

--- a/internal/vercel/static_commands.go
+++ b/internal/vercel/static_commands.go
@@ -446,7 +446,7 @@ type storageStore struct {
 }
 
 func listStorage(ctx context.Context, client *Client, storeType string) error {
-	endpoint := fmt.Sprintf("/v1/storage/stores?storeType=%s", storeType)
+	endpoint := fmt.Sprintf("/v1/storage/stores?storeType=%s", url.QueryEscape(storeType))
 	out, err := client.RunAPIWithContext(ctx, "GET", endpoint, "")
 	if err != nil {
 		return err

--- a/internal/vercel/types.go
+++ b/internal/vercel/types.go
@@ -8,8 +8,8 @@ type Project struct {
 	Name        string `json:"name"`
 	AccountID   string `json:"accountId"`
 	Framework   string `json:"framework,omitempty"`
-	CreatedAt   int64  `json:"createdAt,omitempty"`
-	UpdatedAt   int64  `json:"updatedAt,omitempty"`
+	CreatedAt   int64  `json:"createdAt,omitempty"` // milliseconds since Unix epoch
+	UpdatedAt   int64  `json:"updatedAt,omitempty"` // milliseconds since Unix epoch
 	NodeVersion string `json:"nodeVersion,omitempty"`
 	Link        *struct {
 		Type             string `json:"type"`
@@ -35,8 +35,8 @@ type Deployment struct {
 	Target     string `json:"target,omitempty"`     // "production" | "" (preview)
 	Type       string `json:"type,omitempty"`       // LAMBDAS
 	ProjectID  string `json:"projectId,omitempty"`
-	Created    int64  `json:"created,omitempty"`
-	Ready      int64  `json:"ready,omitempty"`
+	Created    int64  `json:"created,omitempty"` // milliseconds since Unix epoch
+	Ready      int64  `json:"ready,omitempty"`   // milliseconds since Unix epoch
 	Creator    *struct {
 		UID      string `json:"uid"`
 		Username string `json:"username"`
@@ -49,8 +49,8 @@ type Domain struct {
 	Name        string   `json:"name"`
 	ProjectID   string   `json:"projectId,omitempty"`
 	Verified    bool     `json:"verified"`
-	CreatedAt   int64    `json:"createdAt,omitempty"`
-	UpdatedAt   int64    `json:"updatedAt,omitempty"`
+	CreatedAt   int64    `json:"createdAt,omitempty"` // milliseconds since Unix epoch
+	UpdatedAt   int64    `json:"updatedAt,omitempty"` // milliseconds since Unix epoch
 	Nameservers []string `json:"nameservers,omitempty"`
 }
 

--- a/internal/vercel/types.go
+++ b/internal/vercel/types.go
@@ -1,0 +1,127 @@
+package vercel
+
+// Project represents a Vercel project.
+// Fields are a subset of the /v9/projects response — enough for listing and
+// drawer display, not the full schema.
+type Project struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	AccountID   string `json:"accountId"`
+	Framework   string `json:"framework,omitempty"`
+	CreatedAt   int64  `json:"createdAt,omitempty"`
+	UpdatedAt   int64  `json:"updatedAt,omitempty"`
+	NodeVersion string `json:"nodeVersion,omitempty"`
+	Link        *struct {
+		Type             string `json:"type"`
+		Repo             string `json:"repo,omitempty"`
+		RepoID           int64  `json:"repoId,omitempty"`
+		ProductionBranch string `json:"productionBranch,omitempty"`
+	} `json:"link,omitempty"`
+	LatestDeployments []Deployment `json:"latestDeployments,omitempty"`
+	Targets           map[string]struct {
+		ID    string   `json:"id"`
+		URL   string   `json:"url"`
+		Alias []string `json:"alias,omitempty"`
+	} `json:"targets,omitempty"`
+}
+
+// Deployment represents a Vercel deployment.
+type Deployment struct {
+	UID        string `json:"uid"`
+	Name       string `json:"name,omitempty"`
+	URL        string `json:"url,omitempty"`
+	State      string `json:"state,omitempty"`      // READY, BUILDING, ERROR, CANCELED, QUEUED
+	ReadyState string `json:"readyState,omitempty"` // legacy alias used by /v6
+	Target     string `json:"target,omitempty"`     // "production" | "" (preview)
+	Type       string `json:"type,omitempty"`       // LAMBDAS
+	ProjectID  string `json:"projectId,omitempty"`
+	Created    int64  `json:"created,omitempty"`
+	Ready      int64  `json:"ready,omitempty"`
+	Creator    *struct {
+		UID      string `json:"uid"`
+		Username string `json:"username"`
+		Email    string `json:"email,omitempty"`
+	} `json:"creator,omitempty"`
+}
+
+// Domain represents a custom domain.
+type Domain struct {
+	Name        string   `json:"name"`
+	ProjectID   string   `json:"projectId,omitempty"`
+	Verified    bool     `json:"verified"`
+	CreatedAt   int64    `json:"createdAt,omitempty"`
+	UpdatedAt   int64    `json:"updatedAt,omitempty"`
+	Nameservers []string `json:"nameservers,omitempty"`
+}
+
+// EnvVar represents a project environment variable.
+// The `value` field is only returned when explicitly requested and when the
+// caller's token has `read:env` scope; otherwise the UI must treat keys as
+// opaque and not persist them.
+type EnvVar struct {
+	ID     string   `json:"id"`
+	Key    string   `json:"key"`
+	Value  string   `json:"value,omitempty"`
+	Type   string   `json:"type,omitempty"`   // plain, encrypted, system, secret
+	Target []string `json:"target,omitempty"` // production, preview, development
+}
+
+// Team represents a Vercel team (org).
+type Team struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Slug string `json:"slug"`
+}
+
+// User represents the authenticated Vercel user.
+type User struct {
+	UID      string `json:"uid"`
+	ID       string `json:"id,omitempty"`
+	Username string `json:"username"`
+	Email    string `json:"email,omitempty"`
+	Name     string `json:"name,omitempty"`
+}
+
+// UsageSummary summarizes recent consumption for cost estimation and analytics.
+type UsageSummary struct {
+	Bandwidth                 int64   `json:"bandwidth,omitempty"`
+	FunctionInvocations       int64   `json:"functionInvocations,omitempty"`
+	EdgeMiddlewareInvocations int64   `json:"edgeMiddlewareInvocations,omitempty"`
+	BuildMinutes              float64 `json:"buildMinutes,omitempty"`
+	ImageOptimizations        int64   `json:"imageOptimizations,omitempty"`
+	Period                    string  `json:"period,omitempty"`
+}
+
+// --- Storage products (phase 1 read-only) ---
+
+// KVDatabase represents a Vercel KV (Upstash Redis) store.
+type KVDatabase struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Status    string `json:"status,omitempty"`
+	CreatedAt int64  `json:"createdAt,omitempty"`
+}
+
+// BlobStore represents a Vercel Blob store.
+type BlobStore struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Status    string `json:"status,omitempty"`
+	CreatedAt int64  `json:"createdAt,omitempty"`
+}
+
+// PostgresDatabase represents a Vercel Postgres (Neon) instance.
+type PostgresDatabase struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Status    string `json:"status,omitempty"`
+	CreatedAt int64  `json:"createdAt,omitempty"`
+}
+
+// EdgeConfig represents a Vercel Edge Config store.
+type EdgeConfig struct {
+	ID        string `json:"id"`
+	Slug      string `json:"slug,omitempty"`
+	CreatedAt int64  `json:"createdAt,omitempty"`
+	UpdatedAt int64  `json:"updatedAt,omitempty"`
+}

--- a/internal/vercel/types.go
+++ b/internal/vercel/types.go
@@ -73,6 +73,19 @@ type Team struct {
 	Slug string `json:"slug"`
 }
 
+// Alias represents a Vercel deployment alias (/v4/aliases response).
+type Alias struct {
+	UID          string `json:"uid"`
+	Alias        string `json:"alias"`
+	ProjectID    string `json:"projectId,omitempty"`
+	DeploymentID string `json:"deploymentId,omitempty"`
+	Created      int64  `json:"created,omitempty"`
+	Deployment   *struct {
+		ID  string `json:"id,omitempty"`
+		URL string `json:"url,omitempty"`
+	} `json:"deployment,omitempty"`
+}
+
 // User represents the authenticated Vercel user.
 type User struct {
 	UID      string `json:"uid"`


### PR DESCRIPTION
## Summary

Phase 1 of the Vercel integration plan. Adds a read-only Vercel provider to the CLI, mirroring the Cloudflare pattern.

- `internal/vercel/` — REST client with token + team resolution, exponential backoff, error hints, keyword-gated `GetRelevantContext` for LLM prompts, typed models (Project / Deployment / Domain / EnvVar / Team / User / UsageSummary / storage products)
- `clanker vercel list <projects|deployments|domains|env|teams|aliases|kv|blob|postgres|edge-configs>`
- `clanker vercel get <project|deployment> <id>`
- `clanker vercel logs <deploymentId>` (phase-1 snapshot; `--follow` stub for phase 3)
- `clanker vercel analytics [--period 30d]`
- `cmd/vercel.go` — phase-1 ask stub so the subcommand layout is stable; real LLM ask-mode arrives in phase 4
- `internal/routing/routing.go` — new `Vercel bool` on `ServiceContext`, strict keyword list ("vercel", "vercel.app", edge middleware, etc.), classifier prompt entry, and `infra.default_provider: vercel` support
- `.clanker.example.yaml` — documents `vercel.api_token` / `vercel.team_id` plus `VERCEL_TOKEN` / `VERCEL_TEAM_ID` fallbacks

Deploy + mutate paths (`vercel deploy`, `redeploy`, `rollback`, env CRUD, domain CRUD) come in phase 2; AI ask-mode + Cost Explorer integration in phase 4; MCP + auto-heal in phase 5.

## Non-breaking invariants held

- `ServiceContext` existing fields untouched — only `Vercel bool` added
- `maker.ExecOptions` unchanged in this phase (phase 2 adds `VercelAPIToken` / `VercelTeamID`)
- `agent.CLIMode` unchanged in this phase
- Cobra command tree — only `rootCmd.AddCommand(vercelCmd)` appended; no existing commands removed or renamed
- Routing: every existing LLM-classification case explicitly zeroes the new `Vercel` flag so behavior for existing queries is unchanged
- MCP unchanged — `cmd/mcp.go`'s `clanker_run_command` already exposes the new cobra subcommands transparently

## Test plan

- [ ] `go build ./...` — full repo compiles
- [ ] `go vet ./...` — clean
- [ ] `go test ./internal/routing/... ./internal/vercel/...` — routing tests pass, vercel package is source-only today
- [ ] `clanker vercel --help` — shows `list`, `get`, `logs`, `analytics`, `ask` subcommands
- [ ] With `VERCEL_TOKEN` set: `clanker vercel list projects` returns JSON
- [ ] `clanker ask --vercel …` (phase 4) — routing already directs Vercel-mentioning queries through the classifier; the classifier returns `"vercel"` which sets `ctx.Vercel`