### PR TITLE
feat: verda cloud (gpu/ai) provider support

### DIFF
--- a/.clanker.example.yaml
+++ b/.clanker.example.yaml
@@ -186,6 +186,15 @@ infra:
 #   api_token: ""            # Vercel API token (or set VERCEL_TOKEN / VERCEL_API_TOKEN)
 #   team_id: ""              # Optional team ID for team-scoped accounts (or set VERCEL_TEAM_ID / VERCEL_ORG_ID)
 
+# Verda Cloud (for `clanker verda ...` and `clanker ask --verda ...`):
+# verda:
+#   client_id: ""            # Verda OAuth2 client ID (or set VERDA_CLIENT_ID, or run `verda auth login`)
+#   client_secret: ""        # Verda OAuth2 client secret (or set VERDA_CLIENT_SECRET, or run `verda auth login`)
+#   default_project_id: ""   # Verda project ID (or set VERDA_PROJECT_ID)
+#   default_location: ""     # Default datacenter code, e.g. "FIN-01", "ICE-01"
+#   default_ssh_key_id: ""   # SSH key UUID used by k8s create / deploy flows
+#   ssh_key_path: "~/.ssh/id_ed25519"  # Local private key used to pull kubeconfig from Verda Instant Clusters
+
 # Hermes Agent (for `clanker talk` and `clanker ask --agent hermes`):
 # hermes:
 #   path: "./vendor/hermes-agent"    # Auto-detected if omitted

--- a/README.md
+++ b/README.md
@@ -539,6 +539,107 @@ clanker ask --apply --plan-file plan.json | cat
 clanker ask --hetzner --maker --destroyer "delete the test server" | cat
 ```
 
+## Verda Cloud
+
+Clanker supports [Verda Cloud](https://verda.com) (ex-DataCrunch), a European GPU/AI cloud. Every operation runs against Verda's REST API directly — the `verda` CLI binary is optional and only needed for `verda auth login` and `verda skills install`.
+
+### Setup
+
+Verda uses OAuth2 Client Credentials. Generate a `client_id` / `client_secret` pair at [console.verda.com/account/api-keys](https://console.verda.com/account/api-keys) (scope `cloud-api-v1`), then pick one of the resolution paths below.
+
+Option 1 — install the Verda CLI and log in:
+
+```bash
+brew install verda-cloud/tap/verda-cli
+verda auth login   # writes ~/.verda/credentials which clanker reads
+```
+
+Option 2 — environment variables:
+
+```bash
+export VERDA_CLIENT_ID="..."
+export VERDA_CLIENT_SECRET="..."
+export VERDA_PROJECT_ID="..."   # optional
+```
+
+Option 3 — `~/.clanker.yaml`:
+
+```yaml
+verda:
+    client_id: ""
+    client_secret: ""
+    default_project_id: ""
+    default_location: "FIN-01"
+    default_ssh_key_id: ""
+    ssh_key_path: "~/.ssh/id_ed25519"
+```
+
+Option 4 — store in the clanker backend so other machines pick it up automatically:
+
+```bash
+clanker credentials store verda --client-id "$VERDA_CLIENT_ID" --client-secret "$VERDA_CLIENT_SECRET"
+clanker credentials test verda    # hits /v1/balance through the stored creds
+```
+
+### Static Commands
+
+```bash
+clanker verda list instances
+clanker verda list clusters
+clanker verda list volumes
+clanker verda list instance-types
+clanker verda list locations
+clanker verda list containers         # serverless container deployments
+clanker verda list jobs               # serverless job deployments
+clanker verda balance
+
+clanker verda get instance <uuid|hostname>
+clanker verda action start <uuid|hostname>
+clanker verda action shutdown <uuid|hostname>
+clanker verda action delete <uuid|hostname>   # destructive, requires confirmation
+```
+
+### AI Queries
+
+```bash
+# Explicit flag
+clanker ask --verda "what GPU instances are running?"
+clanker ask --verda "how much am I spending this month?"
+
+# Keyword routing (no flag needed when the query mentions verda/datacrunch)
+clanker ask "list my verda clusters"
+
+# Default provider — set infra.default_provider: verda in ~/.clanker.yaml
+# to route bare `clanker ask "..."` queries through Verda.
+```
+
+### Maker (Plan + Apply)
+
+Verda plans use a `verda-api` verb so execution goes through the REST client directly (no CLI dependency). Destructive actions — `DELETE`, `action=delete|discontinue|force_shutdown|delete_stuck|hibernate` — require `--destroyer`.
+
+```bash
+# Generate a plan
+clanker ask --verda --maker "spin up one H100 in FIN-01 with my default ssh key" | tee plan.json
+
+# Apply an approved plan
+clanker ask --apply --plan-file plan.json
+
+# Allow destructive operations (delete instances / discontinue clusters)
+clanker ask --verda --maker --destroyer "delete the training instance" | cat
+```
+
+### Kubernetes (Instant Clusters)
+
+Verda doesn't have a managed K8s control plane, but its Instant Clusters ship with Kubernetes preinstalled. Clanker registers a `verda-instant` provider under its K8s agent that provisions a cluster and pulls kubeconfig off the head node. From the desktop app, click the "kubeconfig →" button on a Verda cluster in the resource list to get a ready-to-paste `ssh | sed` one-liner.
+
+### MCP
+
+Verda is exposed over MCP as `clanker_verda_ask` and `clanker_verda_list` so any MCP-compatible agent (Claude Desktop, Cursor, Zed, etc) can reach the same surface:
+
+```bash
+clanker mcp --transport http --listen :39393
+```
+
 ## Troubleshooting
 
 AWS auth:

--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -321,6 +321,21 @@ Examples:
 				})
 			}
 
+			if strings.EqualFold(strings.TrimSpace(makerPlan.Provider), "verda") {
+				verdaClientID, verdaClientSecret, verdaProjectID, vErr := resolveVerdaCredentialsWithContext(ctx, debug)
+				if vErr != nil {
+					return vErr
+				}
+				return maker.ExecuteVerdaPlan(ctx, makerPlan, maker.ExecOptions{
+					VerdaClientID:     verdaClientID,
+					VerdaClientSecret: verdaClientSecret,
+					VerdaProjectID:    verdaProjectID,
+					Writer:            os.Stdout,
+					Destroyer:         destroyer,
+					Debug:             debug,
+				})
+			}
+
 			// Resolve AWS profile/region for execution.
 			targetProfile := resolveAWSProfile(profile)
 
@@ -485,9 +500,6 @@ Examples:
 			if explicitCount > 1 {
 				return fmt.Errorf("cannot use multiple provider flags (--aws, --gcp, --azure, --cloudflare, --digitalocean, --hetzner, --vercel, --verda) together with --maker")
 			}
-			if explicitVerda {
-				return fmt.Errorf("--maker is not yet supported for Verda — drop the --maker flag and use `clanker ask --verda \"%s\"` for read-only queries", question)
-			}
 			switch {
 			case explicitHetzner:
 				makerProvider = "hetzner"
@@ -510,6 +522,9 @@ Examples:
 			case explicitVercel:
 				makerProvider = "vercel"
 				makerProviderReason = "explicit"
+			case explicitVerda:
+				makerProvider = "verda"
+				makerProviderReason = "explicit"
 			default:
 				svcCtx := routing.InferContext(questionForRouting(question))
 				if svcCtx.Cloudflare {
@@ -529,6 +544,9 @@ Examples:
 					makerProviderReason = "inferred"
 				} else if svcCtx.Vercel {
 					makerProvider = "vercel"
+					makerProviderReason = "inferred"
+				} else if svcCtx.Verda {
+					makerProvider = "verda"
 					makerProviderReason = "inferred"
 				}
 			}
@@ -551,6 +569,8 @@ Examples:
 				prompt = maker.GCPPlanPromptWithMode(question, destroyer)
 			case "vercel":
 				prompt = maker.VercelPlanPromptWithMode(question, destroyer)
+			case "verda":
+				prompt = maker.VerdaPlanPromptWithMode(question, destroyer)
 			default:
 				prompt = maker.PlanPromptWithMode(question, destroyer)
 			}
@@ -611,9 +631,9 @@ Examples:
 
 			plan.Provider = makerProvider
 
-			// Handle GCP, Azure, Cloudflare, and Digital Ocean plans (output directly, no enrichment)
+			// Handle GCP, Azure, Cloudflare, Digital Ocean, Hetzner, Vercel, and Verda plans (output directly, no enrichment)
 			providerLower := strings.ToLower(strings.TrimSpace(plan.Provider))
-			if providerLower == "gcp" || providerLower == "azure" || providerLower == "cloudflare" || providerLower == "digitalocean" || providerLower == "hetzner" || providerLower == "vercel" {
+			if providerLower == "gcp" || providerLower == "azure" || providerLower == "cloudflare" || providerLower == "digitalocean" || providerLower == "hetzner" || providerLower == "vercel" || providerLower == "verda" {
 				if plan.CreatedAt.IsZero() {
 					plan.CreatedAt = time.Now().UTC()
 				}

--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -35,6 +35,7 @@ import (
 	"github.com/bgdnvk/clanker/internal/routing"
 	tfclient "github.com/bgdnvk/clanker/internal/terraform"
 	"github.com/bgdnvk/clanker/internal/vercel"
+	"github.com/bgdnvk/clanker/internal/verda"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -42,10 +43,10 @@ import (
 // askCmd represents the ask command
 const defaultGeminiModel = "gemini-2.5-flash"
 
-func applyDiscoveryContextDefaults(includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel bool) (bool, bool, bool, bool, bool, bool, bool, bool) {
+func applyDiscoveryContextDefaults(includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel, includeVerda bool) (bool, bool, bool, bool, bool, bool, bool, bool, bool) {
 	includeTerraform = true
-	if includeAWS || includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeHetzner || includeVercel {
-		return includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel
+	if includeAWS || includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeHetzner || includeVercel || includeVerda {
+		return includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel, includeVerda
 	}
 
 	switch routing.DefaultInfraProvider() {
@@ -61,11 +62,13 @@ func applyDiscoveryContextDefaults(includeAWS, includeGCP, includeAzure, include
 		includeHetzner = true
 	case "vercel":
 		includeVercel = true
+	case "verda":
+		includeVerda = true
 	default:
 		includeAWS = true
 	}
 
-	return includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel
+	return includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel, includeVerda
 }
 
 var askCmd = &cobra.Command{
@@ -108,6 +111,7 @@ Examples:
 		includeDigitalOcean, _ := cmd.Flags().GetBool("digitalocean")
 		includeHetzner, _ := cmd.Flags().GetBool("hetzner")
 		includeVercel, _ := cmd.Flags().GetBool("vercel")
+		includeVerda, _ := cmd.Flags().GetBool("verda")
 		includeTerraform, _ := cmd.Flags().GetBool("terraform")
 		includeIAM, _ := cmd.Flags().GetBool("iam")
 		dbConnection, _ := cmd.Flags().GetString("db-connection")
@@ -452,6 +456,7 @@ Examples:
 			explicitHetzner := cmd.Flags().Changed("hetzner") && includeHetzner
 			explicitAzure := cmd.Flags().Changed("azure") && includeAzure
 			explicitVercel := cmd.Flags().Changed("vercel") && includeVercel
+			explicitVerda := cmd.Flags().Changed("verda") && includeVerda
 			explicitCount := 0
 			if explicitGCP {
 				explicitCount++
@@ -474,8 +479,14 @@ Examples:
 			if explicitVercel {
 				explicitCount++
 			}
+			if explicitVerda {
+				explicitCount++
+			}
 			if explicitCount > 1 {
-				return fmt.Errorf("cannot use multiple provider flags (--aws, --gcp, --azure, --cloudflare, --digitalocean, --hetzner, --vercel) together with --maker")
+				return fmt.Errorf("cannot use multiple provider flags (--aws, --gcp, --azure, --cloudflare, --digitalocean, --hetzner, --vercel, --verda) together with --maker")
+			}
+			if explicitVerda {
+				return fmt.Errorf("--maker is not yet supported for Verda — drop the --maker flag and use `clanker ask --verda \"%s\"` for read-only queries", question)
 			}
 			switch {
 			case explicitHetzner:
@@ -692,7 +703,7 @@ Format as a professional compliance table suitable for government security docum
 
 		// Discovery mode enables comprehensive infrastructure analysis
 		if discovery {
-			includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel = applyDiscoveryContextDefaults(
+			includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel, includeVerda = applyDiscoveryContextDefaults(
 				includeAWS,
 				includeGCP,
 				includeAzure,
@@ -701,6 +712,7 @@ Format as a professional compliance table suitable for government security docum
 				includeHetzner,
 				includeTerraform,
 				includeVercel,
+				includeVerda,
 			)
 			if debug {
 				fmt.Println("Discovery mode enabled: Terraform context activated alongside the selected infrastructure provider(s)")
@@ -736,7 +748,12 @@ Format as a professional compliance table suitable for government security docum
 			return handleVercelQuery(context.Background(), question, debug)
 		}
 
-		if !includeAWS && !includeGitHub && !includeTerraform && !includeGCP && !includeAzure && !includeCloudflare && !includeDigitalOcean && !includeHetzner && !includeVercel && !includeDB {
+		// Handle explicit --verda flag
+		if includeVerda && !makerMode {
+			return handleVerdaQuery(context.Background(), question, debug)
+		}
+
+		if !includeAWS && !includeGitHub && !includeTerraform && !includeGCP && !includeAzure && !includeCloudflare && !includeDigitalOcean && !includeHetzner && !includeVercel && !includeVerda && !includeDB {
 			routingQuestion := questionForRouting(question)
 
 			// First, do quick keyword check for explicit terms
@@ -810,6 +827,11 @@ Format as a professional compliance table suitable for government security docum
 			// Handle Vercel queries
 			if svcCtx.Vercel {
 				return handleVercelQuery(context.Background(), routingQuestion, debug)
+			}
+
+			// Handle Verda queries
+			if svcCtx.Verda {
+				return handleVerdaQuery(context.Background(), routingQuestion, debug)
 			}
 
 			// Handle IAM queries by delegating to IAM agent
@@ -1296,6 +1318,7 @@ func init() {
 	askCmd.Flags().Bool("digitalocean", false, "Include Digital Ocean infrastructure context")
 	askCmd.Flags().Bool("hetzner", false, "Include Hetzner Cloud infrastructure context")
 	askCmd.Flags().Bool("vercel", false, "Include Vercel context")
+	askCmd.Flags().Bool("verda", false, "Include Verda Cloud (GPU/AI) infrastructure context")
 	askCmd.Flags().Bool("github", false, "Include GitHub repository context")
 	askCmd.Flags().Bool("cicd", false, "Include CI/CD context (currently GitHub Actions)")
 	askCmd.Flags().Bool("db", false, "Include configured database context")
@@ -2348,6 +2371,118 @@ func buildVercelPrompt(question, vercelContext, historyContext string) string {
 	sb.WriteString("User Question: ")
 	sb.WriteString(question)
 	sb.WriteString("\n\nProvide a helpful, concise response in markdown format.")
+	return sb.String()
+}
+
+// resolveVerdaCredentials returns the Verda client ID / client secret / project ID
+// resolving in this order: ~/.clanker.yaml (verda.* keys) → VERDA_* env vars →
+// ~/.verda/credentials (written by `verda auth login`).
+func resolveVerdaCredentials() (clientID, clientSecret, projectID string, err error) {
+	clientID = verda.ResolveClientID()
+	clientSecret = verda.ResolveClientSecret()
+	projectID = verda.ResolveProjectID()
+	if clientID == "" || clientSecret == "" {
+		return "", "", "", fmt.Errorf("Verda credentials not configured. Set verda.client_id / verda.client_secret in ~/.clanker.yaml, export VERDA_CLIENT_ID / VERDA_CLIENT_SECRET, or run `verda auth login`")
+	}
+	return clientID, clientSecret, projectID, nil
+}
+
+// handleVerdaQuery delegates a Verda Cloud query to the Verda agent with
+// per-project conversation history for multi-turn context.
+func handleVerdaQuery(ctx context.Context, question string, debug bool) error {
+	if debug {
+		fmt.Println("Delegating query to Verda agent...")
+	}
+
+	clientID, clientSecret, projectID, err := resolveVerdaCredentials()
+	if err != nil {
+		return err
+	}
+
+	client, err := verda.NewClient(clientID, clientSecret, projectID, debug)
+	if err != nil {
+		return fmt.Errorf("failed to create Verda client: %w", err)
+	}
+
+	scope := projectID
+	if scope == "" {
+		scope = "personal"
+	}
+	history := verda.NewConversationHistory(scope)
+	if err := history.Load(); err != nil && debug {
+		fmt.Fprintf(os.Stderr, "[debug] verda conversation history: %v\n", err)
+	}
+
+	verdaContext, err := client.GetRelevantContext(ctx, question)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[verda] warning: failed to fetch context: %v\n", err)
+		if strings.TrimSpace(verdaContext) == "" {
+			return fmt.Errorf("failed to fetch Verda context: %w", err)
+		}
+	}
+
+	provider := viper.GetString("ai.default_provider")
+	if provider == "" {
+		provider = "openai"
+	}
+	var apiKey string
+	switch provider {
+	case "bedrock", "claude":
+		apiKey = ""
+	case "gemini", "gemini-api":
+		apiKey = ""
+	case "openai":
+		apiKey = resolveOpenAIKey("")
+	case "anthropic":
+		apiKey = resolveAnthropicKey("")
+	case "cohere":
+		apiKey = resolveCohereKey("")
+	case "deepseek":
+		apiKey = resolveDeepSeekKey("")
+	case "minimax":
+		apiKey = resolveMiniMaxKey("")
+	default:
+		apiKey = viper.GetString(fmt.Sprintf("ai.providers.%s.api_key", provider))
+	}
+
+	aiClient := ai.NewClient(provider, apiKey, debug, provider)
+
+	historyContext := history.GetRecentContext(5)
+	prompt := buildVerdaPrompt(question, verdaContext, historyContext)
+
+	response, err := aiClient.AskPrompt(ctx, prompt)
+	if err != nil {
+		return fmt.Errorf("Verda AI query failed: %w", err)
+	}
+
+	fmt.Println(response)
+
+	history.AddEntry(question, response)
+	if err := history.Save(); err != nil && debug {
+		fmt.Fprintf(os.Stderr, "[debug] save verda history: %v\n", err)
+	}
+	return nil
+}
+
+// buildVerdaPrompt assembles the system prompt for a Verda ask query, injecting
+// resource context and recent conversation history when available.
+func buildVerdaPrompt(question, verdaContext, historyContext string) string {
+	var sb strings.Builder
+	sb.WriteString("You are a Verda Cloud infrastructure assistant. ")
+	sb.WriteString("Verda (ex-DataCrunch) is a European GPU/AI cloud that provides GPU instances (H100, A100, H200, B200, L40S, V100, A6000), Instant Clusters (with Slurm or Kubernetes orchestrator), volumes (including shared filesystems), serverless containers and jobs. Answer questions about the user's Verda account based on the provided context.\n\n")
+	if verdaContext != "" {
+		sb.WriteString("Verda Context:\n")
+		sb.WriteString(verdaContext)
+		sb.WriteString("\n\n")
+	}
+	if historyContext != "" {
+		sb.WriteString("Recent Conversation:\n")
+		sb.WriteString(historyContext)
+		sb.WriteString("\n\n")
+	}
+	sb.WriteString("User Question: ")
+	sb.WriteString(question)
+	sb.WriteString("\n\nProvide a helpful, concise response in markdown format. When discussing pricing, remember Verda hourly prices can be converted to monthly using *730.")
 	return sb.String()
 }
 

--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -1369,7 +1369,7 @@ func init() {
 	askCmd.Flags().String("minimax-model", "", "MiniMax model to use (overrides config)")
 	askCmd.Flags().String("github-model", "", "GitHub Models model to use (overrides config)")
 	askCmd.Flags().Bool("agent-trace", false, "Show detailed coordinator agent lifecycle logs (overrides config)")
-	askCmd.Flags().Bool("maker", false, "Generate an AWS, GCP, Azure, Cloudflare, Digital Ocean, or Hetzner CLI plan (JSON) for infrastructure changes")
+	askCmd.Flags().Bool("maker", false, "Generate an AWS, GCP, Azure, Cloudflare, Digital Ocean, Hetzner, Vercel, or Verda plan (JSON) for infrastructure changes")
 	askCmd.Flags().Bool("destroyer", false, "Allow destructive operations when using --maker (requires explicit confirmation in UI/workflow)")
 	askCmd.Flags().Bool("apply", false, "Apply an approved maker plan (reads from stdin unless --plan-file is provided)")
 	askCmd.Flags().String("plan-file", "", "Optional path to maker plan JSON file for --apply")

--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -750,7 +750,7 @@ Format as a professional compliance table suitable for government security docum
 
 		// Handle explicit --verda flag
 		if includeVerda && !makerMode {
-			return handleVerdaQuery(context.Background(), question, debug)
+			return handleVerdaQuery(cmd.Context(), question, debug)
 		}
 
 		if !includeAWS && !includeGitHub && !includeTerraform && !includeGCP && !includeAzure && !includeCloudflare && !includeDigitalOcean && !includeHetzner && !includeVercel && !includeVerda && !includeDB {
@@ -831,7 +831,7 @@ Format as a professional compliance table suitable for government security docum
 
 			// Handle Verda queries
 			if svcCtx.Verda {
-				return handleVerdaQuery(context.Background(), routingQuestion, debug)
+				return handleVerdaQuery(cmd.Context(), routingQuestion, debug)
 			}
 
 			// Handle IAM queries by delegating to IAM agent

--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -2382,7 +2382,14 @@ func resolveVerdaCredentials() (clientID, clientSecret, projectID string, err er
 	clientSecret = verda.ResolveClientSecret()
 	projectID = verda.ResolveProjectID()
 	if clientID == "" || clientSecret == "" {
-		return "", "", "", fmt.Errorf("Verda credentials not configured. Set verda.client_id / verda.client_secret in ~/.clanker.yaml, export VERDA_CLIENT_ID / VERDA_CLIENT_SECRET, or run `verda auth login`")
+		// Pick the most-likely-useful suggestion based on whether the verda
+		// CLI is installed. Users without the CLI should never be told to run
+		// `verda auth login` — they'll get a confusing "command not found".
+		suggestion := "Set verda.client_id / verda.client_secret in ~/.clanker.yaml or export VERDA_CLIENT_ID / VERDA_CLIENT_SECRET."
+		if verda.CLIInstalled() {
+			suggestion = "Set verda.client_id / verda.client_secret in ~/.clanker.yaml, export VERDA_CLIENT_ID / VERDA_CLIENT_SECRET, or run `verda auth login` (the CLI writes ~/.verda/credentials which clanker reads automatically)."
+		}
+		return "", "", "", fmt.Errorf("Verda credentials not configured. %s", suggestion)
 	}
 	return clientID, clientSecret, projectID, nil
 }

--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -2378,20 +2378,47 @@ func buildVercelPrompt(question, vercelContext, historyContext string) string {
 // resolving in this order: ~/.clanker.yaml (verda.* keys) → VERDA_* env vars →
 // ~/.verda/credentials (written by `verda auth login`).
 func resolveVerdaCredentials() (clientID, clientSecret, projectID string, err error) {
+	return resolveVerdaCredentialsWithContext(context.Background(), false)
+}
+
+// resolveVerdaCredentialsWithContext mirrors resolveVercelToken's fallback
+// chain: local config / env / ~/.verda/credentials first, then the clanker
+// backend credential store if the local path has nothing. `debug` controls
+// whether the backend fallback logs its decision.
+func resolveVerdaCredentialsWithContext(ctx context.Context, debug bool) (clientID, clientSecret, projectID string, err error) {
 	clientID = verda.ResolveClientID()
 	clientSecret = verda.ResolveClientSecret()
 	projectID = verda.ResolveProjectID()
-	if clientID == "" || clientSecret == "" {
-		// Pick the most-likely-useful suggestion based on whether the verda
-		// CLI is installed. Users without the CLI should never be told to run
-		// `verda auth login` — they'll get a confusing "command not found".
-		suggestion := "Set verda.client_id / verda.client_secret in ~/.clanker.yaml or export VERDA_CLIENT_ID / VERDA_CLIENT_SECRET."
-		if verda.CLIInstalled() {
-			suggestion = "Set verda.client_id / verda.client_secret in ~/.clanker.yaml, export VERDA_CLIENT_ID / VERDA_CLIENT_SECRET, or run `verda auth login` (the CLI writes ~/.verda/credentials which clanker reads automatically)."
-		}
-		return "", "", "", fmt.Errorf("Verda credentials not configured. %s", suggestion)
+	if clientID != "" && clientSecret != "" {
+		return clientID, clientSecret, projectID, nil
 	}
-	return clientID, clientSecret, projectID, nil
+
+	// Local resolution failed — try the clanker backend credential store if
+	// the user has an API key configured. If the backend route isn't
+	// provisioned server-side yet we get a 404 and fall through to the
+	// human-readable error below.
+	if backendAPIKey := backend.ResolveAPIKey(""); backendAPIKey != "" {
+		backendClient := backend.NewClient(backendAPIKey, debug)
+		creds, bErr := backendClient.GetVerdaCredentials(ctx)
+		if bErr == nil && strings.TrimSpace(creds.ClientID) != "" && strings.TrimSpace(creds.ClientSecret) != "" {
+			if debug {
+				fmt.Println("[backend] Using Verda credentials from backend")
+			}
+			return strings.TrimSpace(creds.ClientID), strings.TrimSpace(creds.ClientSecret), strings.TrimSpace(creds.ProjectID), nil
+		}
+		if debug {
+			fmt.Printf("[backend] No Verda credentials available (%v), falling back to local error\n", bErr)
+		}
+	}
+
+	// Pick the most-likely-useful suggestion based on whether the verda
+	// CLI is installed. Users without the CLI should never be told to run
+	// `verda auth login` — they'll get a confusing "command not found".
+	suggestion := "Set verda.client_id / verda.client_secret in ~/.clanker.yaml or export VERDA_CLIENT_ID / VERDA_CLIENT_SECRET."
+	if verda.CLIInstalled() {
+		suggestion = "Set verda.client_id / verda.client_secret in ~/.clanker.yaml, export VERDA_CLIENT_ID / VERDA_CLIENT_SECRET, or run `verda auth login` (the CLI writes ~/.verda/credentials which clanker reads automatically)."
+	}
+	return "", "", "", fmt.Errorf("Verda credentials not configured. %s", suggestion)
 }
 
 // handleVerdaQuery delegates a Verda Cloud query to the Verda agent with
@@ -2401,7 +2428,7 @@ func handleVerdaQuery(ctx context.Context, question string, debug bool) error {
 		fmt.Println("Delegating query to Verda agent...")
 	}
 
-	clientID, clientSecret, projectID, err := resolveVerdaCredentials()
+	clientID, clientSecret, projectID, err := resolveVerdaCredentialsWithContext(ctx, debug)
 	if err != nil {
 		return err
 	}

--- a/cmd/ask_test.go
+++ b/cmd/ask_test.go
@@ -60,12 +60,12 @@ func TestApplyCommandAIOverrides_RespectsConfiguredProvider(t *testing.T) {
 func TestApplyDiscoveryContextDefaults_UsesConfiguredHetzner(t *testing.T) {
 	useDefaultInfraProvider(t, "hetzner")
 
-	includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel := applyDiscoveryContextDefaults(false, false, false, false, false, false, false, false)
+	includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel, includeVerda := applyDiscoveryContextDefaults(false, false, false, false, false, false, false, false, false)
 
 	if includeAWS {
 		t.Fatal("expected discovery defaults not to force AWS when Hetzner is configured")
 	}
-	if includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeVercel {
+	if includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeVercel || includeVerda {
 		t.Fatal("expected discovery defaults to select only the configured provider")
 	}
 	if !includeHetzner {
@@ -79,9 +79,9 @@ func TestApplyDiscoveryContextDefaults_UsesConfiguredHetzner(t *testing.T) {
 func TestApplyDiscoveryContextDefaults_PreservesExplicitProviderSelection(t *testing.T) {
 	useDefaultInfraProvider(t, "hetzner")
 
-	includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel := applyDiscoveryContextDefaults(false, false, false, false, false, true, false, false)
+	includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel, includeVerda := applyDiscoveryContextDefaults(false, false, false, false, false, true, false, false, false)
 
-	if includeAWS || includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeVercel {
+	if includeAWS || includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeVercel || includeVerda {
 		t.Fatal("expected explicit provider selection to be preserved without adding other providers")
 	}
 	if !includeHetzner {
@@ -95,16 +95,35 @@ func TestApplyDiscoveryContextDefaults_PreservesExplicitProviderSelection(t *tes
 func TestApplyDiscoveryContextDefaults_UsesConfiguredVercel(t *testing.T) {
 	useDefaultInfraProvider(t, "vercel")
 
-	includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel := applyDiscoveryContextDefaults(false, false, false, false, false, false, false, false)
+	includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel, includeVerda := applyDiscoveryContextDefaults(false, false, false, false, false, false, false, false, false)
 
 	if includeAWS {
 		t.Fatal("expected discovery defaults not to force AWS when Vercel is configured")
 	}
-	if includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeHetzner {
+	if includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeHetzner || includeVerda {
 		t.Fatal("expected discovery defaults to select only the configured provider")
 	}
 	if !includeVercel {
 		t.Fatal("expected discovery defaults to enable Vercel when configured")
+	}
+	if !includeTerraform {
+		t.Fatal("expected discovery defaults to enable Terraform context")
+	}
+}
+
+func TestApplyDiscoveryContextDefaults_UsesConfiguredVerda(t *testing.T) {
+	useDefaultInfraProvider(t, "verda")
+
+	includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel, includeVerda := applyDiscoveryContextDefaults(false, false, false, false, false, false, false, false, false)
+
+	if includeAWS {
+		t.Fatal("expected discovery defaults not to force AWS when Verda is configured")
+	}
+	if includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeHetzner || includeVercel {
+		t.Fatal("expected discovery defaults to select only the configured provider")
+	}
+	if !includeVerda {
+		t.Fatal("expected discovery defaults to enable Verda when configured")
 	}
 	if !includeTerraform {
 		t.Fatal("expected discovery defaults to enable Terraform context")

--- a/cmd/credentials.go
+++ b/cmd/credentials.go
@@ -15,6 +15,7 @@ import (
 	"github.com/bgdnvk/clanker/internal/cloudflare"
 	"github.com/bgdnvk/clanker/internal/hetzner"
 	"github.com/bgdnvk/clanker/internal/vercel"
+	"github.com/bgdnvk/clanker/internal/verda"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -40,7 +41,7 @@ var credentialsStoreCmd = &cobra.Command{
 	Short: "Store credentials in the backend",
 	Long: `Upload local credentials to the clanker backend.
 
-Supported providers: aws, gcp, hetzner, cloudflare, vercel, k8s
+Supported providers: aws, gcp, hetzner, cloudflare, vercel, verda, k8s
 
 AWS:
   Exports credentials from local AWS CLI profile using 'aws configure export-credentials'.
@@ -69,6 +70,8 @@ Examples:
   clanker credentials store cloudflare
   clanker credentials store vercel
   clanker credentials store vercel --api-token ${VERCEL_TOKEN} --team-id team_abc
+  clanker credentials store verda
+  clanker credentials store verda --client-id ${VERDA_CLIENT_ID} --client-secret ${VERDA_CLIENT_SECRET}
   clanker credentials store k8s --kubeconfig ~/.kube/config`,
 	Args: cobra.ExactArgs(1),
 	RunE: runCredentialsStore,
@@ -129,6 +132,9 @@ func init() {
 	credentialsStoreCmd.Flags().String("context", "", "Kubernetes context name to use")
 	credentialsStoreCmd.Flags().String("api-token", "", "Vercel API token (overrides vercel.api_token / VERCEL_TOKEN)")
 	credentialsStoreCmd.Flags().String("team-id", "", "Vercel team ID (overrides vercel.team_id / VERCEL_TEAM_ID)")
+	credentialsStoreCmd.Flags().String("client-id", "", "Verda OAuth2 client ID (overrides verda.client_id / VERDA_CLIENT_ID)")
+	credentialsStoreCmd.Flags().String("client-secret", "", "Verda OAuth2 client secret (overrides verda.client_secret / VERDA_CLIENT_SECRET)")
+	credentialsStoreCmd.Flags().String("project-id", "", "Verda project ID (overrides verda.default_project_id / VERDA_PROJECT_ID)")
 }
 
 func requireAPIKey(cmd *cobra.Command) (string, error) {
@@ -166,10 +172,12 @@ func runCredentialsStore(cmd *cobra.Command, args []string) error {
 		return storeCloudflareCredentials(ctx, cmd, client)
 	case "vercel":
 		return storeVercelCredentials(ctx, cmd, client)
+	case "verda":
+		return storeVerdaCredentials(ctx, cmd, client)
 	case "k8s", "kubernetes":
 		return storeKubernetesCredentials(ctx, cmd, client)
 	default:
-		return fmt.Errorf("unsupported provider: %s (supported: aws, gcp, hetzner, cloudflare, vercel, k8s)", provider)
+		return fmt.Errorf("unsupported provider: %s (supported: aws, gcp, hetzner, cloudflare, vercel, verda, k8s)", provider)
 	}
 }
 
@@ -345,6 +353,44 @@ func storeVercelCredentials(ctx context.Context, cmd *cobra.Command, client *bac
 	fmt.Println("Vercel credentials stored successfully")
 	if teamID != "" {
 		fmt.Printf("Team ID: %s\n", teamID)
+	}
+	return nil
+}
+
+// storeVerdaCredentials pushes Verda OAuth2 client_id / client_secret (plus
+// optional project_id) to the clanker backend so other machines can pull
+// them via `clanker ask --verda` without re-authenticating.
+func storeVerdaCredentials(ctx context.Context, cmd *cobra.Command, client *backend.Client) error {
+	clientID, _ := cmd.Flags().GetString("client-id")
+	if strings.TrimSpace(clientID) == "" {
+		clientID = verda.ResolveClientID()
+	}
+	clientSecret, _ := cmd.Flags().GetString("client-secret")
+	if strings.TrimSpace(clientSecret) == "" {
+		clientSecret = verda.ResolveClientSecret()
+	}
+	if strings.TrimSpace(clientID) == "" || strings.TrimSpace(clientSecret) == "" {
+		return fmt.Errorf("Verda client_id and client_secret required: pass --client-id / --client-secret, set verda.client_id / verda.client_secret in config, export VERDA_CLIENT_ID / VERDA_CLIENT_SECRET, or run `verda auth login` (writes ~/.verda/credentials)")
+	}
+
+	projectID, _ := cmd.Flags().GetString("project-id")
+	if strings.TrimSpace(projectID) == "" {
+		projectID = verda.ResolveProjectID()
+	}
+
+	creds := &backend.VerdaCredentials{
+		ClientID:     strings.TrimSpace(clientID),
+		ClientSecret: strings.TrimSpace(clientSecret),
+		ProjectID:    strings.TrimSpace(projectID),
+	}
+
+	if err := client.StoreVerdaCredentials(ctx, creds); err != nil {
+		return fmt.Errorf("failed to store Verda credentials: %w", err)
+	}
+
+	fmt.Println("Verda credentials stored successfully")
+	if projectID != "" {
+		fmt.Printf("Project ID: %s\n", projectID)
 	}
 	return nil
 }

--- a/cmd/credentials.go
+++ b/cmd/credentials.go
@@ -538,6 +538,8 @@ func testCredential(ctx context.Context, client *backend.Client, provider backen
 		return testCloudflareCredentials(ctx, client, debug)
 	case backend.ProviderVercel:
 		return testVercelCredentials(ctx, client, debug)
+	case backend.ProviderVerda:
+		return testVerdaCredentials(ctx, client, debug)
 	case backend.ProviderKubernetes:
 		return testKubernetesCredentials(ctx, client, debug)
 	default:
@@ -724,6 +726,41 @@ func testCloudflareCredentials(ctx context.Context, client *backend.Client, debu
 	return nil
 }
 
+// testVerdaCredentials pulls the stored Verda creds from the clanker backend
+// and exercises them against Verda's balance endpoint, which is the cheapest
+// authenticated call. A success response confirms the oauth2 token flow works
+// end-to-end through the saved credentials.
+func testVerdaCredentials(ctx context.Context, client *backend.Client, debug bool) error {
+	creds, err := client.GetVerdaCredentials(ctx)
+	if err != nil {
+		fmt.Printf("  FAILED: %v\n", err)
+		return err
+	}
+	if creds.ClientID == "" || creds.ClientSecret == "" {
+		fmt.Println("  FAILED: no client_id/client_secret stored")
+		return fmt.Errorf("no Verda credentials")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+
+	vClient, err := verda.NewClient(creds.ClientID, creds.ClientSecret, creds.ProjectID, debug)
+	if err != nil {
+		fmt.Printf("  FAILED: %v\n", err)
+		return err
+	}
+	body, err := vClient.RunAPIWithContext(ctx, "GET", "/v1/balance", "")
+	if err != nil {
+		fmt.Printf("  FAILED: %v\n", err)
+		return err
+	}
+	fmt.Println("  PASSED: authenticated against /v1/balance")
+	if debug {
+		fmt.Printf("  balance: %s\n", strings.TrimSpace(body))
+	}
+	return nil
+}
+
 func testVercelCredentials(ctx context.Context, client *backend.Client, debug bool) error {
 	creds, err := client.GetVercelCredentials(ctx)
 	if err != nil {
@@ -880,10 +917,12 @@ func runCredentialsDelete(cmd *cobra.Command, args []string) error {
 		credProvider = backend.ProviderCloudflare
 	case "vercel":
 		credProvider = backend.ProviderVercel
+	case "verda":
+		credProvider = backend.ProviderVerda
 	case "k8s", "kubernetes":
 		credProvider = backend.ProviderKubernetes
 	default:
-		return fmt.Errorf("unsupported provider: %s (supported: aws, gcp, hetzner, cloudflare, vercel, k8s)", provider)
+		return fmt.Errorf("unsupported provider: %s (supported: aws, gcp, hetzner, cloudflare, vercel, verda, k8s)", provider)
 	}
 
 	client := backend.NewClient(apiKey, debug)

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -56,7 +56,7 @@ type verdaAskArgs struct {
 }
 
 type verdaListArgs struct {
-	Resource     string `json:"resource" jsonschema:"description=Resource type: instances|clusters|volumes|ssh-keys|scripts|instance-types|cluster-types|locations|balance|images|cluster-images|availability,required"`
+	Resource     string `json:"resource" jsonschema:"description=Resource type: instances|clusters|volumes|ssh-keys|scripts|instance-types|cluster-types|container-types|containers|jobs|secrets|file-secrets|registry-creds|locations|balance|images|cluster-images|availability,required"`
 	ClientID     string `json:"clientId,omitempty" jsonschema:"description=Verda OAuth2 client ID (falls back to config/env/credentials file)"`
 	ClientSecret string `json:"clientSecret,omitempty" jsonschema:"description=Verda OAuth2 client secret (falls back to config/env/credentials file)"`
 	ProjectID    string `json:"projectId,omitempty" jsonschema:"description=Verda project ID"`
@@ -378,6 +378,16 @@ func handleMCPVerdaList(ctx context.Context, args verdaListArgs) (*mcp.CallToolR
 		path = "/v1/cluster-types"
 	case "container-types":
 		path = "/v1/container-types"
+	case "containers", "container-deployments":
+		path = "/v1/container-deployments"
+	case "jobs", "job-deployments":
+		path = "/v1/job-deployments"
+	case "secrets":
+		path = "/v1/secrets"
+	case "file-secrets":
+		path = "/v1/file-secrets"
+	case "registry-creds", "registry-credentials":
+		path = "/v1/container-registry-credentials"
 	case "locations":
 		path = "/v1/locations"
 	case "balance":
@@ -389,7 +399,7 @@ func handleMCPVerdaList(ctx context.Context, args verdaListArgs) (*mcp.CallToolR
 	case "availability":
 		path = "/v1/instance-availability"
 	default:
-		return mcp.NewToolResultError(fmt.Sprintf("unknown resource type: %s", resource)), nil
+		return mcp.NewToolResultError(fmt.Sprintf("unknown resource type %q. Supported: instances, clusters, volumes, ssh-keys, scripts, instance-types, cluster-types, container-types, containers, jobs, secrets, file-secrets, registry-creds, locations, balance, images, cluster-images, availability", resource)), nil
 	}
 
 	result, err := client.RunAPIWithContext(ctx, "GET", path, "")

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/bgdnvk/clanker/internal/ai"
 	"github.com/bgdnvk/clanker/internal/vercel"
+	"github.com/bgdnvk/clanker/internal/verda"
 	"github.com/mark3labs/mcp-go/mcp"
 	mcptransport "github.com/mark3labs/mcp-go/server"
 	"github.com/spf13/cobra"
@@ -44,6 +45,21 @@ type vercelListArgs struct {
 	Token    string `json:"token,omitempty" jsonschema:"description=Vercel API token (falls back to config/env)"`
 	TeamID   string `json:"teamId,omitempty" jsonschema:"description=Vercel team ID"`
 	Project  string `json:"project,omitempty" jsonschema:"description=Project ID for scoped resources (deployments and env)"`
+}
+
+type verdaAskArgs struct {
+	Question     string `json:"question" jsonschema:"description=Natural language question about Verda Cloud (GPU/AI) infrastructure,required"`
+	ClientID     string `json:"clientId,omitempty" jsonschema:"description=Verda OAuth2 client ID (falls back to config/env/credentials file)"`
+	ClientSecret string `json:"clientSecret,omitempty" jsonschema:"description=Verda OAuth2 client secret (falls back to config/env/credentials file)"`
+	ProjectID    string `json:"projectId,omitempty" jsonschema:"description=Verda project ID for conversation scoping"`
+	Debug        bool   `json:"debug,omitempty" jsonschema:"description=Enable debug output"`
+}
+
+type verdaListArgs struct {
+	Resource     string `json:"resource" jsonschema:"description=Resource type: instances|clusters|volumes|ssh-keys|scripts|instance-types|cluster-types|locations|balance|images|cluster-images|availability,required"`
+	ClientID     string `json:"clientId,omitempty" jsonschema:"description=Verda OAuth2 client ID (falls back to config/env/credentials file)"`
+	ClientSecret string `json:"clientSecret,omitempty" jsonschema:"description=Verda OAuth2 client secret (falls back to config/env/credentials file)"`
+	ProjectID    string `json:"projectId,omitempty" jsonschema:"description=Verda project ID"`
 }
 
 var mcpCmd = &cobra.Command{
@@ -136,6 +152,29 @@ func newClankerMCPServer() *mcptransport.MCPServer {
 		),
 		mcp.NewTypedToolHandler(func(ctx context.Context, _ mcp.CallToolRequest, args vercelListArgs) (*mcp.CallToolResult, error) {
 			return handleMCPVercelList(ctx, args)
+		}),
+	)
+
+	server.AddTool(
+		mcp.NewTool(
+			"clanker_verda_ask",
+			mcp.WithDescription("Ask a natural language question about your Verda Cloud (GPU/AI) infrastructure. Gathers Verda context (instances, clusters, volumes, balance) and uses the configured AI provider to answer."),
+			mcp.WithInputSchema[verdaAskArgs](),
+		),
+		mcp.NewTypedToolHandler(func(ctx context.Context, _ mcp.CallToolRequest, args verdaAskArgs) (*mcp.CallToolResult, error) {
+			return handleMCPVerdaAsk(ctx, args)
+		}),
+	)
+
+	server.AddTool(
+		mcp.NewTool(
+			"clanker_verda_list",
+			mcp.WithDescription("List Verda Cloud resources. Returns raw JSON from the Verda REST API."),
+			mcp.WithInputSchema[verdaListArgs](),
+			mcp.WithReadOnlyHintAnnotation(true),
+		),
+		mcp.NewTypedToolHandler(func(ctx context.Context, _ mcp.CallToolRequest, args verdaListArgs) (*mcp.CallToolResult, error) {
+			return handleMCPVerdaList(ctx, args)
 		}),
 	)
 
@@ -249,6 +288,114 @@ func handleMCPVercelList(ctx context.Context, args vercelListArgs) (*mcp.CallToo
 		return mcp.NewToolResultError(fmt.Sprintf("Vercel API error: %v", err)), nil
 	}
 
+	return mcp.NewToolResultText(result), nil
+}
+
+// handleMCPVerdaAsk resolves Verda credentials, gathers context, and asks the
+// configured AI provider about the user's Verda Cloud infrastructure.
+func handleMCPVerdaAsk(ctx context.Context, args verdaAskArgs) (*mcp.CallToolResult, error) {
+	clientID := args.ClientID
+	if clientID == "" {
+		clientID = verda.ResolveClientID()
+	}
+	clientSecret := args.ClientSecret
+	if clientSecret == "" {
+		clientSecret = verda.ResolveClientSecret()
+	}
+	if clientID == "" || clientSecret == "" {
+		return mcp.NewToolResultError("Verda credentials not configured. Set verda.client_id / verda.client_secret in ~/.clanker.yaml, export VERDA_CLIENT_ID / VERDA_CLIENT_SECRET, or run `verda auth login`"), nil
+	}
+	projectID := args.ProjectID
+	if projectID == "" {
+		projectID = verda.ResolveProjectID()
+	}
+
+	client, err := verda.NewClient(clientID, clientSecret, projectID, args.Debug)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to create Verda client: %v", err)), nil
+	}
+
+	verdaContext, _ := client.GetRelevantContext(ctx, args.Question)
+
+	prompt := buildVerdaPrompt(args.Question, verdaContext, "")
+
+	provider := viper.GetString("ai.default_provider")
+	if provider == "" {
+		provider = "openai"
+	}
+	apiKey := mcpResolveProviderKey(provider)
+	aiClient := ai.NewClient(provider, apiKey, args.Debug, provider)
+
+	response, err := aiClient.AskPrompt(ctx, prompt)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("AI query failed: %v", err)), nil
+	}
+	return mcp.NewToolResultText(response), nil
+}
+
+// handleMCPVerdaList resolves Verda credentials and lists the requested resource type.
+func handleMCPVerdaList(ctx context.Context, args verdaListArgs) (*mcp.CallToolResult, error) {
+	clientID := args.ClientID
+	if clientID == "" {
+		clientID = verda.ResolveClientID()
+	}
+	clientSecret := args.ClientSecret
+	if clientSecret == "" {
+		clientSecret = verda.ResolveClientSecret()
+	}
+	if clientID == "" || clientSecret == "" {
+		return mcp.NewToolResultError("Verda credentials not configured. Set verda.client_id / verda.client_secret in ~/.clanker.yaml, export VERDA_CLIENT_ID / VERDA_CLIENT_SECRET, or run `verda auth login`"), nil
+	}
+	projectID := args.ProjectID
+	if projectID == "" {
+		projectID = verda.ResolveProjectID()
+	}
+
+	client, err := verda.NewClient(clientID, clientSecret, projectID, false)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to create Verda client: %v", err)), nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	resource := strings.ToLower(strings.TrimSpace(args.Resource))
+	var path string
+	switch resource {
+	case "instances", "instance", "vm", "vms":
+		path = "/v1/instances"
+	case "clusters", "cluster":
+		path = "/v1/clusters"
+	case "volumes", "volume":
+		path = "/v1/volumes"
+	case "ssh-keys", "ssh", "keys":
+		path = "/v1/ssh-keys"
+	case "scripts", "startup-scripts":
+		path = "/v1/scripts?pageSize=100"
+	case "instance-types", "types":
+		path = "/v1/instance-types"
+	case "cluster-types":
+		path = "/v1/cluster-types"
+	case "container-types":
+		path = "/v1/container-types"
+	case "locations":
+		path = "/v1/locations"
+	case "balance":
+		path = "/v1/balance"
+	case "images":
+		path = "/v1/images"
+	case "cluster-images":
+		path = "/v1/images/cluster"
+	case "availability":
+		path = "/v1/instance-availability"
+	default:
+		return mcp.NewToolResultError(fmt.Sprintf("unknown resource type: %s", resource)), nil
+	}
+
+	result, err := client.RunAPIWithContext(ctx, "GET", path, "")
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Verda API error: %v", err)), nil
+	}
 	return mcp.NewToolResultText(result), nil
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bgdnvk/clanker/internal/gcp"
 	"github.com/bgdnvk/clanker/internal/hetzner"
 	"github.com/bgdnvk/clanker/internal/vercel"
+	"github.com/bgdnvk/clanker/internal/verda"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -116,6 +117,11 @@ func init() {
 	vercelCmd := vercel.CreateVercelCommands()
 	AddVercelAskCommand(vercelCmd)
 	rootCmd.AddCommand(vercelCmd)
+
+	// Register Verda Cloud static commands + ask subcommand
+	verdaCmd := verda.CreateVerdaCommands()
+	AddVerdaAskCommand(verdaCmd)
+	rootCmd.AddCommand(verdaCmd)
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/verda.go
+++ b/cmd/verda.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// verdaAskCmd hangs off `clanker verda ask` and redirects to the main ask-mode
+// flow. Keeping the subcommand registered from day one gives muscle memory
+// parity with `clanker cf ask` / `clanker vercel ask` without a version gate.
+var verdaAskCmd = &cobra.Command{
+	Use:   "ask [question]",
+	Short: "Ask natural language questions about your Verda Cloud account",
+	Long: `Ask natural language questions about your Verda Cloud (GPU/AI) account.
+
+Use ` + "`clanker ask --verda \"...\"`" + ` — it resolves credentials, gathers
+context (instances, clusters, volumes, balance, locations), and drives the
+configured AI provider. Or run ` + "`clanker verda list instances`" + ` for raw data.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runVerdaAsk,
+}
+
+// AddVerdaAskCommand attaches the ask subcommand to the `verda` tree.
+// Called from root.go after `verda.CreateVerdaCommands()` returns.
+func AddVerdaAskCommand(verdaCmd *cobra.Command) {
+	verdaCmd.AddCommand(verdaAskCmd)
+}
+
+func runVerdaAsk(cmd *cobra.Command, args []string) error {
+	question := strings.TrimSpace(args[0])
+	if question == "" {
+		return fmt.Errorf("question cannot be empty")
+	}
+	debug, _ := cmd.Root().PersistentFlags().GetBool("debug")
+	return handleVerdaQuery(cmd.Context(), question, debug)
+}

--- a/internal/backend/client.go
+++ b/internal/backend/client.go
@@ -449,6 +449,45 @@ func (c *Client) GetVercelCredentials(ctx context.Context) (*VercelCredentials, 
 	return &response.Data.Credentials, nil
 }
 
+// GetVerdaCredentials retrieves Verda Cloud credentials from the backend.
+// The clanker backend may return 404 today (route may not be provisioned
+// server-side yet); the caller treats that as "fall back to local creds" so
+// behaviour degrades gracefully until the server adds the endpoint.
+func (c *Client) GetVerdaCredentials(ctx context.Context) (*VerdaCredentials, error) {
+	respBody, err := c.doRequest(ctx, http.MethodGet, "/api/v1/cli/credentials/verda", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var response struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Provider    string           `json:"provider"`
+			Credentials VerdaCredentials `json:"credentials"`
+		} `json:"data"`
+	}
+
+	if err := json.Unmarshal(respBody, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	if !response.Success {
+		return nil, fmt.Errorf("failed to get Verda credentials")
+	}
+
+	return &response.Data.Credentials, nil
+}
+
+// StoreVerdaCredentials stores Verda Cloud credentials in the backend.
+func (c *Client) StoreVerdaCredentials(ctx context.Context, creds *VerdaCredentials) error {
+	body := map[string]interface{}{
+		"provider":    "verda",
+		"credentials": creds,
+	}
+	_, err := c.doRequest(ctx, http.MethodPut, "/api/v1/cli/credentials/verda", body)
+	return err
+}
+
 // StoreVercelCredentials stores Vercel credentials in the backend
 func (c *Client) StoreVercelCredentials(ctx context.Context, creds *VercelCredentials) error {
 	body := map[string]interface{}{

--- a/internal/backend/types.go
+++ b/internal/backend/types.go
@@ -54,6 +54,15 @@ type VercelCredentials struct {
 	TeamID   string `json:"team_id,omitempty"`
 }
 
+// VerdaCredentials represents Verda Cloud (ex-DataCrunch) credentials stored
+// in the backend. Verda uses OAuth2 Client Credentials so we need both IDs.
+// ProjectID is optional.
+type VerdaCredentials struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	ProjectID    string `json:"project_id,omitempty"`
+}
+
 // CredentialProvider represents supported credential providers
 type CredentialProvider string
 
@@ -66,6 +75,7 @@ const (
 	ProviderHetzner      CredentialProvider = "hetzner"
 	ProviderKubernetes   CredentialProvider = "kubernetes"
 	ProviderVercel       CredentialProvider = "vercel"
+	ProviderVerda        CredentialProvider = "verda"
 )
 
 // CredentialEntry represents a stored credential in the backend

--- a/internal/k8s/agent.go
+++ b/internal/k8s/agent.go
@@ -63,17 +63,36 @@ func NewAgentWithOptions(opts AgentOptions) *Agent {
 
 	// Register Verda Instant Cluster provider if Verda credentials are configured.
 	// Failing to build a client is non-fatal — it just means the provider won't
-	// be available until the user adds credentials.
-	if verdaClientID := verda.ResolveClientID(); verdaClientID != "" {
-		if verdaClientSecret := verda.ResolveClientSecret(); verdaClientSecret != "" {
-			if client, err := verda.NewClient(verdaClientID, verdaClientSecret, verda.ResolveProjectID(), opts.Debug); err == nil {
-				mgr.RegisterProvider(cluster.NewVerdaInstantProvider(cluster.VerdaInstantProviderOptions{
-					Client:          client,
-					DefaultLocation: verda.ResolveDefaultLocation(),
-					DefaultSSHKeyID: verda.ResolveDefaultSSHKeyID(),
-					SSHKeyPath:      verda.ResolveSSHKeyPath(),
-					Debug:           opts.Debug,
-				}))
+	// be available until the user adds credentials. Log at debug so a user
+	// investigating why "verda-instant" isn't a selectable cluster type has a
+	// breadcrumb to follow.
+	verdaClientID := verda.ResolveClientID()
+	verdaClientSecret := verda.ResolveClientSecret()
+	switch {
+	case verdaClientID == "" && verdaClientSecret == "":
+		if opts.Debug {
+			fmt.Println("[k8s] verda provider skipped: no verda credentials configured")
+		}
+	case verdaClientID == "" || verdaClientSecret == "":
+		if opts.Debug {
+			fmt.Println("[k8s] verda provider skipped: partial credentials (need both client_id and client_secret)")
+		}
+	default:
+		client, err := verda.NewClient(verdaClientID, verdaClientSecret, verda.ResolveProjectID(), opts.Debug)
+		if err != nil {
+			if opts.Debug {
+				fmt.Printf("[k8s] verda provider skipped: %v\n", err)
+			}
+		} else {
+			mgr.RegisterProvider(cluster.NewVerdaInstantProvider(cluster.VerdaInstantProviderOptions{
+				Client:          client,
+				DefaultLocation: verda.ResolveDefaultLocation(),
+				DefaultSSHKeyID: verda.ResolveDefaultSSHKeyID(),
+				SSHKeyPath:      verda.ResolveSSHKeyPath(),
+				Debug:           opts.Debug,
+			}))
+			if opts.Debug {
+				fmt.Println("[k8s] verda-instant provider registered")
 			}
 		}
 	}

--- a/internal/k8s/agent.go
+++ b/internal/k8s/agent.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bgdnvk/clanker/internal/k8s/storage"
 	"github.com/bgdnvk/clanker/internal/k8s/telemetry"
 	"github.com/bgdnvk/clanker/internal/k8s/workloads"
+	"github.com/bgdnvk/clanker/internal/verda"
 )
 
 // Agent is the main K8s orchestrator that receives delegated queries from the main agent
@@ -60,6 +61,23 @@ func NewAgentWithOptions(opts AgentOptions) *Agent {
 		}))
 	}
 
+	// Register Verda Instant Cluster provider if Verda credentials are configured.
+	// Failing to build a client is non-fatal — it just means the provider won't
+	// be available until the user adds credentials.
+	if verdaClientID := verda.ResolveClientID(); verdaClientID != "" {
+		if verdaClientSecret := verda.ResolveClientSecret(); verdaClientSecret != "" {
+			if client, err := verda.NewClient(verdaClientID, verdaClientSecret, verda.ResolveProjectID(), opts.Debug); err == nil {
+				mgr.RegisterProvider(cluster.NewVerdaInstantProvider(cluster.VerdaInstantProviderOptions{
+					Client:          client,
+					DefaultLocation: verda.ResolveDefaultLocation(),
+					DefaultSSHKeyID: verda.ResolveDefaultSSHKeyID(),
+					SSHKeyPath:      verda.ResolveSSHKeyPath(),
+					Debug:           opts.Debug,
+				}))
+			}
+		}
+	}
+
 	return &Agent{
 		clusterMgr: mgr,
 		debug:      opts.Debug,
@@ -85,6 +103,19 @@ func (a *Agent) RegisterKubeadmProvider(opts KubeadmProviderOptions) {
 		KeyPairName: opts.KeyPairName,
 		SSHKeyPath:  opts.SSHKeyPath,
 		Debug:       a.debug,
+	}))
+}
+
+// RegisterVerdaInstantProvider registers a Verda Cloud Instant Cluster provider
+// with the agent. Idempotent — the underlying Manager replaces existing entries
+// of the same type.
+func (a *Agent) RegisterVerdaInstantProvider(client *verda.Client, defaultLocation, defaultSSHKeyID, sshKeyPath string) {
+	a.clusterMgr.RegisterProvider(cluster.NewVerdaInstantProvider(cluster.VerdaInstantProviderOptions{
+		Client:          client,
+		DefaultLocation: defaultLocation,
+		DefaultSSHKeyID: defaultSSHKeyID,
+		SSHKeyPath:      sshKeyPath,
+		Debug:           a.debug,
 	}))
 }
 

--- a/internal/k8s/cluster/provider.go
+++ b/internal/k8s/cluster/provider.go
@@ -35,13 +35,14 @@ func DebugLog(debug bool, provider, format string, args ...interface{}) {
 type ClusterType string
 
 const (
-	ClusterTypeEKS      ClusterType = "eks"
-	ClusterTypeGKE      ClusterType = "gke"
-	ClusterTypeAKS      ClusterType = "aks"
-	ClusterTypeKubeadm  ClusterType = "kubeadm"
-	ClusterTypeKops     ClusterType = "kops"
-	ClusterTypeK3s      ClusterType = "k3s"
-	ClusterTypeExisting ClusterType = "existing"
+	ClusterTypeEKS          ClusterType = "eks"
+	ClusterTypeGKE          ClusterType = "gke"
+	ClusterTypeAKS          ClusterType = "aks"
+	ClusterTypeKubeadm      ClusterType = "kubeadm"
+	ClusterTypeKops         ClusterType = "kops"
+	ClusterTypeK3s          ClusterType = "k3s"
+	ClusterTypeExisting     ClusterType = "existing"
+	ClusterTypeVerdaInstant ClusterType = "verda-instant"
 )
 
 // Standard timeout constants for cluster operations

--- a/internal/k8s/cluster/verda.go
+++ b/internal/k8s/cluster/verda.go
@@ -305,9 +305,12 @@ func (p *VerdaInstantProvider) GetCluster(ctx context.Context, clusterName strin
 // resolveClusterID maps a hostname or raw ID to a cluster ID. Verda's API keys
 // everything by UUID, but users specify clusters by name in clanker commands.
 func (p *VerdaInstantProvider) resolveClusterID(ctx context.Context, nameOrID string) (string, error) {
-	// Treat the input as a UUID if it looks like one.
-	if looksLikeUUID(nameOrID) {
-		return nameOrID, nil
+	// Treat the input as a UUID if it looks like one. Verda UUIDs are
+	// lowercase per the spec, so normalise in case a user pasted an
+	// uppercase variant from a UI.
+	lowered := strings.ToLower(strings.TrimSpace(nameOrID))
+	if looksLikeUUID(lowered) {
+		return lowered, nil
 	}
 	return p.findClusterIDByHostname(ctx, nameOrID)
 }
@@ -385,20 +388,29 @@ func (p *VerdaInstantProvider) fetchRemoteKubeconfig(ctx context.Context, host s
 }
 
 func (p *VerdaInstantProvider) scpRead(ctx context.Context, target string) (string, error) {
-	// Use `scp` piping to stdout via `cat`, avoiding temp files. Practically
-	// we invoke `ssh <host> cat <path>` since `scp - <remote:path>` has
-	// inconsistent support.
+	// We invoke `ssh <host> cat <path>` since `scp - <remote:path>` has
+	// inconsistent support across OpenSSH versions.
 	host, path := splitSCPTarget(target)
 	if host == "" || path == "" {
 		return "", fmt.Errorf("invalid scp target %s", target)
+	}
+	// Belt-and-braces: reject any path containing shell metacharacters in case
+	// the candidate list ever becomes user-supplied. `ssh` concatenates the
+	// remote args into a single string before passing to the login shell, so
+	// anything non-literal here is an injection vector.
+	if strings.ContainsAny(path, ";&|`$><\n\r") {
+		return "", fmt.Errorf("refusing to scp path with shell metacharacters: %q", path)
 	}
 
 	args := []string{
 		"-i", p.sshKeyPath,
 		"-o", "StrictHostKeyChecking=accept-new",
 		"-o", "ConnectTimeout=10",
+		"-o", "BatchMode=yes",
 		host,
-		"cat " + path,
+		"--",
+		"cat",
+		path,
 	}
 	DebugLog(p.debug, "ssh", "%s", strings.Join(args, " "))
 

--- a/internal/k8s/cluster/verda.go
+++ b/internal/k8s/cluster/verda.go
@@ -1,0 +1,517 @@
+package cluster
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/bgdnvk/clanker/internal/verda"
+)
+
+// VerdaInstantProviderOptions configures a VerdaInstantProvider.
+type VerdaInstantProviderOptions struct {
+	Client          *verda.Client
+	DefaultLocation string
+	DefaultSSHKeyID string
+	SSHKeyPath      string
+	Debug           bool
+}
+
+// VerdaInstantProvider provisions Verda Cloud "Instant Clusters" with the
+// Kubernetes orchestrator preinstalled. Scale() is intentionally not supported
+// — Verda Instant Clusters are fixed-size per cluster_type.
+type VerdaInstantProvider struct {
+	client          *verda.Client
+	defaultLocation string
+	defaultSSHKey   string
+	sshKeyPath      string
+	debug           bool
+}
+
+// NewVerdaInstantProvider constructs a provider. The caller must pass a
+// configured *verda.Client (nil clients return an error on every method).
+func NewVerdaInstantProvider(opts VerdaInstantProviderOptions) *VerdaInstantProvider {
+	return &VerdaInstantProvider{
+		client:          opts.Client,
+		defaultLocation: opts.DefaultLocation,
+		defaultSSHKey:   opts.DefaultSSHKeyID,
+		sshKeyPath:      opts.SSHKeyPath,
+		debug:           opts.Debug,
+	}
+}
+
+// Type returns the cluster type identifier.
+func (p *VerdaInstantProvider) Type() ClusterType { return ClusterTypeVerdaInstant }
+
+func (p *VerdaInstantProvider) requireClient() error {
+	if p.client == nil {
+		return fmt.Errorf("verda client not configured — set verda.client_id/client_secret in ~/.clanker.yaml or run `verda auth login`")
+	}
+	return nil
+}
+
+// Create provisions a Verda Instant Cluster and polls until it reaches a
+// terminal state. The cluster's orchestrator is selected via the `image` —
+// we prefer a kubernetes-labelled image from /v1/images/cluster; if none
+// exists we fall back to the first available cluster image and expect the
+// caller to rely on a startup script to install k8s.
+func (p *VerdaInstantProvider) Create(ctx context.Context, opts CreateOptions) (*ClusterInfo, error) {
+	if err := p.requireClient(); err != nil {
+		return nil, err
+	}
+
+	clusterType := strings.TrimSpace(opts.WorkerType)
+	if clusterType == "" {
+		return nil, &ErrInvalidConfiguration{Message: "verda-instant requires WorkerType set to a Verda cluster_type (e.g. \"8H100\")"}
+	}
+
+	location := strings.TrimSpace(opts.Region)
+	if location == "" {
+		location = p.defaultLocation
+	}
+	if location == "" {
+		return nil, &ErrInvalidConfiguration{Message: "verda-instant requires Region (Verda location_code, e.g. FIN-01)"}
+	}
+
+	sshKey := strings.TrimSpace(opts.KeyPairName)
+	if sshKey == "" {
+		sshKey = p.defaultSSHKey
+	}
+	if sshKey == "" {
+		return nil, &ErrInvalidConfiguration{Message: "verda-instant requires an ssh_key_id — set verda.default_ssh_key_id or pass KeyPairName"}
+	}
+
+	image, err := p.pickKubernetesClusterImage(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolve cluster image: %w", err)
+	}
+
+	// Verda requires a shared_volume on every cluster create. Use a default SFS
+	// sized for working-set storage; caller can resize after provisioning.
+	shared := verda.SharedVolumeDto{
+		Name: opts.Name + "-sfs",
+		Size: 100,
+	}
+
+	body := verda.DeployClusterRequest{
+		ClusterType:  clusterType,
+		Image:        image,
+		SSHKeyIDs:    []string{sshKey},
+		Hostname:     opts.Name,
+		Description:  fmt.Sprintf("clanker-managed verda-instant cluster (%s)", opts.Name),
+		LocationCode: location,
+		SharedVolume: &shared,
+		Contract:     verda.ContractPayAsYouGo,
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal cluster request: %w", err)
+	}
+
+	DebugLog(p.debug, "verda", "creating cluster %s (type=%s, location=%s, image=%s)", opts.Name, clusterType, location, image)
+	resp, err := p.client.RunAPIWithContext(ctx, http.MethodPost, "/v1/clusters", string(payload))
+	if err != nil {
+		return nil, fmt.Errorf("POST /v1/clusters: %w", err)
+	}
+
+	// The API returns `{"id":"..."}` on 202. Polling requires the ID.
+	var accepted struct {
+		ID string `json:"id"`
+	}
+	if jerr := json.Unmarshal([]byte(resp), &accepted); jerr != nil || accepted.ID == "" {
+		// Some Verda endpoints wrap the ID differently; fall back to listing + matching hostname.
+		if id, lerr := p.findClusterIDByHostname(ctx, opts.Name); lerr == nil && id != "" {
+			accepted.ID = id
+		} else {
+			return nil, fmt.Errorf("could not determine created cluster ID (resp=%s)", resp)
+		}
+	}
+
+	createTimeout := opts.CreateTimeout
+	if createTimeout == 0 {
+		createTimeout = 30 * time.Minute
+	}
+	cluster, err := p.client.WaitClusterRunning(ctx, accepted.ID, verda.PollOptions{Interval: 30 * time.Second, Max: createTimeout})
+	if err != nil {
+		return nil, err
+	}
+	if cluster == nil {
+		return nil, fmt.Errorf("cluster %s did not return detail payload", accepted.ID)
+	}
+
+	return toClusterInfo(cluster), nil
+}
+
+// Delete issues the `discontinue` cluster action.
+func (p *VerdaInstantProvider) Delete(ctx context.Context, clusterName string) error {
+	if err := p.requireClient(); err != nil {
+		return err
+	}
+	id, err := p.resolveClusterID(ctx, clusterName)
+	if err != nil {
+		return err
+	}
+
+	body, err := json.Marshal(map[string]interface{}{
+		"action": "discontinue",
+		"id":     id,
+	})
+	if err != nil {
+		return err
+	}
+	DebugLog(p.debug, "verda", "discontinuing cluster %s (id=%s)", clusterName, id)
+	_, err = p.client.RunAPIWithContext(ctx, http.MethodPut, "/v1/clusters", string(body))
+	return err
+}
+
+// Scale is not supported — Verda Instant Clusters are fixed-size per type.
+func (p *VerdaInstantProvider) Scale(ctx context.Context, clusterName string, opts ScaleOptions) error {
+	return fmt.Errorf("scale not supported for verda-instant — pick a larger cluster_type and recreate")
+}
+
+// GetKubeconfig SCPs `/root/.kube/config` off the first worker node and
+// rewrites the `server:` URL to the node's public IP so kubectl can reach it
+// from outside Verda's private network.
+func (p *VerdaInstantProvider) GetKubeconfig(ctx context.Context, clusterName string) (string, error) {
+	if err := p.requireClient(); err != nil {
+		return "", err
+	}
+	id, err := p.resolveClusterID(ctx, clusterName)
+	if err != nil {
+		return "", err
+	}
+
+	body, err := p.client.RunAPIWithContext(ctx, http.MethodGet, "/v1/clusters/"+id, "")
+	if err != nil {
+		return "", err
+	}
+	var cluster verda.Cluster
+	if err := json.Unmarshal([]byte(body), &cluster); err != nil {
+		return "", fmt.Errorf("decode cluster: %w", err)
+	}
+
+	host := firstPublicIP(cluster)
+	if host == "" {
+		return "", fmt.Errorf("cluster %s has no reachable public IP yet", clusterName)
+	}
+
+	if p.sshKeyPath == "" {
+		return "", fmt.Errorf("ssh_key_path not configured — set verda.ssh_key_path in ~/.clanker.yaml")
+	}
+
+	kubeconfig, err := p.fetchRemoteKubeconfig(ctx, host)
+	if err != nil {
+		return "", err
+	}
+
+	rewritten, err := rewriteKubeconfigServer(kubeconfig, host)
+	if err != nil {
+		return "", err
+	}
+	return rewritten, nil
+}
+
+// Health reports node readiness based on the cluster's worker-node status list.
+func (p *VerdaInstantProvider) Health(ctx context.Context, clusterName string) (*HealthStatus, error) {
+	if err := p.requireClient(); err != nil {
+		return nil, err
+	}
+	id, err := p.resolveClusterID(ctx, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := p.client.RunAPIWithContext(ctx, http.MethodGet, "/v1/clusters/"+id, "")
+	if err != nil {
+		return nil, err
+	}
+	var cluster verda.Cluster
+	if err := json.Unmarshal([]byte(body), &cluster); err != nil {
+		return nil, fmt.Errorf("decode cluster: %w", err)
+	}
+
+	status := &HealthStatus{
+		Components:  make(map[string]string),
+		NodeStatus:  make(map[string]string),
+		LastChecked: time.Now(),
+	}
+	ready := 0
+	for _, n := range cluster.WorkerNodes {
+		name := n.Hostname
+		if name == "" {
+			name = n.ID
+		}
+		status.NodeStatus[name] = n.Status
+		if n.Status == verda.StatusRunning {
+			ready++
+		}
+	}
+	total := len(cluster.WorkerNodes)
+	status.Healthy = total > 0 && ready == total && cluster.Status == verda.StatusRunning
+	if status.Healthy {
+		status.Message = fmt.Sprintf("cluster running, %d/%d nodes ready", ready, total)
+	} else {
+		status.Message = fmt.Sprintf("cluster status=%s, %d/%d nodes ready", cluster.Status, ready, total)
+	}
+	return status, nil
+}
+
+// ListClusters returns every Verda cluster visible to the current credentials.
+func (p *VerdaInstantProvider) ListClusters(ctx context.Context) ([]ClusterInfo, error) {
+	if err := p.requireClient(); err != nil {
+		return nil, err
+	}
+	body, err := p.client.RunAPIWithContext(ctx, http.MethodGet, "/v1/clusters", "")
+	if err != nil {
+		return nil, err
+	}
+	var list []verda.Cluster
+	if err := json.Unmarshal([]byte(body), &list); err != nil {
+		return nil, fmt.Errorf("decode cluster list: %w", err)
+	}
+	out := make([]ClusterInfo, 0, len(list))
+	for i := range list {
+		out = append(out, *toClusterInfo(&list[i]))
+	}
+	return out, nil
+}
+
+// GetCluster fetches a single cluster by hostname (or ID).
+func (p *VerdaInstantProvider) GetCluster(ctx context.Context, clusterName string) (*ClusterInfo, error) {
+	if err := p.requireClient(); err != nil {
+		return nil, err
+	}
+	id, err := p.resolveClusterID(ctx, clusterName)
+	if err != nil {
+		return nil, err
+	}
+	body, err := p.client.RunAPIWithContext(ctx, http.MethodGet, "/v1/clusters/"+id, "")
+	if err != nil {
+		return nil, err
+	}
+	var cluster verda.Cluster
+	if err := json.Unmarshal([]byte(body), &cluster); err != nil {
+		return nil, fmt.Errorf("decode cluster: %w", err)
+	}
+	return toClusterInfo(&cluster), nil
+}
+
+// resolveClusterID maps a hostname or raw ID to a cluster ID. Verda's API keys
+// everything by UUID, but users specify clusters by name in clanker commands.
+func (p *VerdaInstantProvider) resolveClusterID(ctx context.Context, nameOrID string) (string, error) {
+	// Treat the input as a UUID if it looks like one.
+	if looksLikeUUID(nameOrID) {
+		return nameOrID, nil
+	}
+	return p.findClusterIDByHostname(ctx, nameOrID)
+}
+
+func (p *VerdaInstantProvider) findClusterIDByHostname(ctx context.Context, hostname string) (string, error) {
+	body, err := p.client.RunAPIWithContext(ctx, http.MethodGet, "/v1/clusters", "")
+	if err != nil {
+		return "", err
+	}
+	var list []verda.Cluster
+	if err := json.Unmarshal([]byte(body), &list); err != nil {
+		return "", fmt.Errorf("decode cluster list: %w", err)
+	}
+	for _, c := range list {
+		if strings.EqualFold(c.Hostname, hostname) {
+			return c.ID, nil
+		}
+	}
+	return "", &ErrClusterNotFound{ClusterName: hostname}
+}
+
+// pickKubernetesClusterImage selects a cluster OS image labelled as Kubernetes.
+func (p *VerdaInstantProvider) pickKubernetesClusterImage(ctx context.Context) (string, error) {
+	body, err := p.client.RunAPIWithContext(ctx, http.MethodGet, "/v1/images/cluster", "")
+	if err != nil {
+		return "", err
+	}
+	var images []verda.Image
+	if err := json.Unmarshal([]byte(body), &images); err != nil {
+		return "", fmt.Errorf("decode cluster images: %w", err)
+	}
+	// Prefer an image whose name/category hints at Kubernetes.
+	for _, img := range images {
+		joined := strings.ToLower(img.Name + " " + img.Category + " " + img.ImageType + " " + strings.Join(img.Details, " "))
+		if strings.Contains(joined, "kubernetes") || strings.Contains(joined, "k8s") {
+			return pickImageID(img), nil
+		}
+	}
+	// Fall back to the default image — cluster will come up without k8s baked
+	// in; caller is expected to configure a startup script.
+	for _, img := range images {
+		if img.IsDefault {
+			return pickImageID(img), nil
+		}
+	}
+	if len(images) > 0 {
+		return pickImageID(images[0]), nil
+	}
+	return "", fmt.Errorf("no cluster images available from Verda")
+}
+
+func pickImageID(img verda.Image) string {
+	if img.ID != "" {
+		return img.ID
+	}
+	return img.ImageType
+}
+
+func (p *VerdaInstantProvider) fetchRemoteKubeconfig(ctx context.Context, host string) (string, error) {
+	// Try root first, then ubuntu — Verda cluster nodes expose kubeconfig in
+	// both locations depending on the OS image.
+	candidates := []string{
+		"root@" + host + ":/root/.kube/config",
+		"ubuntu@" + host + ":/home/ubuntu/.kube/config",
+	}
+	var lastErr error
+	for _, target := range candidates {
+		out, err := p.scpRead(ctx, target)
+		if err == nil && strings.TrimSpace(out) != "" {
+			return out, nil
+		}
+		lastErr = err
+	}
+	return "", fmt.Errorf("failed to read kubeconfig from %s: %w", host, lastErr)
+}
+
+func (p *VerdaInstantProvider) scpRead(ctx context.Context, target string) (string, error) {
+	// Use `scp` piping to stdout via `cat`, avoiding temp files. Practically
+	// we invoke `ssh <host> cat <path>` since `scp - <remote:path>` has
+	// inconsistent support.
+	host, path := splitSCPTarget(target)
+	if host == "" || path == "" {
+		return "", fmt.Errorf("invalid scp target %s", target)
+	}
+
+	args := []string{
+		"-i", p.sshKeyPath,
+		"-o", "StrictHostKeyChecking=accept-new",
+		"-o", "ConnectTimeout=10",
+		host,
+		"cat " + path,
+	}
+	DebugLog(p.debug, "ssh", "%s", strings.Join(args, " "))
+
+	cmd := exec.CommandContext(ctx, "ssh", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("ssh %s: %w, stderr=%s", host, err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.String(), nil
+}
+
+func splitSCPTarget(target string) (host, path string) {
+	i := strings.Index(target, ":")
+	if i <= 0 {
+		return "", ""
+	}
+	return target[:i], target[i+1:]
+}
+
+// rewriteKubeconfigServer updates the `server:` URL to use the supplied host
+// so kubectl can reach the cluster from outside Verda's private network.
+func rewriteKubeconfigServer(kubeconfig, publicHost string) (string, error) {
+	var sb strings.Builder
+	for _, line := range strings.Split(kubeconfig, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "server:") {
+			u, err := url.Parse(strings.TrimSpace(strings.TrimPrefix(trimmed, "server:")))
+			if err == nil && u.Host != "" {
+				newHost := publicHost
+				if port := u.Port(); port != "" {
+					newHost = publicHost + ":" + port
+				} else {
+					newHost = publicHost + ":6443"
+				}
+				u.Host = newHost
+				indent := line[:len(line)-len(strings.TrimLeft(line, " \t"))]
+				sb.WriteString(indent + "server: " + u.String() + "\n")
+				continue
+			}
+		}
+		sb.WriteString(line + "\n")
+	}
+	out := sb.String()
+	if !strings.Contains(out, "server:") {
+		return "", fmt.Errorf("kubeconfig has no server entry to rewrite")
+	}
+	return out, nil
+}
+
+func firstPublicIP(c verda.Cluster) string {
+	for _, n := range c.WorkerNodes {
+		if n.PublicIP != "" {
+			return n.PublicIP
+		}
+	}
+	return c.IP
+}
+
+func toClusterInfo(c *verda.Cluster) *ClusterInfo {
+	if c == nil {
+		return nil
+	}
+	info := &ClusterInfo{
+		Name:              c.Hostname,
+		Type:              ClusterTypeVerdaInstant,
+		Status:            c.Status,
+		Endpoint:          firstPublicIP(*c),
+		Region:            c.Location,
+		KubernetesVersion: "",
+	}
+	if t, err := time.Parse(time.RFC3339, c.CreatedAt); err == nil {
+		info.CreatedAt = t
+	}
+	for _, n := range c.WorkerNodes {
+		role := "worker"
+		// The first worker node is conventionally the control-plane jump host.
+		if len(info.ControlPlaneNodes) == 0 {
+			role = "control-plane"
+		}
+		node := NodeInfo{
+			Name:       n.Hostname,
+			Role:       role,
+			Status:     n.Status,
+			InternalIP: n.PrivateIP,
+			ExternalIP: n.PublicIP,
+			InstanceID: n.ID,
+		}
+		if role == "control-plane" {
+			info.ControlPlaneNodes = append(info.ControlPlaneNodes, node)
+		} else {
+			info.WorkerNodes = append(info.WorkerNodes, node)
+		}
+	}
+	return info
+}
+
+func looksLikeUUID(s string) bool {
+	if len(s) != 36 {
+		return false
+	}
+	for i, r := range s {
+		switch i {
+		case 8, 13, 18, 23:
+			if r != '-' {
+				return false
+			}
+		default:
+			if !(r >= '0' && r <= '9') && !(r >= 'a' && r <= 'f') && !(r >= 'A' && r <= 'F') {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/internal/k8s/cluster/verda.go
+++ b/internal/k8s/cluster/verda.go
@@ -509,6 +509,9 @@ func toClusterInfo(c *verda.Cluster) *ClusterInfo {
 	return info
 }
 
+// looksLikeUUID reports whether s is a canonical lowercase Verda UUID. Callers
+// should lowercase inputs before calling so pasted uppercase IDs still match —
+// resolveClusterID does this.
 func looksLikeUUID(s string) bool {
 	if len(s) != 36 {
 		return false
@@ -520,7 +523,7 @@ func looksLikeUUID(s string) bool {
 				return false
 			}
 		default:
-			if !(r >= '0' && r <= '9') && !(r >= 'a' && r <= 'f') && !(r >= 'A' && r <= 'F') {
+			if !(r >= '0' && r <= '9') && !(r >= 'a' && r <= 'f') {
 				return false
 			}
 		}

--- a/internal/k8s/cluster/verda.go
+++ b/internal/k8s/cluster/verda.go
@@ -87,13 +87,20 @@ func (p *VerdaInstantProvider) Create(ctx context.Context, opts CreateOptions) (
 		return nil, &ErrInvalidConfiguration{Message: "verda-instant requires an ssh_key_id — set verda.default_ssh_key_id or pass KeyPairName"}
 	}
 
-	image, err := p.pickKubernetesClusterImage(ctx)
+	image, k8sLabelled, err := p.pickKubernetesClusterImage(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("resolve cluster image: %w", err)
 	}
+	if !k8sLabelled {
+		// Surface loudly — downstream GetKubeconfig will fail without k8s
+		// installed, so callers need a chance to abort or supply a startup
+		// script before we burn GPU hours.
+		DebugLog(true, "verda", "WARNING: no kubernetes-labelled cluster image found; falling back to image %q. Configure verda.default_startup_script_id to install k8s manually, or GetKubeconfig will fail.", image)
+	}
 
-	// Verda requires a shared_volume on every cluster create. Use a default SFS
-	// sized for working-set storage; caller can resize after provisioning.
+	// Verda requires a shared_volume on every cluster create. 100 GB is enough
+	// for working-set storage; users who need more can resize via
+	// `clanker verda action` or use `PUT /v1/volumes` with {action:"resize"}.
 	shared := verda.SharedVolumeDto{
 		Name: opts.Name + "-sfs",
 		Size: 100,
@@ -333,33 +340,38 @@ func (p *VerdaInstantProvider) findClusterIDByHostname(ctx context.Context, host
 }
 
 // pickKubernetesClusterImage selects a cluster OS image labelled as Kubernetes.
-func (p *VerdaInstantProvider) pickKubernetesClusterImage(ctx context.Context) (string, error) {
+// Returns (imageID, foundK8sLabel, error). `foundK8sLabel` is true when the
+// match was explicit (name/category/details hints at Kubernetes); false when
+// we fell back to the default image. Callers should surface a loud warning in
+// the fallback case because the cluster may provision without k8s baked in,
+// which makes GetKubeconfig fail opaquely later.
+func (p *VerdaInstantProvider) pickKubernetesClusterImage(ctx context.Context) (string, bool, error) {
 	body, err := p.client.RunAPIWithContext(ctx, http.MethodGet, "/v1/images/cluster", "")
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 	var images []verda.Image
 	if err := json.Unmarshal([]byte(body), &images); err != nil {
-		return "", fmt.Errorf("decode cluster images: %w", err)
+		return "", false, fmt.Errorf("decode cluster images: %w", err)
 	}
 	// Prefer an image whose name/category hints at Kubernetes.
 	for _, img := range images {
 		joined := strings.ToLower(img.Name + " " + img.Category + " " + img.ImageType + " " + strings.Join(img.Details, " "))
 		if strings.Contains(joined, "kubernetes") || strings.Contains(joined, "k8s") {
-			return pickImageID(img), nil
+			return pickImageID(img), true, nil
 		}
 	}
 	// Fall back to the default image — cluster will come up without k8s baked
 	// in; caller is expected to configure a startup script.
 	for _, img := range images {
 		if img.IsDefault {
-			return pickImageID(img), nil
+			return pickImageID(img), false, nil
 		}
 	}
 	if len(images) > 0 {
-		return pickImageID(images[0]), nil
+		return pickImageID(images[0]), false, nil
 	}
-	return "", fmt.Errorf("no cluster images available from Verda")
+	return "", false, fmt.Errorf("no cluster images available from Verda")
 }
 
 func pickImageID(img verda.Image) string {

--- a/internal/k8s/cluster/verda_test.go
+++ b/internal/k8s/cluster/verda_test.go
@@ -1,0 +1,124 @@
+package cluster
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLooksLikeUUID(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"valid lowercase", "4d04ce40-aed8-4bed-aa73-648e74b188c7", true},
+		{"valid all zeros", "00000000-0000-0000-0000-000000000000", true},
+		{"uppercase rejected", "4D04CE40-AED8-4BED-AA73-648E74B188C7", false},
+		{"too short", "4d04ce40-aed8-4bed-aa73-648e74b188", false},
+		{"too long", "4d04ce40-aed8-4bed-aa73-648e74b188c7aa", false},
+		{"bad separator", "4d04ce40_aed8_4bed_aa73_648e74b188c7", false},
+		{"non-hex chars", "zzzzzzzz-aed8-4bed-aa73-648e74b188c7", false},
+		{"hostname shaped", "my-host-01", false},
+		{"empty", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := looksLikeUUID(tc.in); got != tc.want {
+				t.Errorf("looksLikeUUID(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSplitSCPTarget(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantHost string
+		wantPath string
+	}{
+		{"root@1.2.3.4:/root/.kube/config", "root@1.2.3.4", "/root/.kube/config"},
+		{"ubuntu@host:/home/ubuntu/.kube/config", "ubuntu@host", "/home/ubuntu/.kube/config"},
+		{"bad-no-colon", "", ""},
+		{":nohost-only-path", "", ""},
+	}
+	for _, tc := range cases {
+		host, path := splitSCPTarget(tc.in)
+		if host != tc.wantHost || path != tc.wantPath {
+			t.Errorf("splitSCPTarget(%q) = (%q, %q), want (%q, %q)", tc.in, host, path, tc.wantHost, tc.wantPath)
+		}
+	}
+}
+
+func TestRewriteKubeconfigServerPreservesIndent(t *testing.T) {
+	kubeconfig := `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: AAAA==
+    server: https://10.0.0.1:6443
+  name: verda
+contexts:
+- context:
+    cluster: verda
+    user: admin
+  name: verda
+current-context: verda
+kind: Config
+users:
+- name: admin
+  user:
+    token: tok
+`
+	out, err := rewriteKubeconfigServer(kubeconfig, "1.2.3.4")
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	if !strings.Contains(out, "server: https://1.2.3.4:6443") {
+		t.Errorf("expected rewritten server URL to keep port 6443, got:\n%s", out)
+	}
+	// Original indentation (4 spaces before "server:") must be preserved so the
+	// resulting document parses as valid YAML.
+	if !strings.Contains(out, "    server: https://1.2.3.4:6443") {
+		t.Errorf("indentation not preserved, got:\n%s", out)
+	}
+}
+
+func TestRewriteKubeconfigServerKeepsCustomPort(t *testing.T) {
+	kubeconfig := `apiVersion: v1
+clusters:
+- cluster:
+    server: https://10.0.0.1:8443
+  name: verda
+kind: Config
+`
+	out, err := rewriteKubeconfigServer(kubeconfig, "1.2.3.4")
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	if !strings.Contains(out, "server: https://1.2.3.4:8443") {
+		t.Errorf("expected port 8443 to be preserved, got:\n%s", out)
+	}
+}
+
+func TestRewriteKubeconfigServerMissingServerErrors(t *testing.T) {
+	kubeconfig := `apiVersion: v1
+kind: Config
+users: []
+`
+	if _, err := rewriteKubeconfigServer(kubeconfig, "1.2.3.4"); err == nil {
+		t.Fatal("expected error when kubeconfig has no server line")
+	}
+}
+
+func TestVerdaInstantProviderType(t *testing.T) {
+	p := NewVerdaInstantProvider(VerdaInstantProviderOptions{})
+	if p.Type() != ClusterTypeVerdaInstant {
+		t.Errorf("Type() = %s, want %s", p.Type(), ClusterTypeVerdaInstant)
+	}
+}
+
+func TestVerdaInstantProviderRequireClient(t *testing.T) {
+	p := NewVerdaInstantProvider(VerdaInstantProviderOptions{})
+	if err := p.requireClient(); err == nil {
+		t.Fatal("expected error when client is nil")
+	}
+}

--- a/internal/maker/exec.go
+++ b/internal/maker/exec.go
@@ -235,6 +235,11 @@ type ExecOptions struct {
 	VercelAPIToken string
 	VercelTeamID   string
 
+	// Verda Cloud options (OAuth2 client credentials — both required)
+	VerdaClientID     string
+	VerdaClientSecret string
+	VerdaProjectID    string
+
 	CheckpointKey            string
 	DisableDurableCheckpoint bool
 

--- a/internal/maker/exec_verda.go
+++ b/internal/maker/exec_verda.go
@@ -1,0 +1,155 @@
+package maker
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/bgdnvk/clanker/internal/verda"
+)
+
+// ExecuteVerdaPlan executes a Verda Cloud maker plan. Commands take the form
+// ["verda-api", METHOD, "/v1/path", BODY?] and are dispatched to the shared
+// verda.Client which handles OAuth2, retries, and typed error decoding.
+//
+// Unlike the Vercel/Cloudflare/Hetzner executors, we don't shell out — Verda's
+// REST surface is well-defined and the verda package already owns the auth
+// plumbing, so embedding that client is cleaner than piping args through a
+// CLI. The tradeoff is that the maker plan format is Verda-specific (verb
+// "verda-api" rather than a standard CLI binary name) but the rules file
+// documents the shape clearly for the planner LLM.
+func ExecuteVerdaPlan(ctx context.Context, plan *Plan, opts ExecOptions) error {
+	if plan == nil {
+		return fmt.Errorf("nil plan")
+	}
+	if opts.Writer == nil {
+		return fmt.Errorf("missing output writer")
+	}
+	if opts.VerdaClientID == "" || opts.VerdaClientSecret == "" {
+		return fmt.Errorf("missing verda client_id / client_secret (set verda.client_id in ~/.clanker.yaml, export VERDA_CLIENT_ID / VERDA_CLIENT_SECRET, or run `verda auth login`)")
+	}
+
+	client, err := verda.NewClient(opts.VerdaClientID, opts.VerdaClientSecret, opts.VerdaProjectID, opts.Debug)
+	if err != nil {
+		return fmt.Errorf("build verda client: %w", err)
+	}
+
+	bindings := make(map[string]string)
+
+	for idx, cmdSpec := range plan.Commands {
+		args := make([]string, 0, len(cmdSpec.Args)+2)
+		args = append(args, cmdSpec.Args...)
+		args = applyPlanBindings(args, bindings)
+
+		if err := validateVerdaCommand(args, opts.Destroyer); err != nil {
+			return fmt.Errorf("command %d rejected: %w", idx+1, err)
+		}
+		if hasUnresolvedPlaceholders(args) {
+			return fmt.Errorf("command %d has unresolved placeholders after substitutions", idx+1)
+		}
+
+		method := strings.ToUpper(args[1])
+		path := args[2]
+		body := ""
+		if len(args) >= 4 {
+			body = args[3]
+		}
+
+		_, _ = fmt.Fprintf(opts.Writer, "[maker] running %d/%d: verda-api %s %s\n",
+			idx+1, len(plan.Commands), method, path)
+		if opts.Debug && body != "" {
+			_, _ = fmt.Fprintf(opts.Writer, "[maker]   body: %s\n", body)
+		}
+
+		out, err := client.RunAPIWithContext(ctx, method, path, body)
+		if err != nil {
+			return fmt.Errorf("verda command %d failed (%s %s): %w", idx+1, method, path, err)
+		}
+
+		if strings.TrimSpace(out) != "" {
+			_, _ = fmt.Fprintln(opts.Writer, out)
+		}
+		learnPlanBindingsFromProduces(cmdSpec.Produces, out, bindings)
+	}
+
+	return nil
+}
+
+// validateVerdaCommand rejects anything that isn't a well-formed verda-api
+// call. The planner prompt restricts args to exactly [verda-api, METHOD, path,
+// body?] and blocks CLI-style verbs like `verda vm create` that would require
+// shelling out. Destructive actions are gated behind --destroyer.
+func validateVerdaCommand(args []string, allowDestructive bool) error {
+	if len(args) < 3 {
+		return fmt.Errorf("verda plan commands require at least 3 args [verb, method, path], got %d", len(args))
+	}
+	if len(args) > 4 {
+		return fmt.Errorf("verda plan commands take at most 4 args [verb, method, path, body], got %d", len(args))
+	}
+
+	verb := strings.ToLower(strings.TrimSpace(args[0]))
+	if verb != "verda-api" {
+		return fmt.Errorf("only verda-api verb is supported (got %q); see the planner prompt for the schema", args[0])
+	}
+
+	method := strings.ToUpper(strings.TrimSpace(args[1]))
+	switch method {
+	case "GET", "POST", "PUT", "PATCH", "DELETE":
+	default:
+		return fmt.Errorf("unsupported HTTP method %q; use GET|POST|PUT|PATCH|DELETE", args[1])
+	}
+
+	path := args[2]
+	if !strings.HasPrefix(path, "/v1/") {
+		return fmt.Errorf("verda paths must start with /v1/, got %q", path)
+	}
+	// Reject shell metacharacters in every token so a compromised planner
+	// can't smuggle an injection into the path or body.
+	for _, a := range args {
+		if strings.ContainsAny(a, "\n\r") {
+			return fmt.Errorf("newlines in args are not allowed")
+		}
+	}
+
+	if !allowDestructive {
+		if isVerdaDestructive(method, path, verdaBodyOrEmpty(args)) {
+			return fmt.Errorf("destructive verda operation blocked (use --destroyer to allow): %s %s", method, path)
+		}
+	}
+
+	return nil
+}
+
+// verdaBodyOrEmpty returns the optional body arg or an empty string. Exists
+// so validators can inspect the body without every caller doing a len check.
+func verdaBodyOrEmpty(args []string) string {
+	if len(args) >= 4 {
+		return args[3]
+	}
+	return ""
+}
+
+// isVerdaDestructive returns true when a command would delete, discontinue,
+// hibernate, or force-stop resources. This is the gate for --destroyer mode.
+// We err on the side of caution — anything ambiguous is treated as
+// destructive so users always opt in explicitly.
+func isVerdaDestructive(method, path, body string) bool {
+	if method == "DELETE" {
+		return true
+	}
+	if method == "PUT" && (strings.HasPrefix(path, "/v1/instances") || strings.HasPrefix(path, "/v1/clusters") || strings.HasPrefix(path, "/v1/volumes")) {
+		lower := strings.ToLower(body)
+		for _, verb := range []string{
+			`"action":"delete"`,
+			`"action":"discontinue"`,
+			`"action":"force_shutdown"`,
+			`"action":"delete_stuck"`,
+			`"action":"hibernate"`,
+		} {
+			if strings.Contains(lower, strings.ReplaceAll(verb, " ", "")) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/maker/exec_verda_test.go
+++ b/internal/maker/exec_verda_test.go
@@ -1,0 +1,251 @@
+package maker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// withVerdaTestServer swaps the verda package baseURL for the test server's
+// URL. We can't import internal/verda's test hook from this package, so the
+// trick is to run the executor against a real httptest server that serves
+// /v1/oauth2/token and the target endpoints — verda.NewClient picks up the
+// configured baseURL via the package's exported const... actually the
+// internal baseURL is a var in the verda package so we need to set it via
+// a tiny test-only helper. We accomplish that via the public SetBaseURL()
+// shim added alongside these tests. If the shim is missing we skip.
+
+func TestValidateVerdaCommand_Shape(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		destroy bool
+		ok      bool
+	}{
+		{"too few args", []string{"verda-api", "GET"}, false, false},
+		{"too many args", []string{"verda-api", "GET", "/v1/balance", "", "extra"}, false, false},
+		{"wrong verb", []string{"verda", "GET", "/v1/balance"}, false, false},
+		{"bad method", []string{"verda-api", "QUERY", "/v1/balance", ""}, false, false},
+		{"bad path prefix", []string{"verda-api", "GET", "v1/balance", ""}, false, false},
+		{"newline in body", []string{"verda-api", "POST", "/v1/instances", "{\"hostname\":\"h\nevil\"}"}, false, false},
+		{"valid GET", []string{"verda-api", "GET", "/v1/balance", ""}, false, true},
+		{"valid POST with body", []string{"verda-api", "POST", "/v1/instances", `{"instance_type":"1H100.80S.22V"}`}, false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateVerdaCommand(tc.args, tc.destroy)
+			if tc.ok && err != nil {
+				t.Errorf("expected ok, got: %v", err)
+			}
+			if !tc.ok && err == nil {
+				t.Error("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestValidateVerdaCommand_DestructiveGate(t *testing.T) {
+	// DELETE is always destructive.
+	if err := validateVerdaCommand([]string{"verda-api", "DELETE", "/v1/volumes/abc", ""}, false); err == nil {
+		t.Error("DELETE should be blocked without destroyer")
+	}
+	if err := validateVerdaCommand([]string{"verda-api", "DELETE", "/v1/volumes/abc", ""}, true); err != nil {
+		t.Errorf("DELETE should pass with destroyer: %v", err)
+	}
+
+	// PUT /v1/instances with action=delete is destructive.
+	bodyDelete := `{"action":"delete","id":"abc"}`
+	if err := validateVerdaCommand([]string{"verda-api", "PUT", "/v1/instances", bodyDelete}, false); err == nil {
+		t.Error("PUT action=delete should be blocked without destroyer")
+	}
+	if err := validateVerdaCommand([]string{"verda-api", "PUT", "/v1/instances", bodyDelete}, true); err != nil {
+		t.Errorf("PUT action=delete should pass with destroyer: %v", err)
+	}
+
+	// PUT /v1/instances with action=start is NOT destructive.
+	bodyStart := `{"action":"start","id":"abc"}`
+	if err := validateVerdaCommand([]string{"verda-api", "PUT", "/v1/instances", bodyStart}, false); err != nil {
+		t.Errorf("PUT action=start should pass: %v", err)
+	}
+
+	// PUT /v1/clusters with action=discontinue is destructive.
+	bodyDiscontinue := `{"action":"discontinue","id":"abc"}`
+	if err := validateVerdaCommand([]string{"verda-api", "PUT", "/v1/clusters", bodyDiscontinue}, false); err == nil {
+		t.Error("PUT cluster action=discontinue should be blocked without destroyer")
+	}
+}
+
+func TestIsVerdaDestructive(t *testing.T) {
+	cases := []struct {
+		method, path, body string
+		want               bool
+	}{
+		{"GET", "/v1/instances", "", false},
+		{"POST", "/v1/instances", `{"instance_type":"1"}`, false},
+		{"PUT", "/v1/instances", `{"action":"start","id":"a"}`, false},
+		{"PUT", "/v1/instances", `{"action":"shutdown","id":"a"}`, false},
+		{"PUT", "/v1/instances", `{"action":"delete","id":"a"}`, true},
+		{"PUT", "/v1/instances", `{"action":"force_shutdown","id":"a"}`, true},
+		{"PUT", "/v1/instances", `{"action":"hibernate","id":"a"}`, true},
+		{"DELETE", "/v1/volumes/abc", "", true},
+		{"PUT", "/v1/clusters", `{"action":"discontinue","id":"a"}`, true},
+		{"PATCH", "/v1/container-deployments/foo", "{}", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			if got := isVerdaDestructive(tc.method, tc.path, tc.body); got != tc.want {
+				t.Errorf("isVerdaDestructive(%s %s) = %v, want %v", tc.method, tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExecuteVerdaPlan_EndToEnd(t *testing.T) {
+	var tokenCalls, balanceCalls, createCalls int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/oauth2/token", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&tokenCalls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "tok",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+			"scope":        "cloud-api-v1",
+		})
+	})
+	mux.HandleFunc("/v1/balance", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer tok" {
+			http.Error(w, "bad token", http.StatusUnauthorized)
+			return
+		}
+		atomic.AddInt32(&balanceCalls, 1)
+		_, _ = w.Write([]byte(`{"amount": 100, "currency": "usd"}`))
+	})
+	mux.HandleFunc("/v1/instances", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.NotFound(w, r)
+			return
+		}
+		atomic.AddInt32(&createCalls, 1)
+		// Echo the created instance id so binding capture exercises the
+		// `produces` JSONPath flow.
+		_, _ = w.Write([]byte(`{"id": "new-instance-uuid"}`))
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	// Redirect the verda package at the test server.
+	origBase := verdaTestBaseURL(t, ts.URL)
+	defer verdaTestBaseURL(t, origBase)
+
+	plan := &Plan{
+		Version:  CurrentPlanVersion,
+		Provider: "verda",
+		Commands: []Command{
+			{Args: []string{"verda-api", "GET", "/v1/balance", ""}, Reason: "check balance"},
+			{
+				Args:     []string{"verda-api", "POST", "/v1/instances", `{"instance_type":"1H100.80S.22V","image":"ubuntu","hostname":"h","description":"d","location_code":"FIN-01","ssh_key_ids":["k"]}`},
+				Reason:   "create instance",
+				Produces: map[string]string{"INSTANCE_ID": "$.id"},
+			},
+		},
+	}
+
+	var out bytes.Buffer
+	err := ExecuteVerdaPlan(context.Background(), plan, ExecOptions{
+		VerdaClientID:     "cid",
+		VerdaClientSecret: "secret",
+		VerdaProjectID:    "proj-1",
+		Writer:            &out,
+	})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	if atomic.LoadInt32(&tokenCalls) != 1 {
+		t.Errorf("expected 1 token fetch (cached between calls), got %d", tokenCalls)
+	}
+	if atomic.LoadInt32(&balanceCalls) != 1 {
+		t.Errorf("expected 1 balance call, got %d", balanceCalls)
+	}
+	if atomic.LoadInt32(&createCalls) != 1 {
+		t.Errorf("expected 1 create call, got %d", createCalls)
+	}
+	if !strings.Contains(out.String(), "verda-api GET /v1/balance") {
+		t.Errorf("expected progress line for balance call, got:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "verda-api POST /v1/instances") {
+		t.Errorf("expected progress line for create call, got:\n%s", out.String())
+	}
+}
+
+func TestExecuteVerdaPlan_BindingFlow(t *testing.T) {
+	// Smoke-test that a placeholder <INSTANCE_ID> emitted by the first
+	// command's `produces` is substituted into the second command before
+	// execution.
+	var lastBody string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/oauth2/token", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"access_token": "tok", "expires_in": 3600})
+	})
+	mux.HandleFunc("/v1/instances", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			_, _ = w.Write([]byte(`{"id": "abc-123"}`))
+		case http.MethodPut:
+			buf := new(bytes.Buffer)
+			_, _ = buf.ReadFrom(r.Body)
+			lastBody = buf.String()
+			_, _ = w.Write([]byte(`{"accepted": true}`))
+		}
+	})
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+	orig := verdaTestBaseURL(t, ts.URL)
+	defer verdaTestBaseURL(t, orig)
+
+	plan := &Plan{
+		Version:  CurrentPlanVersion,
+		Provider: "verda",
+		Commands: []Command{
+			{
+				Args:     []string{"verda-api", "POST", "/v1/instances", `{"instance_type":"1H100","image":"u","hostname":"h","description":"d","location_code":"FIN-01"}`},
+				Produces: map[string]string{"INSTANCE_ID": "$.id"},
+			},
+			{
+				Args: []string{"verda-api", "PUT", "/v1/instances", `{"action":"start","id":"<INSTANCE_ID>"}`},
+			},
+		},
+	}
+
+	var out bytes.Buffer
+	if err := ExecuteVerdaPlan(context.Background(), plan, ExecOptions{
+		VerdaClientID:     "cid",
+		VerdaClientSecret: "secret",
+		Writer:            &out,
+	}); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(lastBody, `"id":"abc-123"`) {
+		t.Errorf("placeholder not substituted; PUT body was %q", lastBody)
+	}
+}
+
+func TestExecuteVerdaPlan_MissingCreds(t *testing.T) {
+	plan := &Plan{Provider: "verda", Commands: []Command{
+		{Args: []string{"verda-api", "GET", "/v1/balance", ""}},
+	}}
+	var out bytes.Buffer
+	err := ExecuteVerdaPlan(context.Background(), plan, ExecOptions{Writer: &out})
+	if err == nil {
+		t.Fatal("expected error on missing creds")
+	}
+	if !strings.Contains(err.Error(), "client_id") {
+		t.Errorf("error should mention client_id: %v", err)
+	}
+}

--- a/internal/maker/verda_prompts.go
+++ b/internal/maker/verda_prompts.go
@@ -1,0 +1,173 @@
+package maker
+
+import "fmt"
+
+// VerdaPlanPrompt returns the Verda planner prompt without destroyer mode.
+func VerdaPlanPrompt(question string) string {
+	return VerdaPlanPromptWithMode(question, false)
+}
+
+// VerdaPlanPromptWithMode returns a Verda (ex-DataCrunch) maker plan prompt.
+// Unlike Vercel/Cloudflare whose maker plans shell out to a CLI, Verda plans
+// use a `verda-api` verb that the executor maps directly to REST calls via
+// the verda.Client. This avoids a hard dependency on the `verda` binary for
+// plan execution and reuses the OAuth2 token caching + retry behaviour we
+// already trust.
+func VerdaPlanPromptWithMode(question string, destroyer bool) string {
+	destructiveRule := "- Avoid any destructive operations (delete/discontinue/force_shutdown/delete_stuck)."
+	if destroyer {
+		destructiveRule = "- Destructive operations are allowed ONLY if the user explicitly asked for deletion."
+	}
+
+	return fmt.Sprintf(`You are an infrastructure maker planner for Verda Cloud (ex-DataCrunch), a European GPU/AI cloud.
+
+Your job: produce a concrete, minimal Verda REST API execution plan to satisfy the user request.
+
+Constraints:
+- Output ONLY valid JSON.
+- Use this schema exactly:
+{
+  "version": 1,
+  "createdAt": "RFC3339 timestamp",
+  "provider": "verda",
+  "question": "original user question",
+  "summary": "short summary of what will be created/changed",
+  "commands": [
+    {
+      "args": ["verda-api", "METHOD", "/v1/path", "{json-body-or-empty-string}"],
+      "reason": "why this command is needed",
+      "produces": {
+        "OPTIONAL_BINDING_NAME": "$.id"
+      }
+    }
+  ],
+  "notes": ["optional notes"]
+}
+
+Command verbs:
+- Use "verda-api" as the first arg for REST calls. Executor calls
+  verda.Client.RunAPIWithContext(ctx, METHOD, path, body) which handles
+  OAuth2 token acquisition, 429 backoff, and error decoding.
+- METHOD is one of: GET, POST, PUT, PATCH, DELETE.
+- The path must start with /v1/.
+- The body is a JSON string (use "" for GET/DELETE without body).
+- Every command args MUST start with "verda-api".
+- Do NOT include any non-verda programs (no aws/gcloud/az/curl/terraform/etc).
+- Do NOT include shell operators, pipes, redirects, or subshells.
+- Prefer idempotent operations where possible.
+
+Rules for commands:
+- The "commands" array MUST contain at least 1 command.
+- Provide args as an array of exactly 3 or 4 strings: [verb, method, path, body?].
+- If the user request is ambiguous or missing required details, output a DISCOVERY-ONLY plan:
+  - Still output a NON-EMPTY commands array.
+  - Use READ-ONLY GET commands to gather missing inputs (examples:
+    ["verda-api", "GET", "/v1/instance-types", ""],
+    ["verda-api", "GET", "/v1/locations", ""],
+    ["verda-api", "GET", "/v1/ssh-keys", ""]).
+
+%s
+
+Placeholders and bindings:
+- You MAY use placeholder tokens like "<INSTANCE_ID>" or "<SSH_KEY_ID>".
+- If you use ANY placeholder, ensure an earlier command includes "produces" mapping the field.
+- JSONPath for Verda responses: top-level arrays return [{id, ...}], details return {id, ...}. Use "$.id" for single-resource creates, "$[0].id" for first-in-array.
+
+Important Verda surface knowledge:
+- Creation calls (POST /v1/instances, /v1/clusters, /v1/volumes) require "location_code" (e.g. "FIN-01", "ICE-01"). Query GET /v1/locations if unknown.
+- Instance lifecycle actions go to PUT /v1/instances with body {"action": "start|shutdown|delete|hibernate|...", "id": "<uuid>"}.
+  Valid actions: boot, start, shutdown, force_shutdown, delete, discontinue, hibernate, configure_spot, delete_stuck, deploy, transfer.
+- Cluster actions go to PUT /v1/clusters with body {"action": "discontinue", "id": "<uuid>"}.
+- Volume creation needs a "type" enum (HDD, NVMe, HDD_Shared, NVMe_Shared, NVMe_Local_Storage, NVMe_Shared_Cluster, NVMe_OS_Cluster) plus size in GB.
+- Cluster creation requires a shared_volume {name, size} block even if small.
+- Serverless: POST /v1/container-deployments and /v1/job-deployments.
+
+Common Verda operations:
+
+Create a single GPU instance:
+{
+  "args": ["verda-api", "POST", "/v1/instances", "{\"instance_type\":\"1H100.80S.22V\",\"image\":\"ubuntu-22.04-cuda-12.4-docker\",\"hostname\":\"gpu-1\",\"description\":\"training box\",\"location_code\":\"FIN-01\",\"ssh_key_ids\":[\"<SSH_KEY_ID>\"]}"],
+  "reason": "Provision one H100 instance in Finland",
+  "produces": { "INSTANCE_ID": "$.id" }
+}
+
+Query running instances:
+{
+  "args": ["verda-api", "GET", "/v1/instances", ""],
+  "reason": "Discover current inventory"
+}
+
+Start an instance:
+{
+  "args": ["verda-api", "PUT", "/v1/instances", "{\"action\":\"start\",\"id\":\"<INSTANCE_ID>\"}"],
+  "reason": "Start the instance we just created"
+}
+
+Stop an instance:
+{
+  "args": ["verda-api", "PUT", "/v1/instances", "{\"action\":\"shutdown\",\"id\":\"<INSTANCE_ID>\"}"],
+  "reason": "Stop the instance (keeps billing per Verda policy; use delete to fully release)"
+}
+
+Delete an instance:
+{
+  "args": ["verda-api", "PUT", "/v1/instances", "{\"action\":\"delete\",\"id\":\"<INSTANCE_ID>\"}"],
+  "reason": "Delete the instance and stop billing"
+}
+
+Create a volume:
+{
+  "args": ["verda-api", "POST", "/v1/volumes", "{\"type\":\"NVMe\",\"location_code\":\"FIN-01\",\"size\":500,\"name\":\"dataset-disk\"}"],
+  "reason": "Create a 500 GB NVMe volume for dataset storage",
+  "produces": { "VOLUME_ID": "$.id" }
+}
+
+Attach a volume to an existing instance:
+{
+  "args": ["verda-api", "PUT", "/v1/volumes", "{\"action\":\"attach\",\"id\":\"<VOLUME_ID>\",\"instance_id\":\"<INSTANCE_ID>\"}"],
+  "reason": "Attach dataset volume to training instance"
+}
+
+Create an SSH key:
+{
+  "args": ["verda-api", "POST", "/v1/ssh-keys", "{\"name\":\"clanker-key\",\"key\":\"ssh-ed25519 AAAA... user@host\"}"],
+  "reason": "Register our public key so we can ssh into instances",
+  "produces": { "SSH_KEY_ID": "$.id" }
+}
+
+Create a startup script:
+{
+  "args": ["verda-api", "POST", "/v1/scripts", "{\"name\":\"install-deps\",\"script\":\"#!/bin/bash\\napt-get update && apt-get install -y python3-pip\"}"],
+  "reason": "Define first-boot provisioning commands",
+  "produces": { "SCRIPT_ID": "$.id" }
+}
+
+Create a GPU cluster with Kubernetes orchestrator:
+{
+  "args": ["verda-api", "POST", "/v1/clusters", "{\"cluster_type\":\"8H100\",\"image\":\"ubuntu-22.04-cuda-kubernetes\",\"hostname\":\"train-cluster\",\"description\":\"multi-node training\",\"location_code\":\"FIN-01\",\"ssh_key_ids\":[\"<SSH_KEY_ID>\"],\"shared_volume\":{\"name\":\"train-sfs\",\"size\":500}}"],
+  "reason": "Create an 8x H100 instant cluster",
+  "produces": { "CLUSTER_ID": "$.id" }
+}
+
+Discontinue a cluster (teardown):
+{
+  "args": ["verda-api", "PUT", "/v1/clusters", "{\"action\":\"discontinue\",\"id\":\"<CLUSTER_ID>\"}"],
+  "reason": "Tear down the cluster and stop billing"
+}
+
+Check current balance before committing:
+{
+  "args": ["verda-api", "GET", "/v1/balance", ""],
+  "reason": "Confirm project has enough credit before provisioning GPUs"
+}
+
+List instance types (unauth'd, no credit needed):
+{
+  "args": ["verda-api", "GET", "/v1/instance-types", ""],
+  "reason": "Enumerate available GPU SKUs with pricing"
+}
+
+User request: %s
+
+Output only the JSON plan. Do NOT wrap in markdown code fences.`, destructiveRule, question)
+}

--- a/internal/maker/verda_testhelpers_test.go
+++ b/internal/maker/verda_testhelpers_test.go
@@ -1,0 +1,16 @@
+package maker
+
+import (
+	"testing"
+
+	"github.com/bgdnvk/clanker/internal/verda"
+)
+
+// verdaTestBaseURL redirects the verda package's REST base URL to the given
+// test-server URL and returns the previous value so the caller can restore
+// it via a defer. Wraps verda.SetBaseURLForTest to keep test files in this
+// package from importing verda directly.
+func verdaTestBaseURL(t *testing.T, url string) string {
+	t.Helper()
+	return verda.SetBaseURLForTest(url)
+}

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -561,6 +561,7 @@ func ApplyLLMClassification(ctx *ServiceContext, llmService string) {
 		ctx.DigitalOcean = false
 		ctx.Hetzner = false
 		ctx.Vercel = false
+		ctx.Verda = false
 		ctx.IAM = false
 	case "k8s":
 		ctx.K8s = true
@@ -570,6 +571,7 @@ func ApplyLLMClassification(ctx *ServiceContext, llmService string) {
 		ctx.DigitalOcean = false
 		ctx.Hetzner = false
 		ctx.Vercel = false
+		ctx.Verda = false
 		ctx.IAM = false
 	case "gcp":
 		ctx.GCP = true
@@ -579,6 +581,7 @@ func ApplyLLMClassification(ctx *ServiceContext, llmService string) {
 		ctx.DigitalOcean = false
 		ctx.Hetzner = false
 		ctx.Vercel = false
+		ctx.Verda = false
 		ctx.IAM = false
 	case "azure":
 		ctx.Azure = true
@@ -589,6 +592,7 @@ func ApplyLLMClassification(ctx *ServiceContext, llmService string) {
 		ctx.DigitalOcean = false
 		ctx.Hetzner = false
 		ctx.Vercel = false
+		ctx.Verda = false
 		ctx.IAM = false
 	case "digitalocean":
 		ctx.DigitalOcean = true
@@ -599,6 +603,7 @@ func ApplyLLMClassification(ctx *ServiceContext, llmService string) {
 		ctx.Azure = false
 		ctx.Hetzner = false
 		ctx.Vercel = false
+		ctx.Verda = false
 		ctx.IAM = false
 	case "hetzner":
 		ctx.Hetzner = true
@@ -609,6 +614,7 @@ func ApplyLLMClassification(ctx *ServiceContext, llmService string) {
 		ctx.Azure = false
 		ctx.DigitalOcean = false
 		ctx.Vercel = false
+		ctx.Verda = false
 		ctx.IAM = false
 	case "vercel":
 		ctx.Vercel = true
@@ -653,6 +659,7 @@ func ApplyLLMClassification(ctx *ServiceContext, llmService string) {
 		ctx.DigitalOcean = false
 		ctx.Hetzner = false
 		ctx.Vercel = false
+		ctx.Verda = false
 	case "terraform":
 		ctx.Terraform = true
 		ctx.Cloudflare = false

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -25,6 +25,7 @@ type ServiceContext struct {
 	DigitalOcean bool
 	Hetzner      bool
 	Vercel       bool
+	Verda        bool
 	IAM          bool
 	Code         bool
 }
@@ -41,7 +42,7 @@ type Classification struct {
 func DefaultInfraProvider() string {
 	p := strings.ToLower(strings.TrimSpace(viper.GetString("infra.default_provider")))
 	switch p {
-	case "aws", "gcp", "azure", "cloudflare", "digitalocean", "hetzner", "vercel":
+	case "aws", "gcp", "azure", "cloudflare", "digitalocean", "hetzner", "vercel", "verda":
 		return p
 	default:
 		return "aws"
@@ -59,6 +60,7 @@ func applyConfiguredDefaultContext(ctx *ServiceContext) {
 	ctx.DigitalOcean = false
 	ctx.Hetzner = false
 	ctx.Vercel = false
+	ctx.Verda = false
 	ctx.IAM = false
 
 	switch DefaultInfraProvider() {
@@ -74,6 +76,8 @@ func applyConfiguredDefaultContext(ctx *ServiceContext) {
 		ctx.Hetzner = true
 	case "vercel":
 		ctx.Vercel = true
+	case "verda":
+		ctx.Verda = true
 	default:
 		ctx.AWS = true
 		ctx.GitHub = true
@@ -261,6 +265,21 @@ func InferContext(question string) ServiceContext {
 		"edge middleware",
 	}
 
+	verdaKeywords := []string{
+		// Match explicit Verda mentions + DataCrunch (the old brand) + Verda-
+		// specific resource nouns. GPU model codes alone (h100, a100, etc.) are
+		// intentionally NOT included — they also apply to AWS p4/p5 families.
+		"verda",
+		"datacrunch",
+		"verda cloud",
+		"verda cluster",
+		"verda instance",
+		"verda gpu",
+		"instant cluster",
+		"verda volume",
+		"verda deployment",
+	}
+
 	iamKeywords := []string{
 		// IAM specific queries
 		"iam role", "iam roles", "iam policy", "iam policies",
@@ -351,6 +370,13 @@ func InferContext(question string) ServiceContext {
 		}
 	}
 
+	for _, keyword := range verdaKeywords {
+		if contains(questionLower, keyword) {
+			ctx.Verda = true
+			break
+		}
+	}
+
 	// Check for IAM-specific queries (takes precedence over general AWS)
 	for _, keyword := range iamKeywords {
 		if contains(questionLower, keyword) {
@@ -361,7 +387,7 @@ func InferContext(question string) ServiceContext {
 
 	// Default to the configured provider if nothing is detected.
 	// AWS keeps GitHub enabled for backward compatibility.
-	if !ctx.AWS && !ctx.GitHub && !ctx.Terraform && !ctx.K8s && !ctx.GCP && !ctx.Azure && !ctx.Cloudflare && !ctx.DigitalOcean && !ctx.Hetzner && !ctx.Vercel && !ctx.IAM {
+	if !ctx.AWS && !ctx.GitHub && !ctx.Terraform && !ctx.K8s && !ctx.GCP && !ctx.Azure && !ctx.Cloudflare && !ctx.DigitalOcean && !ctx.Hetzner && !ctx.Vercel && !ctx.Verda && !ctx.IAM {
 		applyConfiguredDefaultContext(&ctx)
 	}
 
@@ -385,6 +411,7 @@ Available services:
 - digitalocean: Digital Ocean (Droplets, DOKS, Managed Databases, Spaces, App Platform, Load Balancers, VPCs, etc.)
 - hetzner: Hetzner Cloud (Servers, Load Balancers, Volumes, Networks, Firewalls, Floating IPs, Primary IPs, etc.)
 - vercel: Vercel projects, deployments, domains, env vars, edge functions, KV/Blob/Postgres/Edge Config, analytics
+- verda: Verda Cloud / DataCrunch GPU instances, Instant Clusters, volumes (incl. SFS), serverless containers & jobs, SSH keys, startup scripts, container registry
 - github: GitHub repositories, PRs, issues, actions, workflows
 - terraform: Infrastructure as code, Terraform plans, state, modules
 - general: General questions not specific to any cloud platform
@@ -397,11 +424,12 @@ IMPORTANT RULES:
 5. Only classify as "digitalocean" if the query EXPLICITLY mentions Digital Ocean, doctl, droplets, DOKS, or Digital Ocean-specific products
 6. Only classify as "hetzner" if the query EXPLICITLY mentions Hetzner, hcloud, or Hetzner-specific products
 7. Only classify as "vercel" if the query EXPLICITLY mentions Vercel, vercel.app, a Vercel deployment/project, or Vercel-specific products (Edge Config, Vercel KV / Blob / Postgres)
-8. If uncertain, classify as "%s" (the configured default cloud provider)
+8. Only classify as "verda" if the query EXPLICITLY mentions Verda, DataCrunch, Verda clusters/instances, or an Instant Cluster (Verda's managed cluster product)
+9. If uncertain, classify as "%s" (the configured default cloud provider)
 
 Respond with ONLY a JSON object:
 {
-	"service": "cloudflare|aws|iam|k8s|gcp|azure|digitalocean|hetzner|vercel|github|terraform|general",
+	"service": "cloudflare|aws|iam|k8s|gcp|azure|digitalocean|hetzner|vercel|verda|github|terraform|general",
     "confidence": "high|medium|low",
     "reason": "brief explanation of why this classification"
 }`, question, defaultProvider, defaultProvider)
@@ -503,6 +531,9 @@ func NeedsLLMClassification(ctx ServiceContext) bool {
 	if ctx.Vercel {
 		count++
 	}
+	if ctx.Verda {
+		count++
+	}
 	if ctx.IAM {
 		count++
 	}
@@ -513,8 +544,9 @@ func NeedsLLMClassification(ctx ServiceContext) bool {
 	// 3. Digital Ocean was inferred (verify it's actually DO-related)
 	// 4. Hetzner was inferred (verify it's actually Hetzner-related)
 	// 5. Vercel was inferred (verify it's actually Vercel-related)
-	// 6. IAM was inferred (verify it's actually IAM-related for disambiguation)
-	return count > 1 || ctx.Cloudflare || ctx.DigitalOcean || ctx.Hetzner || ctx.Vercel || ctx.IAM
+	// 6. Verda was inferred (verify it's actually Verda-related)
+	// 7. IAM was inferred (verify it's actually IAM-related for disambiguation)
+	return count > 1 || ctx.Cloudflare || ctx.DigitalOcean || ctx.Hetzner || ctx.Vercel || ctx.Verda || ctx.IAM
 }
 
 // ApplyLLMClassification updates the ServiceContext based on LLM classification result
@@ -587,6 +619,18 @@ func ApplyLLMClassification(ctx *ServiceContext, llmService string) {
 		ctx.Azure = false
 		ctx.DigitalOcean = false
 		ctx.Hetzner = false
+		ctx.Verda = false
+		ctx.IAM = false
+	case "verda":
+		ctx.Verda = true
+		ctx.AWS = false
+		ctx.GCP = false
+		ctx.Cloudflare = false
+		ctx.K8s = false
+		ctx.Azure = false
+		ctx.DigitalOcean = false
+		ctx.Hetzner = false
+		ctx.Vercel = false
 		ctx.IAM = false
 	case "aws":
 		ctx.AWS = true
@@ -597,6 +641,7 @@ func ApplyLLMClassification(ctx *ServiceContext, llmService string) {
 		ctx.DigitalOcean = false
 		ctx.Hetzner = false
 		ctx.Vercel = false
+		ctx.Verda = false
 		ctx.IAM = false
 	case "iam":
 		ctx.IAM = true
@@ -614,12 +659,14 @@ func ApplyLLMClassification(ctx *ServiceContext, llmService string) {
 		ctx.DigitalOcean = false
 		ctx.Hetzner = false
 		ctx.Vercel = false
+		ctx.Verda = false
 	case "github":
 		ctx.GitHub = true
 		ctx.Cloudflare = false
 		ctx.DigitalOcean = false
 		ctx.Hetzner = false
 		ctx.Vercel = false
+		ctx.Verda = false
 	default:
 		// "general" - default to the configured infrastructure provider
 		// Only zero cloud provider flags, preserving GitHub/Terraform/K8s context
@@ -627,6 +674,7 @@ func ApplyLLMClassification(ctx *ServiceContext, llmService string) {
 		ctx.DigitalOcean = false
 		ctx.Hetzner = false
 		ctx.Vercel = false
+		ctx.Verda = false
 		ctx.Azure = false
 		ctx.GCP = false
 		ctx.IAM = false
@@ -643,6 +691,8 @@ func ApplyLLMClassification(ctx *ServiceContext, llmService string) {
 			ctx.Hetzner = true
 		case "vercel":
 			ctx.Vercel = true
+		case "verda":
+			ctx.Verda = true
 		default:
 			ctx.AWS = true
 			ctx.GitHub = true

--- a/internal/routing/routing_test.go
+++ b/internal/routing/routing_test.go
@@ -445,3 +445,59 @@ func TestContains(t *testing.T) {
 		})
 	}
 }
+
+func TestInferContext_VerdaExplicit(t *testing.T) {
+	useDefaultProvider(t, "")
+
+	tests := []string{
+		"list my verda instances",
+		"how much am I spending on verda cloud",
+		"any datacrunch clusters running",
+		"show me the verda gpu usage",
+		"spin up an instant cluster on verda",
+	}
+	for _, q := range tests {
+		t.Run(q, func(t *testing.T) {
+			ctx := InferContext(q)
+			if !ctx.Verda {
+				t.Errorf("expected Verda=true for %q", q)
+			}
+		})
+	}
+}
+
+func TestInferContext_VerdaDefaultProvider(t *testing.T) {
+	useDefaultProvider(t, "verda")
+	// Use a query with no provider/module keywords so the default-provider
+	// fallback at the end of InferContext fires.
+	ctx := InferContext("what is running right now?")
+	if !ctx.Verda {
+		t.Error("generic discovery should activate Verda when it's the default provider")
+	}
+	if ctx.AWS {
+		t.Error("AWS should not be activated when verda is the default")
+	}
+}
+
+func TestInferContext_VerdaNoFalsePositive(t *testing.T) {
+	useDefaultProvider(t, "")
+	// "gpu" alone is not a Verda signal (AWS p4/p5/g5 also have GPUs).
+	ctx := InferContext("list my gpu instances on aws")
+	if ctx.Verda {
+		t.Error("bare 'gpu' + aws should not trigger Verda routing")
+	}
+}
+
+func TestApplyLLMClassification_Verda(t *testing.T) {
+	useDefaultProvider(t, "")
+	ctx := ServiceContext{AWS: true, Cloudflare: true, DigitalOcean: true, Hetzner: true, Vercel: true, IAM: true}
+	ApplyLLMClassification(&ctx, "verda")
+	if !ctx.Verda {
+		t.Error("Verda should be set")
+	}
+	// Per the existing ApplyLLMClassification convention, the Verda case
+	// clears cloud providers + IAM but preserves GitHub/Terraform.
+	if ctx.AWS || ctx.Cloudflare || ctx.DigitalOcean || ctx.Hetzner || ctx.Vercel || ctx.IAM {
+		t.Error("other cloud providers should be cleared when LLM picks verda")
+	}
+}

--- a/internal/routing/routing_test.go
+++ b/internal/routing/routing_test.go
@@ -488,6 +488,21 @@ func TestInferContext_VerdaNoFalsePositive(t *testing.T) {
 	}
 }
 
+func TestApplyLLMClassification_OtherProvidersClearVerda(t *testing.T) {
+	useDefaultProvider(t, "")
+	// Each sibling provider case should clear Verda so a keyword-inferred Verda
+	// doesn't leak into an LLM-picked different provider.
+	for _, svc := range []string{"cloudflare", "k8s", "gcp", "azure", "digitalocean", "hetzner", "vercel", "aws", "iam"} {
+		t.Run(svc, func(t *testing.T) {
+			ctx := ServiceContext{Verda: true}
+			ApplyLLMClassification(&ctx, svc)
+			if ctx.Verda {
+				t.Errorf("Verda should be cleared when LLM picks %s", svc)
+			}
+		})
+	}
+}
+
 func TestApplyLLMClassification_Verda(t *testing.T) {
 	useDefaultProvider(t, "")
 	ctx := ServiceContext{AWS: true, Cloudflare: true, DigitalOcean: true, Hetzner: true, Vercel: true, IAM: true}

--- a/internal/verda/client.go
+++ b/internal/verda/client.go
@@ -49,6 +49,16 @@ const BaseURL = "https://api.verda.com"
 // When empty, the production BaseURL is used.
 var baseURLForTest = ""
 
+// SetBaseURLForTest exposes the test-only base URL override to external test
+// packages (e.g. internal/maker/exec_verda_test.go that need to run the full
+// executor against an httptest server). Returns the previous value so tests
+// can restore on cleanup. Never call from production code.
+func SetBaseURLForTest(url string) string {
+	prev := baseURLForTest
+	baseURLForTest = url
+	return prev
+}
+
 func effectiveBaseURL() string {
 	if baseURLForTest != "" {
 		return baseURLForTest

--- a/internal/verda/client.go
+++ b/internal/verda/client.go
@@ -513,6 +513,56 @@ func isRetryableNetError(err error) bool {
 		strings.Contains(s, "temporarily unavailable")
 }
 
+// ResolveInstanceID returns the Verda instance UUID for the given input. If
+// `nameOrID` already looks like a UUID it's returned verbatim (lowercased).
+// Otherwise we list instances and match by hostname. Used by CLI commands so
+// users can pass a friendly hostname where an ID is expected.
+func (c *Client) ResolveInstanceID(ctx context.Context, nameOrID string) (string, error) {
+	trimmed := strings.TrimSpace(nameOrID)
+	if trimmed == "" {
+		return "", fmt.Errorf("empty instance identifier")
+	}
+	lowered := strings.ToLower(trimmed)
+	if looksLikeUUIDString(lowered) {
+		return lowered, nil
+	}
+	body, err := c.RunAPIWithContext(ctx, http.MethodGet, "/v1/instances", "")
+	if err != nil {
+		return "", err
+	}
+	var list []Instance
+	if err := json.Unmarshal([]byte(body), &list); err != nil {
+		return "", fmt.Errorf("decode instances: %w", err)
+	}
+	for _, inst := range list {
+		if strings.EqualFold(inst.Hostname, trimmed) || inst.ID == trimmed {
+			return inst.ID, nil
+		}
+	}
+	return "", fmt.Errorf("no verda instance found for %q (tried hostname and ID match)", nameOrID)
+}
+
+// looksLikeUUIDString is the package-private mirror of the k8s cluster provider
+// helper — kept here so CLI paths don't reach across packages just for this.
+func looksLikeUUIDString(s string) bool {
+	if len(s) != 36 {
+		return false
+	}
+	for i, r := range s {
+		switch i {
+		case 8, 13, 18, 23:
+			if r != '-' {
+				return false
+			}
+		default:
+			if !(r >= '0' && r <= '9') && !(r >= 'a' && r <= 'f') {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 // DecodeActionResults decodes a 207 Multi-Status body from PUT /v1/instances.
 // When the Verda API succeeds uniformly it returns 202 with a plain JSON body;
 // a partial failure comes back as an array of ActionResult entries.
@@ -584,6 +634,8 @@ func (c *Client) GetRelevantContext(ctx context.Context, question string) (strin
 		{name: "Volumes", path: "/v1/volumes", keys: []string{"volume", "disk", "storage", "sfs", "shared filesystem", "nvme", "hdd"}},
 		{name: "SSHKeys", path: "/v1/ssh-keys", keys: []string{"ssh", "key", "access"}},
 		{name: "Scripts", path: "/v1/scripts?pageSize=25", keys: []string{"script", "startup", "cloud-init"}},
+		{name: "ContainerDeployments", path: "/v1/container-deployments", keys: []string{"container", "serverless", "inference", "endpoint", "replica", "scale"}},
+		{name: "JobDeployments", path: "/v1/job-deployments", keys: []string{"job", "batch", "queue", "serverless", "scaled"}},
 		{name: "Balance", path: "/v1/balance", keys: []string{"balance", "credit", "cost", "bill", "spend", "afford"}, always: true},
 		{name: "Locations", path: "/v1/locations", keys: []string{"location", "region", "datacenter", "availability"}},
 	}

--- a/internal/verda/client.go
+++ b/internal/verda/client.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -21,6 +22,25 @@ import (
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v3"
 )
+
+// ErrCLINotInstalled is returned by RunVerdaCLI* when the `verda` binary is
+// missing from PATH. Typed so callers can surface a clear, one-shot error
+// instead of the generic exec failure and can branch with errors.Is.
+var ErrCLINotInstalled = errors.New("verda CLI not installed")
+
+// IsCLINotInstalled reports whether err indicates the verda binary is missing.
+// Shorthand for `errors.Is(err, ErrCLINotInstalled)` so call sites don't need
+// to import errors explicitly.
+func IsCLINotInstalled(err error) bool { return errors.Is(err, ErrCLINotInstalled) }
+
+// CLIInstalled reports whether the `verda` binary is reachable on PATH.
+// Fast (just a lookpath) so callers can branch UX eagerly — e.g., to hide
+// a "login with verda CLI" hint when the binary isn't present but the
+// REST credentials are configured and usable.
+func CLIInstalled() bool {
+	_, err := exec.LookPath("verda")
+	return err == nil
+}
 
 // BaseURL is the Verda API base; the `/v1` prefix is part of every path we call.
 const BaseURL = "https://api.verda.com"
@@ -590,7 +610,7 @@ func (c *Client) RunVerdaCLI(args ...string) (string, error) {
 // needing a logged-in profile.
 func (c *Client) RunVerdaCLIWithContext(ctx context.Context, args ...string) (string, error) {
 	if _, err := exec.LookPath("verda"); err != nil {
-		return "", fmt.Errorf("verda CLI not found in PATH (install from https://docs.verda.com/cli/)")
+		return "", fmt.Errorf("%w — install it from https://docs.verda.com/cli/ (brew install verda-cloud/tap/verda-cli), or configure client_id / client_secret directly in ~/.clanker.yaml and use the REST paths instead", ErrCLINotInstalled)
 	}
 
 	fullArgs := append([]string{"--agent"}, args...)

--- a/internal/verda/client.go
+++ b/internal/verda/client.go
@@ -1,0 +1,662 @@
+// Package verda provides a client for the Verda Cloud REST API and the
+// `verda` CLI. Verda (ex-DataCrunch) is a European GPU/AI cloud. The package
+// mirrors the shape of internal/vercel so wiring into cmd/, routing, ask-mode,
+// and the desktop backend stays uniform.
+package verda
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
+)
+
+// BaseURL is the Verda API base; the `/v1` prefix is part of every path we call.
+const BaseURL = "https://api.verda.com"
+
+// baseURLForTest lets tests redirect API + token calls at an httptest server.
+// When empty, the production BaseURL is used.
+var baseURLForTest = ""
+
+func effectiveBaseURL() string {
+	if baseURLForTest != "" {
+		return baseURLForTest
+	}
+	return BaseURL
+}
+
+// Client wraps the Verda REST API (OAuth2 Client Credentials) and the official
+// `verda` CLI. A single client is safe to share across goroutines — the token
+// cache is mutex-protected.
+type Client struct {
+	clientID     string
+	clientSecret string
+	projectID    string
+	debug        bool
+	httpClient   *http.Client
+
+	mu           sync.Mutex
+	accessToken  string
+	refreshToken string
+	tokenExpiry  time.Time
+}
+
+// ResolveClientID returns the Verda client ID.
+// Resolution order: `verda.client_id` viper key → VERDA_CLIENT_ID env →
+// parsed ~/.verda/credentials.
+func ResolveClientID() string {
+	if v := strings.TrimSpace(viper.GetString("verda.client_id")); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(os.Getenv("VERDA_CLIENT_ID")); v != "" {
+		return v
+	}
+	if v, _ := readVerdaCredentials(); v.ClientID != "" {
+		return v.ClientID
+	}
+	return ""
+}
+
+// ResolveClientSecret returns the Verda client secret.
+// Resolution order mirrors ResolveClientID.
+func ResolveClientSecret() string {
+	if v := strings.TrimSpace(viper.GetString("verda.client_secret")); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(os.Getenv("VERDA_CLIENT_SECRET")); v != "" {
+		return v
+	}
+	if v, _ := readVerdaCredentials(); v.ClientSecret != "" {
+		return v.ClientSecret
+	}
+	return ""
+}
+
+// ResolveProjectID returns the Verda project ID (used as conversation scope).
+// Resolution order: `verda.default_project_id` → VERDA_PROJECT_ID → empty.
+func ResolveProjectID() string {
+	if v := strings.TrimSpace(viper.GetString("verda.default_project_id")); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(os.Getenv("VERDA_PROJECT_ID")); v != "" {
+		return v
+	}
+	return ""
+}
+
+// ResolveDefaultLocation returns the configured default Verda location code
+// (e.g. "FIN-01"). Used by create-flow helpers when the user doesn't pass --location.
+func ResolveDefaultLocation() string {
+	return strings.TrimSpace(viper.GetString("verda.default_location"))
+}
+
+// ResolveDefaultSSHKeyID returns the configured default Verda SSH key UUID.
+// Used by `clanker verda deploy` and the verda-instant k8s cluster provider.
+func ResolveDefaultSSHKeyID() string {
+	return strings.TrimSpace(viper.GetString("verda.default_ssh_key_id"))
+}
+
+// ResolveSSHKeyPath returns the local private-key path used when pulling
+// kubeconfig off a Verda Instant Cluster's head node. Defaults to
+// ~/.ssh/id_ed25519 if not configured.
+func ResolveSSHKeyPath() string {
+	if v := strings.TrimSpace(viper.GetString("verda.ssh_key_path")); v != "" {
+		return expandHome(v)
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(home, ".ssh", "id_ed25519")
+	}
+	return ""
+}
+
+// verdaCredsFile mirrors the minimum fields we care about in ~/.verda/credentials.
+// The file format isn't officially documented; the Verda CLI uses a YAML-ish layout.
+// We tolerate both YAML and JSON and fall through gracefully when neither parses.
+type verdaCredsFile struct {
+	ClientID     string `yaml:"client_id" json:"client_id"`
+	ClientSecret string `yaml:"client_secret" json:"client_secret"`
+	// The official CLI uses named profiles; we pick the active one when present.
+	ActiveProfile string                     `yaml:"active_profile" json:"active_profile"`
+	Profiles      map[string]verdaCredsEntry `yaml:"profiles" json:"profiles"`
+}
+
+type verdaCredsEntry struct {
+	ClientID     string `yaml:"client_id" json:"client_id"`
+	ClientSecret string `yaml:"client_secret" json:"client_secret"`
+}
+
+// readVerdaCredentials parses ~/.verda/credentials in either YAML or JSON form.
+// Returns the effective client_id / client_secret pair, preferring the active
+// profile if the file uses the multi-profile layout.
+func readVerdaCredentials() (verdaCredsEntry, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return verdaCredsEntry{}, err
+	}
+	path := filepath.Join(home, ".verda", "credentials")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return verdaCredsEntry{}, err
+	}
+
+	// Try YAML first (the Verda CLI's native format).
+	var y verdaCredsFile
+	if err := yaml.Unmarshal(data, &y); err == nil {
+		if entry, ok := activeProfile(y); ok {
+			return entry, nil
+		}
+	}
+
+	// Fallback: JSON.
+	var j verdaCredsFile
+	if err := json.Unmarshal(data, &j); err == nil {
+		if entry, ok := activeProfile(j); ok {
+			return entry, nil
+		}
+	}
+
+	return verdaCredsEntry{}, fmt.Errorf("could not parse %s", path)
+}
+
+func activeProfile(f verdaCredsFile) (verdaCredsEntry, bool) {
+	if f.ClientID != "" || f.ClientSecret != "" {
+		return verdaCredsEntry{ClientID: f.ClientID, ClientSecret: f.ClientSecret}, true
+	}
+	if len(f.Profiles) == 0 {
+		return verdaCredsEntry{}, false
+	}
+	name := f.ActiveProfile
+	if name == "" {
+		name = "default"
+	}
+	if entry, ok := f.Profiles[name]; ok && (entry.ClientID != "" || entry.ClientSecret != "") {
+		return entry, true
+	}
+	for _, entry := range f.Profiles {
+		if entry.ClientID != "" || entry.ClientSecret != "" {
+			return entry, true
+		}
+	}
+	return verdaCredsEntry{}, false
+}
+
+func expandHome(p string) string {
+	if !strings.HasPrefix(p, "~") {
+		return p
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return p
+	}
+	return filepath.Join(home, strings.TrimPrefix(p, "~"))
+}
+
+// NewClient creates a Verda client. The projectID is optional and used only
+// for conversation-history keying.
+func NewClient(clientID, clientSecret, projectID string, debug bool) (*Client, error) {
+	if strings.TrimSpace(clientID) == "" || strings.TrimSpace(clientSecret) == "" {
+		return nil, fmt.Errorf("verda client_id and client_secret are required")
+	}
+	return &Client{
+		clientID:     clientID,
+		clientSecret: clientSecret,
+		projectID:    projectID,
+		debug:        debug,
+		httpClient:   &http.Client{Timeout: 60 * time.Second},
+	}, nil
+}
+
+// ClientID exposes the client ID (used for conversation-history keying).
+func (c *Client) ClientID() string { return c.clientID }
+
+// ProjectID exposes the project ID.
+func (c *Client) ProjectID() string { return c.projectID }
+
+// ensureToken obtains or refreshes the OAuth2 bearer token. Safe to call from
+// any request path.
+func (c *Client) ensureToken(ctx context.Context) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Keep a small margin before expiry so we don't race the clock.
+	if c.accessToken != "" && time.Until(c.tokenExpiry) > 30*time.Second {
+		return c.accessToken, nil
+	}
+
+	var body map[string]string
+	if c.refreshToken != "" {
+		body = map[string]string{
+			"grant_type":    "refresh_token",
+			"refresh_token": c.refreshToken,
+		}
+	} else {
+		body = map[string]string{
+			"grant_type":    "client_credentials",
+			"client_id":     c.clientID,
+			"client_secret": c.clientSecret,
+		}
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return "", fmt.Errorf("marshal token request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, effectiveBaseURL()+"/v1/oauth2/token", bytes.NewReader(payload))
+	if err != nil {
+		return "", fmt.Errorf("build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	if c.debug {
+		fmt.Printf("[verda] POST /v1/oauth2/token grant=%s\n", body["grant_type"])
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		// Refresh can fail if the refresh token has expired; retry once with
+		// client_credentials so the caller doesn't need to reason about it.
+		if c.refreshToken != "" {
+			c.refreshToken = ""
+			c.accessToken = ""
+			c.tokenExpiry = time.Time{}
+			return c.ensureTokenLocked(ctx)
+		}
+		return "", fmt.Errorf("verda token request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	buf := new(bytes.Buffer)
+	if _, err := buf.ReadFrom(resp.Body); err != nil {
+		return "", fmt.Errorf("read token response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		// Retry once with fresh client credentials if we just tried refresh_token.
+		if c.refreshToken != "" {
+			c.refreshToken = ""
+			c.accessToken = ""
+			c.tokenExpiry = time.Time{}
+			return c.ensureTokenLocked(ctx)
+		}
+		return "", decodeAPIErrorBody(buf.Bytes(), resp.StatusCode)
+	}
+
+	var tr TokenResponse
+	if err := json.Unmarshal(buf.Bytes(), &tr); err != nil {
+		return "", fmt.Errorf("decode token response: %w (body: %s)", err, buf.String())
+	}
+	if tr.AccessToken == "" {
+		return "", fmt.Errorf("verda token response missing access_token (body: %s)", buf.String())
+	}
+
+	c.accessToken = tr.AccessToken
+	c.refreshToken = tr.RefreshToken
+	if tr.ExpiresIn > 0 {
+		c.tokenExpiry = time.Now().Add(time.Duration(tr.ExpiresIn) * time.Second)
+	} else {
+		c.tokenExpiry = time.Now().Add(55 * time.Minute)
+	}
+
+	return c.accessToken, nil
+}
+
+// ensureTokenLocked is called after we've reset the cached token state inside
+// ensureToken; it drops the mutex safely because the caller holds it.
+func (c *Client) ensureTokenLocked(ctx context.Context) (string, error) {
+	// We're already holding c.mu — unlock and reacquire via the public path
+	// would deadlock. Inline the minimum client-credentials flow here.
+	body, err := json.Marshal(map[string]string{
+		"grant_type":    "client_credentials",
+		"client_id":     c.clientID,
+		"client_secret": c.clientSecret,
+	})
+	if err != nil {
+		return "", err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, effectiveBaseURL()+"/v1/oauth2/token", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	buf := new(bytes.Buffer)
+	_, _ = buf.ReadFrom(resp.Body)
+	if resp.StatusCode >= 400 {
+		return "", decodeAPIErrorBody(buf.Bytes(), resp.StatusCode)
+	}
+	var tr TokenResponse
+	if err := json.Unmarshal(buf.Bytes(), &tr); err != nil {
+		return "", err
+	}
+	c.accessToken = tr.AccessToken
+	c.refreshToken = tr.RefreshToken
+	if tr.ExpiresIn > 0 {
+		c.tokenExpiry = time.Now().Add(time.Duration(tr.ExpiresIn) * time.Second)
+	} else {
+		c.tokenExpiry = time.Now().Add(55 * time.Minute)
+	}
+	return c.accessToken, nil
+}
+
+// apiResponse carries the decoded parts of a Verda API call we may care about
+// downstream (status, body, rate-limit headers, multi-status array).
+type apiResponse struct {
+	StatusCode int
+	Body       []byte
+	RetryAfter time.Duration
+}
+
+// RunAPI executes a Verda REST call with retry/backoff.
+func (c *Client) RunAPI(method, path, body string) (string, error) {
+	return c.RunAPIWithContext(context.Background(), method, path, body)
+}
+
+// RunAPIWithContext executes a Verda REST call with a caller-controlled context.
+// Path should start with `/v1/...`. Bodies are passed as a JSON string (empty for GETs).
+// Retries on 429 (honoring Retry-After) and 5xx with capped exponential backoff.
+func (c *Client) RunAPIWithContext(ctx context.Context, method, path, body string) (string, error) {
+	const maxAttempts = 4
+	backoffs := []time.Duration{
+		250 * time.Millisecond,
+		750 * time.Millisecond,
+		2 * time.Second,
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		token, err := c.ensureToken(ctx)
+		if err != nil {
+			return "", err
+		}
+
+		resp, err := c.doRequest(ctx, method, path, body, token)
+		if err != nil {
+			lastErr = err
+			if !isRetryableNetError(err) || attempt == maxAttempts-1 {
+				return "", err
+			}
+			time.Sleep(backoffs[attempt])
+			continue
+		}
+
+		// 401 once means our cached token is stale (server-side revoke) — drop it
+		// and retry once.
+		if resp.StatusCode == http.StatusUnauthorized {
+			c.mu.Lock()
+			c.accessToken = ""
+			c.refreshToken = ""
+			c.tokenExpiry = time.Time{}
+			c.mu.Unlock()
+			if attempt < maxAttempts-1 {
+				continue
+			}
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests {
+			if attempt < maxAttempts-1 {
+				wait := resp.RetryAfter
+				if wait == 0 {
+					wait = backoffs[attempt]
+				}
+				time.Sleep(wait)
+				continue
+			}
+			return string(resp.Body), decodeAPIErrorBody(resp.Body, resp.StatusCode)
+		}
+
+		if resp.StatusCode >= 500 && resp.StatusCode < 600 && attempt < maxAttempts-1 {
+			time.Sleep(backoffs[attempt])
+			continue
+		}
+
+		if resp.StatusCode >= 400 {
+			return string(resp.Body), decodeAPIErrorBody(resp.Body, resp.StatusCode)
+		}
+
+		return string(resp.Body), nil
+	}
+
+	if lastErr == nil {
+		lastErr = fmt.Errorf("verda API call failed after %d attempts", maxAttempts)
+	}
+	return "", lastErr
+}
+
+func (c *Client) doRequest(ctx context.Context, method, path, body, token string) (*apiResponse, error) {
+	var reader *bytes.Reader
+	if body != "" {
+		reader = bytes.NewReader([]byte(body))
+	}
+
+	fullURL := effectiveBaseURL() + path
+	var req *http.Request
+	var err error
+	if reader != nil {
+		req, err = http.NewRequestWithContext(ctx, method, fullURL, reader)
+	} else {
+		req, err = http.NewRequestWithContext(ctx, method, fullURL, nil)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	if c.debug {
+		fmt.Printf("[verda] %s %s\n", method, path)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	buf := new(bytes.Buffer)
+	if _, err := buf.ReadFrom(resp.Body); err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+
+	out := &apiResponse{
+		StatusCode: resp.StatusCode,
+		Body:       buf.Bytes(),
+	}
+
+	if ra := resp.Header.Get("Retry-After"); ra != "" {
+		if secs, err := strconv.Atoi(ra); err == nil {
+			out.RetryAfter = time.Duration(secs) * time.Second
+		}
+	}
+
+	return out, nil
+}
+
+// decodeAPIErrorBody turns a non-2xx body into an *APIError when it matches
+// Verda's {code,message} shape; otherwise returns a plain-text error that
+// preserves the raw body for debugging.
+func decodeAPIErrorBody(body []byte, status int) error {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) > 0 && (trimmed[0] == '{' || trimmed[0] == '[') {
+		var apiErr APIError
+		if err := json.Unmarshal(trimmed, &apiErr); err == nil && (apiErr.Code != "" || apiErr.Message != "") {
+			return &apiErr
+		}
+	}
+	return fmt.Errorf("verda API HTTP %d: %s", status, strings.TrimSpace(string(body)))
+}
+
+func isRetryableNetError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := strings.ToLower(err.Error())
+	return strings.Contains(s, "timeout") ||
+		strings.Contains(s, "timed out") ||
+		strings.Contains(s, "connection reset") ||
+		strings.Contains(s, "connection refused") ||
+		strings.Contains(s, "temporarily unavailable")
+}
+
+// DecodeActionResults decodes a 207 Multi-Status body from PUT /v1/instances.
+// When the Verda API succeeds uniformly it returns 202 with a plain JSON body;
+// a partial failure comes back as an array of ActionResult entries.
+func DecodeActionResults(body string) ([]ActionResult, error) {
+	trimmed := strings.TrimSpace(body)
+	if trimmed == "" || !strings.HasPrefix(trimmed, "[") {
+		return nil, nil
+	}
+	var results []ActionResult
+	if err := json.Unmarshal([]byte(trimmed), &results); err != nil {
+		return nil, fmt.Errorf("decode action results: %w", err)
+	}
+	return results, nil
+}
+
+// RunVerdaCLI shells out to the `verda` binary with `--agent` enforced so we
+// get structured JSON on stdout. Useful for commands the CLI covers but we
+// don't want to re-plumb through REST (e.g. `verda auth show`).
+func (c *Client) RunVerdaCLI(args ...string) (string, error) {
+	return c.RunVerdaCLIWithContext(context.Background(), args...)
+}
+
+// RunVerdaCLIWithContext runs the Verda CLI with a caller-controlled context.
+// Credentials flow through env vars so the child process picks them up without
+// needing a logged-in profile.
+func (c *Client) RunVerdaCLIWithContext(ctx context.Context, args ...string) (string, error) {
+	if _, err := exec.LookPath("verda"); err != nil {
+		return "", fmt.Errorf("verda CLI not found in PATH (install from https://docs.verda.com/cli/)")
+	}
+
+	fullArgs := append([]string{"--agent"}, args...)
+
+	cmd := exec.CommandContext(ctx, "verda", fullArgs...)
+	cmd.Env = append(os.Environ(),
+		"VERDA_CLIENT_ID="+c.clientID,
+		"VERDA_CLIENT_SECRET="+c.clientSecret,
+	)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if c.debug {
+		fmt.Printf("[verda] verda %s\n", strings.Join(fullArgs, " "))
+	}
+
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("verda CLI failed: %w, stderr: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.String(), nil
+}
+
+// GetRelevantContext gathers Verda context for LLM queries. Keyword-gated so
+// we don't fetch every resource type on every question. Sections the user's
+// question doesn't reference are skipped unless they're marked default.
+func (c *Client) GetRelevantContext(ctx context.Context, question string) (string, error) {
+	questionLower := strings.ToLower(strings.TrimSpace(question))
+
+	type section struct {
+		name   string
+		path   string
+		keys   []string
+		always bool
+	}
+
+	sections := []section{
+		{name: "Instances", path: "/v1/instances", keys: []string{"instance", "vm", "gpu", "server", "running", "spot", "h100", "a100", "h200", "b200", "l40s", "v100", "a6000"}, always: true},
+		{name: "Clusters", path: "/v1/clusters", keys: []string{"cluster", "kubernetes", "k8s", "slurm", "instant cluster", "training"}},
+		{name: "Volumes", path: "/v1/volumes", keys: []string{"volume", "disk", "storage", "sfs", "shared filesystem", "nvme", "hdd"}},
+		{name: "SSHKeys", path: "/v1/ssh-keys", keys: []string{"ssh", "key", "access"}},
+		{name: "Scripts", path: "/v1/scripts?pageSize=25", keys: []string{"script", "startup", "cloud-init"}},
+		{name: "Balance", path: "/v1/balance", keys: []string{"balance", "credit", "cost", "bill", "spend", "afford"}, always: true},
+		{name: "Locations", path: "/v1/locations", keys: []string{"location", "region", "datacenter", "availability"}},
+	}
+
+	var out strings.Builder
+	var warnings []string
+
+	for _, s := range sections {
+		if !s.always && questionLower != "" && len(s.keys) > 0 {
+			matched := false
+			for _, key := range s.keys {
+				if strings.Contains(questionLower, key) {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
+		}
+
+		result, err := c.RunAPIWithContext(ctx, http.MethodGet, s.path, "")
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("%s: %v", s.name, err))
+			continue
+		}
+
+		formatted := formatAPIResponse(s.name, result)
+		if formatted != "" {
+			out.WriteString(formatted)
+			out.WriteString("\n")
+		}
+	}
+
+	if len(warnings) > 0 {
+		out.WriteString("Verda Warnings:\n")
+		for i, w := range warnings {
+			if i >= 8 {
+				out.WriteString("- (additional warnings omitted)\n")
+				break
+			}
+			out.WriteString("- ")
+			out.WriteString(w)
+			out.WriteString("\n")
+		}
+		out.WriteString("\n")
+	}
+
+	if strings.TrimSpace(out.String()) == "" {
+		return "No Verda data available (missing permissions or no resources).", nil
+	}
+
+	return out.String(), nil
+}
+
+// formatAPIResponse pretty-prints a Verda JSON response for inclusion in an
+// LLM prompt. Verda returns plain arrays for most list endpoints and plain
+// objects for scalar endpoints (balance, locations items).
+func formatAPIResponse(name, response string) string {
+	trimmed := strings.TrimSpace(response)
+	if trimmed == "" {
+		return ""
+	}
+	var root interface{}
+	if err := json.Unmarshal([]byte(trimmed), &root); err == nil {
+		if pretty, err := json.MarshalIndent(root, "", "  "); err == nil {
+			return fmt.Sprintf("%s:\n%s", name, string(pretty))
+		}
+	}
+	return fmt.Sprintf("%s:\n%s", name, trimmed)
+}

--- a/internal/verda/client.go
+++ b/internal/verda/client.go
@@ -223,39 +223,61 @@ func (c *Client) ClientID() string { return c.clientID }
 // ProjectID exposes the project ID.
 func (c *Client) ProjectID() string { return c.projectID }
 
-// ensureToken obtains or refreshes the OAuth2 bearer token. Safe to call from
-// any request path.
+// ensureToken returns a valid OAuth2 bearer token, fetching or refreshing
+// as needed. The mutex is only held for cache reads and writes — HTTP I/O
+// happens with the lock dropped so concurrent callers can't deadlock if
+// the transport ever taps back into c.mu.
 func (c *Client) ensureToken(ctx context.Context) (string, error) {
+	// Fast path: cached token still valid.
 	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	// Keep a small margin before expiry so we don't race the clock.
 	if c.accessToken != "" && time.Until(c.tokenExpiry) > 30*time.Second {
-		return c.accessToken, nil
+		tok := c.accessToken
+		c.mu.Unlock()
+		return tok, nil
 	}
+	refreshTok := c.refreshToken
+	c.mu.Unlock()
 
-	var body map[string]string
-	if c.refreshToken != "" {
-		body = map[string]string{
+	// Slow path: attempt a refresh_token flow first when we have one,
+	// fall back to client_credentials if refresh fails or is absent.
+	if refreshTok != "" {
+		tr, err := c.fetchToken(ctx, map[string]string{
 			"grant_type":    "refresh_token",
-			"refresh_token": c.refreshToken,
+			"refresh_token": refreshTok,
+		})
+		if err == nil {
+			return c.storeToken(tr), nil
 		}
-	} else {
-		body = map[string]string{
-			"grant_type":    "client_credentials",
-			"client_id":     c.clientID,
-			"client_secret": c.clientSecret,
+		// Drop the broken refresh token so subsequent callers don't retry it.
+		c.mu.Lock()
+		if c.refreshToken == refreshTok {
+			c.refreshToken = ""
 		}
+		c.mu.Unlock()
 	}
 
+	tr, err := c.fetchToken(ctx, map[string]string{
+		"grant_type":    "client_credentials",
+		"client_id":     c.clientID,
+		"client_secret": c.clientSecret,
+	})
+	if err != nil {
+		return "", err
+	}
+	return c.storeToken(tr), nil
+}
+
+// fetchToken performs a single POST /v1/oauth2/token with the provided body.
+// Does no locking — callers are responsible for any synchronization.
+func (c *Client) fetchToken(ctx context.Context, body map[string]string) (*TokenResponse, error) {
 	payload, err := json.Marshal(body)
 	if err != nil {
-		return "", fmt.Errorf("marshal token request: %w", err)
+		return nil, fmt.Errorf("marshal token request: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, effectiveBaseURL()+"/v1/oauth2/token", bytes.NewReader(payload))
 	if err != nil {
-		return "", fmt.Errorf("build token request: %w", err)
+		return nil, fmt.Errorf("build token request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
@@ -266,85 +288,34 @@ func (c *Client) ensureToken(ctx context.Context) (string, error) {
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		// Refresh can fail if the refresh token has expired; retry once with
-		// client_credentials so the caller doesn't need to reason about it.
-		if c.refreshToken != "" {
-			c.refreshToken = ""
-			c.accessToken = ""
-			c.tokenExpiry = time.Time{}
-			return c.ensureTokenLocked(ctx)
-		}
-		return "", fmt.Errorf("verda token request failed: %w", err)
+		return nil, fmt.Errorf("verda token request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
 	buf := new(bytes.Buffer)
 	if _, err := buf.ReadFrom(resp.Body); err != nil {
-		return "", fmt.Errorf("read token response: %w", err)
+		return nil, fmt.Errorf("read token response: %w", err)
 	}
 
 	if resp.StatusCode >= 400 {
-		// Retry once with fresh client credentials if we just tried refresh_token.
-		if c.refreshToken != "" {
-			c.refreshToken = ""
-			c.accessToken = ""
-			c.tokenExpiry = time.Time{}
-			return c.ensureTokenLocked(ctx)
-		}
-		return "", decodeAPIErrorBody(buf.Bytes(), resp.StatusCode)
+		return nil, decodeAPIErrorBody(buf.Bytes(), resp.StatusCode)
 	}
 
 	var tr TokenResponse
 	if err := json.Unmarshal(buf.Bytes(), &tr); err != nil {
-		return "", fmt.Errorf("decode token response: %w (body: %s)", err, buf.String())
+		return nil, fmt.Errorf("decode token response: %w (body: %s)", err, buf.String())
 	}
 	if tr.AccessToken == "" {
-		return "", fmt.Errorf("verda token response missing access_token (body: %s)", buf.String())
+		return nil, fmt.Errorf("verda token response missing access_token (body: %s)", buf.String())
 	}
-
-	c.accessToken = tr.AccessToken
-	c.refreshToken = tr.RefreshToken
-	if tr.ExpiresIn > 0 {
-		c.tokenExpiry = time.Now().Add(time.Duration(tr.ExpiresIn) * time.Second)
-	} else {
-		c.tokenExpiry = time.Now().Add(55 * time.Minute)
-	}
-
-	return c.accessToken, nil
+	return &tr, nil
 }
 
-// ensureTokenLocked is called after we've reset the cached token state inside
-// ensureToken; it drops the mutex safely because the caller holds it.
-func (c *Client) ensureTokenLocked(ctx context.Context) (string, error) {
-	// We're already holding c.mu — unlock and reacquire via the public path
-	// would deadlock. Inline the minimum client-credentials flow here.
-	body, err := json.Marshal(map[string]string{
-		"grant_type":    "client_credentials",
-		"client_id":     c.clientID,
-		"client_secret": c.clientSecret,
-	})
-	if err != nil {
-		return "", err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, effectiveBaseURL()+"/v1/oauth2/token", bytes.NewReader(body))
-	if err != nil {
-		return "", err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-	buf := new(bytes.Buffer)
-	_, _ = buf.ReadFrom(resp.Body)
-	if resp.StatusCode >= 400 {
-		return "", decodeAPIErrorBody(buf.Bytes(), resp.StatusCode)
-	}
-	var tr TokenResponse
-	if err := json.Unmarshal(buf.Bytes(), &tr); err != nil {
-		return "", err
-	}
+// storeToken persists a TokenResponse into the client cache and returns the
+// access token.
+func (c *Client) storeToken(tr *TokenResponse) string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.accessToken = tr.AccessToken
 	c.refreshToken = tr.RefreshToken
 	if tr.ExpiresIn > 0 {
@@ -352,7 +323,7 @@ func (c *Client) ensureTokenLocked(ctx context.Context) (string, error) {
 	} else {
 		c.tokenExpiry = time.Now().Add(55 * time.Minute)
 	}
-	return c.accessToken, nil
+	return c.accessToken
 }
 
 // apiResponse carries the decoded parts of a Verda API call we may care about
@@ -392,7 +363,9 @@ func (c *Client) RunAPIWithContext(ctx context.Context, method, path, body strin
 			if !isRetryableNetError(err) || attempt == maxAttempts-1 {
 				return "", err
 			}
-			time.Sleep(backoffs[attempt])
+			if err := sleepCtx(ctx, backoffs[attempt]); err != nil {
+				return "", err
+			}
 			continue
 		}
 
@@ -415,14 +388,18 @@ func (c *Client) RunAPIWithContext(ctx context.Context, method, path, body strin
 				if wait == 0 {
 					wait = backoffs[attempt]
 				}
-				time.Sleep(wait)
+				if err := sleepCtx(ctx, wait); err != nil {
+					return "", err
+				}
 				continue
 			}
 			return string(resp.Body), decodeAPIErrorBody(resp.Body, resp.StatusCode)
 		}
 
 		if resp.StatusCode >= 500 && resp.StatusCode < 600 && attempt < maxAttempts-1 {
-			time.Sleep(backoffs[attempt])
+			if err := sleepCtx(ctx, backoffs[attempt]); err != nil {
+				return "", err
+			}
 			continue
 		}
 
@@ -504,6 +481,24 @@ func decodeAPIErrorBody(body []byte, status int) error {
 		}
 	}
 	return fmt.Errorf("verda API HTTP %d: %s", status, strings.TrimSpace(string(body)))
+}
+
+// sleepCtx blocks for the given duration or returns when ctx is cancelled.
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		return nil
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
 }
 
 func isRetryableNetError(err error) bool {

--- a/internal/verda/client_test.go
+++ b/internal/verda/client_test.go
@@ -202,10 +202,107 @@ func TestTerminalStatusHelpers(t *testing.T) {
 	if isTerminalInstanceStatus(StatusProvisioning) {
 		t.Error("provisioning should NOT be terminal")
 	}
+	// Offline is explicitly NOT terminal — WaitInstanceRunning should keep
+	// polling because a stopped instance may come back up.
+	if isTerminalInstanceStatus(StatusOffline) {
+		t.Error("offline should NOT be terminal for WaitInstanceRunning")
+	}
 	if !isTerminalVolumeStatus("attached") {
 		t.Error("attached should be terminal")
 	}
 	if isTerminalVolumeStatus("cloning") {
 		t.Error("cloning should NOT be terminal")
+	}
+}
+
+func TestLooksLikeUUIDString(t *testing.T) {
+	cases := map[string]bool{
+		"4d04ce40-aed8-4bed-aa73-648e74b188c7": true,
+		"4D04CE40-AED8-4BED-AA73-648E74B188C7": false, // caller should lowercase
+		"not-a-uuid":                           false,
+		"":                                     false,
+	}
+	for in, want := range cases {
+		if got := looksLikeUUIDString(in); got != want {
+			t.Errorf("looksLikeUUIDString(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestResolveInstanceIDByHostname(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/oauth2/token":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(TokenResponse{AccessToken: "tok", ExpiresIn: 3600})
+		case "/v1/instances":
+			_, _ = w.Write([]byte(`[
+				{"id": "abc111aa-0000-0000-0000-000000000000", "hostname": "training-box", "status": "running"},
+				{"id": "def222bb-0000-0000-0000-000000000000", "hostname": "infer-box", "status": "running"}
+			]`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	c := &Client{clientID: "id", clientSecret: "sec", httpClient: ts.Client()}
+	origBase := baseURLForTest
+	baseURLForTest = ts.URL
+	defer func() { baseURLForTest = origBase }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Hostname path.
+	id, err := c.ResolveInstanceID(ctx, "infer-box")
+	if err != nil {
+		t.Fatalf("resolve hostname: %v", err)
+	}
+	if id != "def222bb-0000-0000-0000-000000000000" {
+		t.Errorf("wrong id: %s", id)
+	}
+
+	// UUID short-circuit — should not call /v1/instances a second time.
+	got, err := c.ResolveInstanceID(ctx, "ABC111AA-0000-0000-0000-000000000000")
+	if err != nil {
+		t.Fatalf("uuid short-circuit: %v", err)
+	}
+	if got != "abc111aa-0000-0000-0000-000000000000" {
+		t.Errorf("uuid not lowercased: %s", got)
+	}
+
+	// Unknown hostname.
+	if _, err := c.ResolveInstanceID(ctx, "nonexistent"); err == nil {
+		t.Error("expected error for unknown hostname")
+	}
+
+	// Empty input.
+	if _, err := c.ResolveInstanceID(ctx, ""); err == nil {
+		t.Error("expected error for empty input")
+	}
+}
+
+func TestSleepCtxRespectsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	start := time.Now()
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+	err := sleepCtx(ctx, 10*time.Second)
+	if err == nil {
+		t.Fatal("expected context error")
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("sleepCtx ignored cancellation, slept %v", elapsed)
+	}
+}
+
+func TestSleepCtxZero(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := sleepCtx(ctx, 0); err != nil {
+		t.Errorf("zero duration should return nil, got %v", err)
 	}
 }

--- a/internal/verda/client_test.go
+++ b/internal/verda/client_test.go
@@ -1,0 +1,211 @@
+package verda
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestDecodeAPIErrorBody(t *testing.T) {
+	err := decodeAPIErrorBody([]byte(`{"code":"insufficient_funds","message":"balance too low"}`), 402)
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		t.Fatalf("expected *APIError, got %T", err)
+	}
+	if apiErr.Code != "insufficient_funds" {
+		t.Errorf("unexpected code: %q", apiErr.Code)
+	}
+	if !strings.Contains(apiErr.Error(), "insufficient_funds") {
+		t.Errorf("Error() missing code: %q", apiErr.Error())
+	}
+}
+
+func TestDecodeAPIErrorBodyFallback(t *testing.T) {
+	err := decodeAPIErrorBody([]byte("plain text error"), 500)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if _, ok := err.(*APIError); ok {
+		t.Errorf("non-JSON body should not decode to *APIError")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("expected status in fallback message, got %q", err.Error())
+	}
+}
+
+func TestDecodeActionResults(t *testing.T) {
+	body := `[{"instanceId":"abc","action":"start","status":"success"},{"instanceId":"def","action":"start","status":"error","error":"not found","statusCode":404}]`
+	results, err := DecodeActionResults(body)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if results[1].StatusCode != 404 {
+		t.Errorf("expected statusCode 404, got %d", results[1].StatusCode)
+	}
+}
+
+func TestDecodeActionResultsEmpty(t *testing.T) {
+	if results, err := DecodeActionResults(""); err != nil || results != nil {
+		t.Errorf("empty body should return nil results, got %v / %v", results, err)
+	}
+	// Non-array JSON means the endpoint returned a scalar success body.
+	if results, err := DecodeActionResults(`{"id":"abc"}`); err != nil || results != nil {
+		t.Errorf("non-array body should return nil results, got %v / %v", results, err)
+	}
+}
+
+func TestClientEnsureTokenCachesAcrossCalls(t *testing.T) {
+	var tokenCalls int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/oauth2/token":
+			atomic.AddInt32(&tokenCalls, 1)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(TokenResponse{
+				AccessToken: "tok-1", TokenType: "Bearer", ExpiresIn: 3600, Scope: "cloud-api-v1",
+			})
+		case r.URL.Path == "/v1/balance":
+			if r.Header.Get("Authorization") != "Bearer tok-1" {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			_, _ = w.Write([]byte(`{"amount": 100, "currency":"usd"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	c := &Client{clientID: "id", clientSecret: "sec", httpClient: ts.Client()}
+	// Swap the base URL via a test double — point doRequest at the test server.
+	origBase := baseURLForTest
+	baseURLForTest = ts.URL
+	defer func() { baseURLForTest = origBase }()
+
+	for i := 0; i < 3; i++ {
+		if _, err := c.RunAPIWithContext(context.Background(), http.MethodGet, "/v1/balance", ""); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+
+	if got := atomic.LoadInt32(&tokenCalls); got != 1 {
+		t.Errorf("expected token endpoint hit once, got %d", got)
+	}
+}
+
+func TestClientRetriesOn429(t *testing.T) {
+	var instCalls int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/oauth2/token" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(TokenResponse{AccessToken: "tok", ExpiresIn: 3600})
+			return
+		}
+		if r.URL.Path == "/v1/instances" {
+			n := atomic.AddInt32(&instCalls, 1)
+			if n < 2 {
+				w.Header().Set("Retry-After", "0")
+				http.Error(w, `{"code":"rate_limit_exceeded","message":"slow down"}`, http.StatusTooManyRequests)
+				return
+			}
+			_, _ = w.Write([]byte(`[]`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer ts.Close()
+
+	c := &Client{clientID: "id", clientSecret: "sec", httpClient: ts.Client()}
+	origBase := baseURLForTest
+	baseURLForTest = ts.URL
+	defer func() { baseURLForTest = origBase }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if _, err := c.RunAPIWithContext(ctx, http.MethodGet, "/v1/instances", ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := atomic.LoadInt32(&instCalls); got < 2 {
+		t.Errorf("expected at least 2 attempts, got %d", got)
+	}
+}
+
+func TestReadVerdaCredentialsYAML(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	dir := filepath.Join(tmpHome, ".verda")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	yaml := `active_profile: prod
+profiles:
+  prod:
+    client_id: id-prod
+    client_secret: secret-prod
+  dev:
+    client_id: id-dev
+    client_secret: secret-dev
+`
+	if err := os.WriteFile(filepath.Join(dir, "credentials"), []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entry, err := readVerdaCredentials()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if entry.ClientID != "id-prod" || entry.ClientSecret != "secret-prod" {
+		t.Errorf("wrong profile selected: %+v", entry)
+	}
+}
+
+func TestReadVerdaCredentialsFlat(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	dir := filepath.Join(tmpHome, ".verda")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	flat := `client_id: id-flat
+client_secret: secret-flat
+`
+	if err := os.WriteFile(filepath.Join(dir, "credentials"), []byte(flat), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	entry, err := readVerdaCredentials()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if entry.ClientID != "id-flat" || entry.ClientSecret != "secret-flat" {
+		t.Errorf("wrong flat entry: %+v", entry)
+	}
+}
+
+func TestTerminalStatusHelpers(t *testing.T) {
+	if !isTerminalInstanceStatus(StatusRunning) {
+		t.Error("running should be terminal")
+	}
+	if isTerminalInstanceStatus(StatusProvisioning) {
+		t.Error("provisioning should NOT be terminal")
+	}
+	if !isTerminalVolumeStatus("attached") {
+		t.Error("attached should be terminal")
+	}
+	if isTerminalVolumeStatus("cloning") {
+		t.Error("cloning should NOT be terminal")
+	}
+}

--- a/internal/verda/client_test.go
+++ b/internal/verda/client_test.go
@@ -306,3 +306,35 @@ func TestSleepCtxZero(t *testing.T) {
 		t.Errorf("zero duration should return nil, got %v", err)
 	}
 }
+
+func TestRunVerdaCLIReturnsErrCLINotInstalled(t *testing.T) {
+	// Stash PATH so exec.LookPath can't find any binary for the duration of
+	// this test, guaranteeing the RunVerdaCLI path takes the error branch
+	// regardless of what the CI machine has installed.
+	t.Setenv("PATH", "")
+
+	c := &Client{clientID: "id", clientSecret: "sec"}
+	_, err := c.RunVerdaCLI("vm", "list")
+	if err == nil {
+		t.Fatal("expected error when verda binary is absent")
+	}
+	if !IsCLINotInstalled(err) {
+		t.Errorf("expected ErrCLINotInstalled, got %T: %v", err, err)
+	}
+	// The message should mention both the docs URL and the REST fallback so
+	// users can choose their path without reading the sentinel's wrapping.
+	msg := err.Error()
+	if !strings.Contains(msg, "docs.verda.com") {
+		t.Errorf("error message missing docs link: %q", msg)
+	}
+	if !strings.Contains(msg, "client_id") {
+		t.Errorf("error message missing REST fallback hint: %q", msg)
+	}
+}
+
+func TestCLIInstalledOnEmptyPath(t *testing.T) {
+	t.Setenv("PATH", "")
+	if CLIInstalled() {
+		t.Error("CLIInstalled should be false when PATH is empty")
+	}
+}

--- a/internal/verda/conversation.go
+++ b/internal/verda/conversation.go
@@ -10,6 +10,27 @@ import (
 	"time"
 )
 
+// fileLocks serializes Save+Load per ScopeID so two concurrent
+// `clanker verda ask` invocations for the same project don't race on the
+// tmp-file + rename dance and lose one conversation's history. Keyed by the
+// sanitized filename so two scopes that happen to normalise to the same name
+// still share a lock.
+var (
+	fileLocks   = map[string]*sync.Mutex{}
+	fileLocksMu sync.Mutex
+)
+
+func fileLockFor(name string) *sync.Mutex {
+	fileLocksMu.Lock()
+	defer fileLocksMu.Unlock()
+	if m, ok := fileLocks[name]; ok {
+		return m
+	}
+	m := &sync.Mutex{}
+	fileLocks[name] = m
+	return m
+}
+
 // ConversationEntry is a single Q&A exchange.
 type ConversationEntry struct {
 	Timestamp time.Time `json:"timestamp"`
@@ -86,10 +107,21 @@ func (h *ConversationHistory) GetRecentContext(maxEntries int) string {
 // Save persists the conversation to ~/.clanker/conversations/verda_<scope>.json.
 // Write is atomic: marshal → write temp file → rename over the destination.
 // A crash mid-write leaves either the old or new file intact but never a
-// half-written blob that would poison subsequent loads.
+// half-written blob that would poison subsequent loads. A per-scope file lock
+// serializes concurrent Save calls for the same project — without it, two
+// parallel `ask --verda` calls could race on the rename and drop one history.
 func (h *ConversationHistory) Save() error {
 	h.mu.RLock()
-	defer h.mu.RUnlock()
+	data, err := json.MarshalIndent(h, "", "  ")
+	scopeName := sanitize(h.ScopeID)
+	h.mu.RUnlock()
+	if err != nil {
+		return fmt.Errorf("marshal history: %w", err)
+	}
+
+	lock := fileLockFor(scopeName)
+	lock.Lock()
+	defer lock.Unlock()
 
 	dir, err := conversationDir()
 	if err != nil {
@@ -99,12 +131,7 @@ func (h *ConversationHistory) Save() error {
 		return fmt.Errorf("create conversation dir: %w", err)
 	}
 
-	data, err := json.MarshalIndent(h, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshal history: %w", err)
-	}
-
-	path := filepath.Join(dir, fmt.Sprintf("verda_%s.json", sanitize(h.ScopeID)))
+	path := filepath.Join(dir, fmt.Sprintf("verda_%s.json", scopeName))
 	tmp, err := os.CreateTemp(dir, "verda_*.json.tmp")
 	if err != nil {
 		return fmt.Errorf("create tmp: %w", err)
@@ -128,6 +155,15 @@ func (h *ConversationHistory) Save() error {
 
 // Load restores history from disk. Missing file is not an error.
 func (h *ConversationHistory) Load() error {
+	// Take the per-scope file lock first so we don't read a file that Save
+	// is currently mid-rename on. Grabbing the struct mutex early would let
+	// a parallel Save hold fileLock + block here, so the order is:
+	// fileLock (cross-process write barrier) → struct mu (in-memory state).
+	scopeName := sanitize(h.ScopeID)
+	lock := fileLockFor(scopeName)
+	lock.Lock()
+	defer lock.Unlock()
+
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -135,7 +171,7 @@ func (h *ConversationHistory) Load() error {
 	if err != nil {
 		return err
 	}
-	path := filepath.Join(dir, fmt.Sprintf("verda_%s.json", sanitize(h.ScopeID)))
+	path := filepath.Join(dir, fmt.Sprintf("verda_%s.json", scopeName))
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/verda/conversation.go
+++ b/internal/verda/conversation.go
@@ -84,6 +84,9 @@ func (h *ConversationHistory) GetRecentContext(maxEntries int) string {
 }
 
 // Save persists the conversation to ~/.clanker/conversations/verda_<scope>.json.
+// Write is atomic: marshal → write temp file → rename over the destination.
+// A crash mid-write leaves either the old or new file intact but never a
+// half-written blob that would poison subsequent loads.
 func (h *ConversationHistory) Save() error {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
@@ -102,7 +105,25 @@ func (h *ConversationHistory) Save() error {
 	}
 
 	path := filepath.Join(dir, fmt.Sprintf("verda_%s.json", sanitize(h.ScopeID)))
-	return os.WriteFile(path, data, 0o644)
+	tmp, err := os.CreateTemp(dir, "verda_*.json.tmp")
+	if err != nil {
+		return fmt.Errorf("create tmp: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("close tmp: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		_ = os.Remove(tmpName)
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
 }
 
 // Load restores history from disk. Missing file is not an error.

--- a/internal/verda/conversation.go
+++ b/internal/verda/conversation.go
@@ -1,0 +1,162 @@
+package verda
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ConversationEntry is a single Q&A exchange.
+type ConversationEntry struct {
+	Timestamp time.Time `json:"timestamp"`
+	Question  string    `json:"question"`
+	Answer    string    `json:"answer"`
+}
+
+// ConversationHistory maintains conversation state for Verda ask mode.
+type ConversationHistory struct {
+	Entries []ConversationEntry `json:"entries"`
+	ScopeID string              `json:"scope_id"`
+	mu      sync.RWMutex
+}
+
+// MaxHistoryEntries limits the conversation history size.
+const MaxHistoryEntries = 20
+
+// MaxAnswerLengthInContext limits how much of previous answers to include in context.
+const MaxAnswerLengthInContext = 500
+
+// NewConversationHistory creates a new conversation history keyed by scope
+// (project_id for team accounts, "personal" otherwise).
+func NewConversationHistory(scopeID string) *ConversationHistory {
+	if strings.TrimSpace(scopeID) == "" {
+		scopeID = "personal"
+	}
+	return &ConversationHistory{
+		Entries: make([]ConversationEntry, 0),
+		ScopeID: scopeID,
+	}
+}
+
+// AddEntry records a new question/answer pair and prunes the log.
+func (h *ConversationHistory) AddEntry(question, answer string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.Entries = append(h.Entries, ConversationEntry{
+		Timestamp: time.Now(),
+		Question:  question,
+		Answer:    answer,
+	})
+
+	if len(h.Entries) > MaxHistoryEntries {
+		h.Entries = h.Entries[len(h.Entries)-MaxHistoryEntries:]
+	}
+}
+
+// GetRecentContext returns a compact string of recent exchanges for the LLM prompt.
+func (h *ConversationHistory) GetRecentContext(maxEntries int) string {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	if len(h.Entries) == 0 {
+		return ""
+	}
+
+	start := 0
+	if len(h.Entries) > maxEntries {
+		start = len(h.Entries) - maxEntries
+	}
+
+	var sb strings.Builder
+	for i, entry := range h.Entries[start:] {
+		if i > 0 {
+			sb.WriteString("\n")
+		}
+		sb.WriteString(fmt.Sprintf("Q: %s\n", entry.Question))
+		sb.WriteString(fmt.Sprintf("A: %s\n", truncate(entry.Answer, MaxAnswerLengthInContext)))
+	}
+	return sb.String()
+}
+
+// Save persists the conversation to ~/.clanker/conversations/verda_<scope>.json.
+func (h *ConversationHistory) Save() error {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	dir, err := conversationDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create conversation dir: %w", err)
+	}
+
+	data, err := json.MarshalIndent(h, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal history: %w", err)
+	}
+
+	path := filepath.Join(dir, fmt.Sprintf("verda_%s.json", sanitize(h.ScopeID)))
+	return os.WriteFile(path, data, 0o644)
+}
+
+// Load restores history from disk. Missing file is not an error.
+func (h *ConversationHistory) Load() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	dir, err := conversationDir()
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(dir, fmt.Sprintf("verda_%s.json", sanitize(h.ScopeID)))
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read conversation: %w", err)
+	}
+
+	var loaded struct {
+		Entries []ConversationEntry `json:"entries"`
+		ScopeID string              `json:"scope_id"`
+	}
+	if err := json.Unmarshal(data, &loaded); err != nil {
+		return fmt.Errorf("parse conversation: %w", err)
+	}
+
+	h.Entries = loaded.Entries
+	if loaded.ScopeID != "" {
+		h.ScopeID = loaded.ScopeID
+	}
+	return nil
+}
+
+func conversationDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".clanker", "conversations"), nil
+}
+
+func sanitize(s string) string {
+	r := strings.NewReplacer(
+		"/", "_", "\\", "_", ":", "_", "*", "_",
+		"?", "_", "\"", "_", "<", "_", ">", "_", "|", "_", " ", "_",
+	)
+	return r.Replace(s)
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}

--- a/internal/verda/conversation_test.go
+++ b/internal/verda/conversation_test.go
@@ -1,0 +1,95 @@
+package verda
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestConversationHistorySaveLoadRoundTrip(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	h := NewConversationHistory("project-1")
+	h.AddEntry("first question", "first answer")
+	h.AddEntry("second question", "second answer")
+
+	if err := h.Save(); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	loaded := NewConversationHistory("project-1")
+	if err := loaded.Load(); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(loaded.Entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(loaded.Entries))
+	}
+	if loaded.Entries[0].Question != "first question" {
+		t.Errorf("first entry mismatch: %+v", loaded.Entries[0])
+	}
+}
+
+func TestConversationHistoryConcurrentSaves(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	// Fire off N goroutines writing to the same scope. The file-lock per
+	// scope should serialize them; without it the final file may be a
+	// half-written tmp or corrupt JSON.
+	const N = 20
+	var wg sync.WaitGroup
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			h := NewConversationHistory("project-shared")
+			h.AddEntry("q", "a")
+			if err := h.Save(); err != nil {
+				t.Errorf("goroutine %d save: %v", n, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// The final file must parse as valid JSON after the storm.
+	path := filepath.Join(tmpHome, ".clanker", "conversations", "verda_project-shared.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("final file not readable: %v", err)
+	}
+	var got ConversationHistory
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("final file not valid json: %v", err)
+	}
+	if got.ScopeID != "project-shared" {
+		t.Errorf("wrong scope: %q", got.ScopeID)
+	}
+}
+
+func TestConversationHistoryNoTmpLeaksOnSuccess(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	h := NewConversationHistory("clean-up")
+	h.AddEntry("q", "a")
+	if err := h.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := os.ReadDir(filepath.Join(tmpHome, ".clanker", "conversations"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Expect exactly one file: the final verda_clean-up.json. Tmp files
+	// should have been renamed or removed.
+	if len(entries) != 1 {
+		names := []string{}
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("expected 1 file, got %d: %v", len(entries), names)
+	}
+}

--- a/internal/verda/poll.go
+++ b/internal/verda/poll.go
@@ -1,0 +1,147 @@
+package verda
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// PollOptions tune the bounded polling helpers.
+type PollOptions struct {
+	Interval time.Duration
+	Max      time.Duration
+}
+
+func (o PollOptions) withDefaults(interval, max time.Duration) PollOptions {
+	if o.Interval <= 0 {
+		o.Interval = interval
+	}
+	if o.Max <= 0 {
+		o.Max = max
+	}
+	return o
+}
+
+// WaitInstanceRunning polls GET /v1/instances/{id} until the instance reports
+// `running` or a terminal status, or the bounded deadline is reached.
+func (c *Client) WaitInstanceRunning(ctx context.Context, id string, opts PollOptions) (*Instance, error) {
+	opts = opts.withDefaults(15*time.Second, 15*time.Minute)
+	deadline := time.Now().Add(opts.Max)
+
+	for {
+		body, err := c.RunAPIWithContext(ctx, http.MethodGet, "/v1/instances/"+id, "")
+		if err != nil {
+			return nil, err
+		}
+		var inst Instance
+		if err := json.Unmarshal([]byte(body), &inst); err != nil {
+			return nil, fmt.Errorf("decode instance: %w", err)
+		}
+
+		if isTerminalInstanceStatus(inst.Status) {
+			return &inst, nil
+		}
+
+		if time.Now().After(deadline) {
+			return &inst, fmt.Errorf("timeout waiting for instance %s to reach running (last status=%s)", id, inst.Status)
+		}
+
+		select {
+		case <-ctx.Done():
+			return &inst, ctx.Err()
+		case <-time.After(opts.Interval):
+		}
+	}
+}
+
+// WaitClusterRunning polls GET /v1/clusters/{id} until the cluster reports a
+// terminal status (running, error, discontinued, etc.) or the deadline hits.
+func (c *Client) WaitClusterRunning(ctx context.Context, id string, opts PollOptions) (*Cluster, error) {
+	opts = opts.withDefaults(30*time.Second, 30*time.Minute)
+	deadline := time.Now().Add(opts.Max)
+
+	for {
+		body, err := c.RunAPIWithContext(ctx, http.MethodGet, "/v1/clusters/"+id, "")
+		if err != nil {
+			return nil, err
+		}
+		var cl Cluster
+		if err := json.Unmarshal([]byte(body), &cl); err != nil {
+			return nil, fmt.Errorf("decode cluster: %w", err)
+		}
+
+		if isTerminalClusterStatus(cl.Status) {
+			return &cl, nil
+		}
+
+		if time.Now().After(deadline) {
+			return &cl, fmt.Errorf("timeout waiting for cluster %s to reach running (last status=%s)", id, cl.Status)
+		}
+
+		select {
+		case <-ctx.Done():
+			return &cl, ctx.Err()
+		case <-time.After(opts.Interval):
+		}
+	}
+}
+
+// WaitVolumeAvailable polls GET /v1/volumes/{id} until the volume reports a
+// stable status (`attached`, `created`, `detached`, `deleted`) or times out.
+func (c *Client) WaitVolumeAvailable(ctx context.Context, id string, opts PollOptions) (*Volume, error) {
+	opts = opts.withDefaults(10*time.Second, 10*time.Minute)
+	deadline := time.Now().Add(opts.Max)
+
+	for {
+		body, err := c.RunAPIWithContext(ctx, http.MethodGet, "/v1/volumes/"+id, "")
+		if err != nil {
+			return nil, err
+		}
+		var v Volume
+		if err := json.Unmarshal([]byte(body), &v); err != nil {
+			return nil, fmt.Errorf("decode volume: %w", err)
+		}
+
+		if isTerminalVolumeStatus(v.Status) {
+			return &v, nil
+		}
+
+		if time.Now().After(deadline) {
+			return &v, fmt.Errorf("timeout waiting for volume %s to reach ready (last status=%s)", id, v.Status)
+		}
+
+		select {
+		case <-ctx.Done():
+			return &v, ctx.Err()
+		case <-time.After(opts.Interval):
+		}
+	}
+}
+
+func isTerminalInstanceStatus(s string) bool {
+	switch s {
+	case StatusRunning, StatusError, StatusDiscontinued, StatusNotFound,
+		StatusNoCapacity, StatusInstallationFailed, StatusOffline:
+		return true
+	}
+	return false
+}
+
+func isTerminalClusterStatus(s string) bool {
+	switch s {
+	case StatusRunning, StatusError, StatusDiscontinued, StatusNotFound,
+		StatusNoCapacity, StatusInstallationFailed:
+		return true
+	}
+	return false
+}
+
+func isTerminalVolumeStatus(s string) bool {
+	switch s {
+	case "attached", "detached", "created", "deleted", "exported", "canceled":
+		return true
+	}
+	return false
+}

--- a/internal/verda/poll.go
+++ b/internal/verda/poll.go
@@ -44,14 +44,17 @@ func (c *Client) WaitInstanceRunning(ctx context.Context, id string, opts PollOp
 			return &inst, nil
 		}
 
-		if time.Now().After(deadline) {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
 			return &inst, fmt.Errorf("timeout waiting for instance %s to reach running (last status=%s)", id, inst.Status)
 		}
 
-		select {
-		case <-ctx.Done():
-			return &inst, ctx.Err()
-		case <-time.After(opts.Interval):
+		wait := opts.Interval
+		if wait > remaining {
+			wait = remaining
+		}
+		if err := sleepCtx(ctx, wait); err != nil {
+			return &inst, err
 		}
 	}
 }
@@ -76,14 +79,16 @@ func (c *Client) WaitClusterRunning(ctx context.Context, id string, opts PollOpt
 			return &cl, nil
 		}
 
-		if time.Now().After(deadline) {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
 			return &cl, fmt.Errorf("timeout waiting for cluster %s to reach running (last status=%s)", id, cl.Status)
 		}
-
-		select {
-		case <-ctx.Done():
-			return &cl, ctx.Err()
-		case <-time.After(opts.Interval):
+		wait := opts.Interval
+		if wait > remaining {
+			wait = remaining
+		}
+		if err := sleepCtx(ctx, wait); err != nil {
+			return &cl, err
 		}
 	}
 }
@@ -108,22 +113,28 @@ func (c *Client) WaitVolumeAvailable(ctx context.Context, id string, opts PollOp
 			return &v, nil
 		}
 
-		if time.Now().After(deadline) {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
 			return &v, fmt.Errorf("timeout waiting for volume %s to reach ready (last status=%s)", id, v.Status)
 		}
-
-		select {
-		case <-ctx.Done():
-			return &v, ctx.Err()
-		case <-time.After(opts.Interval):
+		wait := opts.Interval
+		if wait > remaining {
+			wait = remaining
+		}
+		if err := sleepCtx(ctx, wait); err != nil {
+			return &v, err
 		}
 	}
 }
 
+// isTerminalInstanceStatus reports whether the status is one WaitInstanceRunning
+// should return on. `StatusOffline` is intentionally NOT terminal — an offline
+// instance may transition back to running after a boot action, so polling must
+// continue until the caller-imposed deadline.
 func isTerminalInstanceStatus(s string) bool {
 	switch s {
 	case StatusRunning, StatusError, StatusDiscontinued, StatusNotFound,
-		StatusNoCapacity, StatusInstallationFailed, StatusOffline:
+		StatusNoCapacity, StatusInstallationFailed:
 		return true
 	}
 	return false

--- a/internal/verda/static_commands.go
+++ b/internal/verda/static_commands.go
@@ -130,7 +130,7 @@ Supported resources:
 			case "availability":
 				path = "/v1/instance-availability"
 			default:
-				return fmt.Errorf("unknown resource type: %s", resource)
+				return fmt.Errorf("unknown resource type %q. Supported: instances, clusters, volumes, ssh-keys, scripts, instance-types, cluster-types, container-types, containers, jobs, secrets, file-secrets, registry-creds, locations, balance, images, cluster-images, availability", resource)
 			}
 
 			body, err := client.RunAPIWithContext(ctx, http.MethodGet, path, "")
@@ -277,6 +277,19 @@ func createVerdaBalanceCmd() *cobra.Command {
 			body, err := client.RunAPIWithContext(ctx, http.MethodGet, "/v1/balance", "")
 			if err != nil {
 				return err
+			}
+			raw, _ := cmd.Flags().GetBool("raw")
+			if raw {
+				fmt.Println(body)
+				return nil
+			}
+			// When the response parses cleanly print a short human-friendly
+			// summary line (e.g. "Balance: $42.17 USD") so users scanning a
+			// terminal don't have to read JSON. The raw body is still
+			// printed below for scripts grepping numeric fields.
+			var b Balance
+			if err := json.Unmarshal([]byte(body), &b); err == nil && b.Currency != "" {
+				fmt.Printf("Balance: %.2f %s\n", b.Amount, strings.ToUpper(b.Currency))
 			}
 			fmt.Println(prettyJSON(body))
 			return nil

--- a/internal/verda/static_commands.go
+++ b/internal/verda/static_commands.go
@@ -1,0 +1,274 @@
+package verda
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// CreateVerdaCommands builds the `verda` command tree. Registered from cmd/root.go
+// as a sibling of `cf`, `do`, `hetzner`, `vercel`.
+func CreateVerdaCommands() *cobra.Command {
+	verdaCmd := &cobra.Command{
+		Use:     "verda",
+		Short:   "Query Verda Cloud (GPU/AI) resources directly",
+		Long:    "Query Verda Cloud (ex-DataCrunch) GPU instances, clusters, volumes, and serverless workloads without AI interpretation.",
+		Aliases: []string{"vd"},
+	}
+
+	verdaCmd.PersistentFlags().String("client-id", "", "Verda client ID (overrides VERDA_CLIENT_ID)")
+	verdaCmd.PersistentFlags().String("client-secret", "", "Verda client secret (overrides VERDA_CLIENT_SECRET)")
+	verdaCmd.PersistentFlags().String("project-id", "", "Verda project ID for scoping")
+	verdaCmd.PersistentFlags().Bool("raw", false, "Output raw JSON instead of formatted")
+
+	verdaCmd.AddCommand(createVerdaListCmd())
+	verdaCmd.AddCommand(createVerdaGetCmd())
+	verdaCmd.AddCommand(createVerdaActionCmd())
+	verdaCmd.AddCommand(createVerdaBalanceCmd())
+
+	return verdaCmd
+}
+
+func newClientFromFlags(cmd *cobra.Command) (*Client, error) {
+	clientID, _ := cmd.Flags().GetString("client-id")
+	if strings.TrimSpace(clientID) == "" {
+		clientID = ResolveClientID()
+	}
+	clientSecret, _ := cmd.Flags().GetString("client-secret")
+	if strings.TrimSpace(clientSecret) == "" {
+		clientSecret = ResolveClientSecret()
+	}
+	projectID, _ := cmd.Flags().GetString("project-id")
+	if strings.TrimSpace(projectID) == "" {
+		projectID = ResolveProjectID()
+	}
+	if strings.TrimSpace(clientID) == "" || strings.TrimSpace(clientSecret) == "" {
+		return nil, fmt.Errorf("verda credentials not configured — set verda.client_id/client_secret in ~/.clanker.yaml, export VERDA_CLIENT_ID/VERDA_CLIENT_SECRET, or run `verda auth login`")
+	}
+	debug, _ := cmd.Root().PersistentFlags().GetBool("debug")
+	return NewClient(clientID, clientSecret, projectID, debug)
+}
+
+func createVerdaListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list [resource]",
+		Short: "List Verda resources",
+		Long: `List Verda resources of a specific type.
+
+Supported resources:
+  instances       - GPU/CPU instances
+  clusters        - GPU clusters (Instant / Bare-metal)
+  volumes         - Block + shared volumes
+  ssh-keys        - SSH keys registered with Verda
+  scripts         - Startup scripts
+  instance-types  - Available instance types with pricing
+  cluster-types   - Available cluster SKUs
+  locations       - Available datacenter locations
+  images          - Available OS images (instance)
+  cluster-images  - Available OS images (cluster)
+  availability    - Current instance-type availability across regions`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resource := strings.ToLower(args[0])
+			raw, _ := cmd.Flags().GetBool("raw")
+
+			client, err := newClientFromFlags(cmd)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
+
+			var path string
+			switch resource {
+			case "instances", "instance", "vm", "vms":
+				path = "/v1/instances"
+			case "clusters", "cluster":
+				path = "/v1/clusters"
+			case "volumes", "volume":
+				path = "/v1/volumes"
+			case "ssh-keys", "ssh", "keys":
+				path = "/v1/ssh-keys"
+			case "scripts", "startup-scripts":
+				path = "/v1/scripts?pageSize=100"
+			case "instance-types", "types":
+				path = "/v1/instance-types"
+			case "cluster-types":
+				path = "/v1/cluster-types"
+			case "locations":
+				path = "/v1/locations"
+			case "images":
+				path = "/v1/images"
+			case "cluster-images":
+				path = "/v1/images/cluster"
+			case "availability":
+				path = "/v1/instance-availability"
+			default:
+				return fmt.Errorf("unknown resource type: %s", resource)
+			}
+
+			body, err := client.RunAPIWithContext(ctx, http.MethodGet, path, "")
+			if err != nil {
+				return err
+			}
+			if raw {
+				fmt.Println(body)
+				return nil
+			}
+			fmt.Println(prettyJSON(body))
+			return nil
+		},
+	}
+	return cmd
+}
+
+func createVerdaGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <instance|cluster|volume|ssh-key|script> <id>",
+		Short: "Get a single Verda resource",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			kind := strings.ToLower(args[0])
+			id := args[1]
+
+			client, err := newClientFromFlags(cmd)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			var path string
+			switch kind {
+			case "instance", "vm":
+				path = "/v1/instances/" + id
+			case "cluster":
+				path = "/v1/clusters/" + id
+			case "volume":
+				path = "/v1/volumes/" + id
+			case "ssh-key", "ssh":
+				path = "/v1/ssh-keys/" + id
+			case "script":
+				path = "/v1/scripts/" + id
+			default:
+				return fmt.Errorf("unknown resource kind: %s (expected instance|cluster|volume|ssh-key|script)", kind)
+			}
+
+			body, err := client.RunAPIWithContext(ctx, http.MethodGet, path, "")
+			if err != nil {
+				return err
+			}
+			raw, _ := cmd.Flags().GetBool("raw")
+			if raw {
+				fmt.Println(body)
+				return nil
+			}
+			fmt.Println(prettyJSON(body))
+			return nil
+		},
+	}
+	return cmd
+}
+
+func createVerdaActionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "action <start|stop|shutdown|delete|discontinue|hibernate|boot|force_shutdown> <instance_id>",
+		Short: "Perform a lifecycle action on a Verda instance",
+		Long: `Invoke PUT /v1/instances with the given action.
+
+The underlying REST call is always PUT /v1/instances regardless of the action verb.
+Supported actions: boot, start, shutdown, force_shutdown, delete, discontinue,
+hibernate, configure_spot, delete_stuck, deploy, transfer.`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			action := strings.ToLower(args[0])
+			id := args[1]
+
+			valid := map[string]bool{
+				InstanceActionBoot:          true,
+				InstanceActionStart:         true,
+				InstanceActionShutdown:      true,
+				InstanceActionForceShutdown: true,
+				InstanceActionDelete:        true,
+				InstanceActionDiscontinue:   true,
+				InstanceActionHibernate:     true,
+				InstanceActionConfigureSpot: true,
+				InstanceActionDeleteStuck:   true,
+				InstanceActionDeploy:        true,
+				InstanceActionTransfer:      true,
+			}
+			if !valid[action] {
+				return fmt.Errorf("invalid action %q", action)
+			}
+
+			client, err := newClientFromFlags(cmd)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
+
+			payload, _ := json.Marshal(PerformInstanceActionRequest{
+				Action: action,
+				ID:     id,
+			})
+
+			body, err := client.RunAPIWithContext(ctx, http.MethodPut, "/v1/instances", string(payload))
+			if err != nil {
+				return err
+			}
+			fmt.Println(prettyJSON(body))
+			return nil
+		},
+	}
+	return cmd
+}
+
+func createVerdaBalanceCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "balance",
+		Short: "Show Verda account balance",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newClientFromFlags(cmd)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+
+			body, err := client.RunAPIWithContext(ctx, http.MethodGet, "/v1/balance", "")
+			if err != nil {
+				return err
+			}
+			fmt.Println(prettyJSON(body))
+			return nil
+		},
+	}
+}
+
+// prettyJSON re-encodes a JSON string with indent-2 for human-friendly output.
+// Non-JSON input is returned verbatim.
+func prettyJSON(s string) string {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return ""
+	}
+	if !strings.HasPrefix(trimmed, "{") && !strings.HasPrefix(trimmed, "[") {
+		return trimmed
+	}
+	var v interface{}
+	if err := json.Unmarshal([]byte(trimmed), &v); err != nil {
+		return trimmed
+	}
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return trimmed
+	}
+	return string(out)
+}

--- a/internal/verda/static_commands.go
+++ b/internal/verda/static_commands.go
@@ -68,7 +68,14 @@ Supported resources:
   scripts         - Startup scripts
   instance-types  - Available instance types with pricing
   cluster-types   - Available cluster SKUs
+  container-types - Serverless container compute types
+  containers      - Serverless container deployments
+  jobs            - Serverless job deployments
+  secrets         - Serverless secrets
+  file-secrets    - Serverless file secrets
+  registry-creds  - Container registry credentials
   locations       - Available datacenter locations
+  balance         - Current project balance
   images          - Available OS images (instance)
   cluster-images  - Available OS images (cluster)
   availability    - Current instance-type availability across regions`,
@@ -100,8 +107,22 @@ Supported resources:
 				path = "/v1/instance-types"
 			case "cluster-types":
 				path = "/v1/cluster-types"
+			case "container-types":
+				path = "/v1/container-types"
+			case "containers", "container-deployments":
+				path = "/v1/container-deployments"
+			case "jobs", "job-deployments":
+				path = "/v1/job-deployments"
+			case "secrets":
+				path = "/v1/secrets"
+			case "file-secrets":
+				path = "/v1/file-secrets"
+			case "registry-creds", "registry-credentials":
+				path = "/v1/container-registry-credentials"
 			case "locations":
 				path = "/v1/locations"
+			case "balance":
+				path = "/v1/balance"
 			case "images":
 				path = "/v1/images"
 			case "cluster-images":
@@ -177,9 +198,12 @@ func createVerdaGetCmd() *cobra.Command {
 
 func createVerdaActionCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "action <start|stop|shutdown|delete|discontinue|hibernate|boot|force_shutdown> <instance_id>",
+		Use:   "action <start|stop|shutdown|delete|discontinue|hibernate|boot|force_shutdown> <instance>",
 		Short: "Perform a lifecycle action on a Verda instance",
 		Long: `Invoke PUT /v1/instances with the given action.
+
+The <instance> argument accepts either a Verda instance UUID or a hostname —
+hostnames are resolved via GET /v1/instances before the action is issued.
 
 The underlying REST call is always PUT /v1/instances regardless of the action verb.
 Supported actions: boot, start, shutdown, force_shutdown, delete, discontinue,
@@ -187,7 +211,7 @@ hibernate, configure_spot, delete_stuck, deploy, transfer.`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			action := strings.ToLower(args[0])
-			id := args[1]
+			nameOrID := args[1]
 
 			valid := map[string]bool{
 				InstanceActionBoot:          true,
@@ -213,10 +237,18 @@ hibernate, configure_spot, delete_stuck, deploy, transfer.`,
 			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 			defer cancel()
 
-			payload, _ := json.Marshal(PerformInstanceActionRequest{
+			id, err := client.ResolveInstanceID(ctx, nameOrID)
+			if err != nil {
+				return err
+			}
+
+			payload, err := json.Marshal(PerformInstanceActionRequest{
 				Action: action,
 				ID:     id,
 			})
+			if err != nil {
+				return fmt.Errorf("marshal action: %w", err)
+			}
 
 			body, err := client.RunAPIWithContext(ctx, http.MethodPut, "/v1/instances", string(payload))
 			if err != nil {

--- a/internal/verda/types.go
+++ b/internal/verda/types.go
@@ -1,0 +1,340 @@
+package verda
+
+// Types mirror the Verda Cloud OpenAPI 3.1 spec at https://api.verda.com/v1/openapi.json
+// We hand-write the subset used by the client/CLI/ask flows rather than pull in a
+// code generator — the surface is small and stable enough that the dependency is
+// not worth it.
+
+// TokenResponse is the body of POST /v1/oauth2/token.
+type TokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	ExpiresIn    int    `json:"expires_in"`
+	RefreshToken string `json:"refresh_token"`
+	Scope        string `json:"scope"`
+}
+
+// APIError is the body of any non-2xx Verda response.
+type APIError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+func (e *APIError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.Code == "" {
+		return e.Message
+	}
+	return "[" + e.Code + "] " + e.Message
+}
+
+// ActionResult is an entry in a 207 Multi-Status response from PUT /v1/instances
+// (and similar bulk-action endpoints). Verda returns one of these per target ID.
+type ActionResult struct {
+	InstanceID string `json:"instanceId"`
+	Action     string `json:"action"`
+	Status     string `json:"status"`
+	Error      string `json:"error,omitempty"`
+	StatusCode int    `json:"statusCode,omitempty"`
+}
+
+// Resource status enum (shared by instances and clusters).
+const (
+	StatusRunning            = "running"
+	StatusProvisioning       = "provisioning"
+	StatusOffline            = "offline"
+	StatusDiscontinued       = "discontinued"
+	StatusUnknown            = "unknown"
+	StatusOrdered            = "ordered"
+	StatusNotFound           = "notfound"
+	StatusNew                = "new"
+	StatusError              = "error"
+	StatusDeleting           = "deleting"
+	StatusValidating         = "validating"
+	StatusNoCapacity         = "no_capacity"
+	StatusInstallationFailed = "installation_failed"
+)
+
+// Instance action enum (body of PUT /v1/instances).
+const (
+	InstanceActionBoot          = "boot"
+	InstanceActionStart         = "start"
+	InstanceActionShutdown      = "shutdown"
+	InstanceActionForceShutdown = "force_shutdown"
+	InstanceActionDelete        = "delete"
+	InstanceActionDiscontinue   = "discontinue"
+	InstanceActionHibernate     = "hibernate"
+	InstanceActionConfigureSpot = "configure_spot"
+	InstanceActionDeleteStuck   = "delete_stuck"
+	InstanceActionDeploy        = "deploy"
+	InstanceActionTransfer      = "transfer"
+)
+
+// Volume action enum (body of PUT /v1/volumes).
+const (
+	VolumeActionAttach  = "attach"
+	VolumeActionDetach  = "detach"
+	VolumeActionDelete  = "delete"
+	VolumeActionRename  = "rename"
+	VolumeActionResize  = "resize"
+	VolumeActionRestore = "restore"
+	VolumeActionClone   = "clone"
+	VolumeActionCancel  = "cancel"
+	VolumeActionCreate  = "create"
+	VolumeActionExport  = "export"
+)
+
+// Volume type enum.
+const (
+	VolumeTypeHDD               = "HDD"
+	VolumeTypeNVMe              = "NVMe"
+	VolumeTypeHDDShared         = "HDD_Shared"
+	VolumeTypeNVMeShared        = "NVMe_Shared"
+	VolumeTypeNVMeLocalStorage  = "NVMe_Local_Storage"
+	VolumeTypeNVMeSharedCluster = "NVMe_Shared_Cluster"
+	VolumeTypeNVMeOSCluster     = "NVMe_OS_Cluster"
+)
+
+// Contract enum.
+const (
+	ContractLongTerm     = "LONG_TERM"
+	ContractPayAsYouGo   = "PAY_AS_YOU_GO"
+	ContractSpot         = "SPOT"
+	ExtensionAutoRenew   = "auto_renew"
+	ExtensionPayAsYouGo  = "pay_as_you_go"
+	ExtensionEndContract = "end_contract"
+)
+
+// HardwareDescriptor is the uniform shape Verda uses for cpu/gpu/memory/storage
+// blocks across instance, cluster, and instance-type responses.
+type HardwareDescriptor struct {
+	Description     string `json:"description,omitempty"`
+	NumberOfCores   int    `json:"number_of_cores,omitempty"`
+	NumberOfGpus    int    `json:"number_of_gpus,omitempty"`
+	SizeInGigabytes int    `json:"size_in_gigabytes,omitempty"`
+}
+
+// Instance is the GET /v1/instances/{id} payload.
+type Instance struct {
+	ID              string             `json:"id"`
+	IP              string             `json:"ip,omitempty"`
+	Status          string             `json:"status"`
+	CreatedAt       string             `json:"created_at,omitempty"`
+	CPU             HardwareDescriptor `json:"cpu"`
+	GPU             HardwareDescriptor `json:"gpu"`
+	GPUMemory       HardwareDescriptor `json:"gpu_memory"`
+	Memory          HardwareDescriptor `json:"memory"`
+	Storage         HardwareDescriptor `json:"storage"`
+	Hostname        string             `json:"hostname,omitempty"`
+	Description     string             `json:"description,omitempty"`
+	Location        string             `json:"location,omitempty"`
+	PricePerHour    float64            `json:"price_per_hour,omitempty"`
+	IsSpot          bool               `json:"is_spot,omitempty"`
+	InstanceType    string             `json:"instance_type,omitempty"`
+	Image           string             `json:"image,omitempty"`
+	OSName          string             `json:"os_name,omitempty"`
+	StartupScriptID string             `json:"startup_script_id,omitempty"`
+	SSHKeyIDs       []string           `json:"ssh_key_ids,omitempty"`
+	OSVolumeID      string             `json:"os_volume_id,omitempty"`
+	JupyterToken    string             `json:"jupyter_token,omitempty"`
+	Contract        string             `json:"contract,omitempty"`
+	Pricing         string             `json:"pricing,omitempty"`
+	VolumeIDs       []string           `json:"volume_ids,omitempty"`
+}
+
+// DeployInstanceRequest is the body of POST /v1/instances.
+type DeployInstanceRequest struct {
+	InstanceType    string       `json:"instance_type"`
+	Image           string       `json:"image"`
+	Hostname        string       `json:"hostname"`
+	Description     string       `json:"description"`
+	LocationCode    string       `json:"location_code"`
+	SSHKeyIDs       []string     `json:"ssh_key_ids,omitempty"`
+	StartupScriptID string       `json:"startup_script_id,omitempty"`
+	IsSpot          bool         `json:"is_spot,omitempty"`
+	Coupon          string       `json:"coupon,omitempty"`
+	Contract        string       `json:"contract,omitempty"`
+	OSVolume        *OSVolumeDto `json:"os_volume,omitempty"`
+	Volumes         []VolumeDto  `json:"volumes,omitempty"`
+	ExistingVolumes []string     `json:"existing_volumes,omitempty"`
+}
+
+// OSVolumeDto is the nested OS-volume spec on DeployInstanceRequest.
+type OSVolumeDto struct {
+	Name              string `json:"name"`
+	Size              int    `json:"size"`
+	OnSpotDiscontinue string `json:"on_spot_discontinue,omitempty"`
+}
+
+// VolumeDto is the nested non-OS-volume spec on DeployInstanceRequest.
+type VolumeDto struct {
+	Name              string `json:"name"`
+	Size              int    `json:"size"`
+	Type              string `json:"type"`
+	OnSpotDiscontinue string `json:"on_spot_discontinue,omitempty"`
+}
+
+// PerformInstanceActionRequest is the body of PUT /v1/instances.
+type PerformInstanceActionRequest struct {
+	Action            string      `json:"action"`
+	ID                interface{} `json:"id"` // string or []string
+	VolumeIDs         []string    `json:"volume_ids,omitempty"`
+	DeletePermanently bool        `json:"delete_permanently,omitempty"`
+}
+
+// WorkerNode is an entry in Cluster.WorkerNodes.
+type WorkerNode struct {
+	ID        string `json:"id"`
+	Hostname  string `json:"hostname,omitempty"`
+	PublicIP  string `json:"public_ip,omitempty"`
+	PrivateIP string `json:"private_ip,omitempty"`
+	Status    string `json:"status,omitempty"`
+}
+
+// ClusterSharedVolume describes an SFS mounted on a cluster.
+type ClusterSharedVolume struct {
+	ID              string `json:"id"`
+	Name            string `json:"name"`
+	MountPoint      string `json:"mount_point,omitempty"`
+	SizeInGigabytes int    `json:"size_in_gigabytes,omitempty"`
+}
+
+// Cluster is the GET /v1/clusters/{id} payload.
+type Cluster struct {
+	ID                string                `json:"id"`
+	IP                string                `json:"ip,omitempty"` // jump host
+	Status            string                `json:"status"`
+	CreatedAt         string                `json:"created_at,omitempty"`
+	CPU               HardwareDescriptor    `json:"cpu"`
+	GPU               HardwareDescriptor    `json:"gpu"`
+	GPUMemory         HardwareDescriptor    `json:"gpu_memory"`
+	Memory            HardwareDescriptor    `json:"memory"`
+	Hostname          string                `json:"hostname,omitempty"`
+	Description       string                `json:"description,omitempty"`
+	Location          string                `json:"location,omitempty"`
+	PricePerHour      float64               `json:"price_per_hour,omitempty"`
+	ClusterType       string                `json:"cluster_type,omitempty"`
+	Image             string                `json:"image,omitempty"`
+	OSName            string                `json:"os_name,omitempty"`
+	StartupScriptID   string                `json:"startup_script_id,omitempty"`
+	SSHKeyIDs         []string              `json:"ssh_key_ids,omitempty"`
+	Contract          string                `json:"contract,omitempty"`
+	ExtensionSettings string                `json:"extension_settings,omitempty"`
+	LongTermPeriod    string                `json:"long_term_period,omitempty"`
+	WorkerNodes       []WorkerNode          `json:"worker_nodes,omitempty"`
+	SharedVolumes     []ClusterSharedVolume `json:"shared_volumes,omitempty"`
+}
+
+// DeployClusterRequest is the body of POST /v1/clusters.
+type DeployClusterRequest struct {
+	ClusterType       string                    `json:"cluster_type"`
+	Image             string                    `json:"image"`
+	SSHKeyIDs         []string                  `json:"ssh_key_ids,omitempty"`
+	StartupScriptID   string                    `json:"startup_script_id,omitempty"`
+	Hostname          string                    `json:"hostname"`
+	Description       string                    `json:"description"`
+	LocationCode      string                    `json:"location_code"`
+	Contract          string                    `json:"contract,omitempty"`
+	ExtensionSettings string                    `json:"extension_settings,omitempty"`
+	SharedVolume      *SharedVolumeDto          `json:"shared_volume,omitempty"`
+	ExistingVolumes   []ExistingSharedVolumeDto `json:"existing_volumes,omitempty"`
+	Coupon            string                    `json:"coupon,omitempty"`
+}
+
+// SharedVolumeDto is the shared_volume block on cluster creation.
+type SharedVolumeDto struct {
+	Name string `json:"name"`
+	Size int    `json:"size"`
+}
+
+// ExistingSharedVolumeDto attaches a previously created SFS on cluster creation.
+type ExistingSharedVolumeDto struct {
+	ID string `json:"id"`
+}
+
+// Volume is the GET /v1/volumes/{id} payload (active; trash has additional fields).
+type Volume struct {
+	ID           string   `json:"id"`
+	InstanceID   string   `json:"instance_id,omitempty"`
+	Name         string   `json:"name"`
+	CreatedAt    string   `json:"created_at,omitempty"`
+	Status       string   `json:"status"`
+	Size         int      `json:"size"`
+	IsOSVolume   bool     `json:"is_os_volume,omitempty"`
+	Target       string   `json:"target,omitempty"`
+	Type         string   `json:"type"`
+	Location     string   `json:"location,omitempty"`
+	SSHKeyIDs    []string `json:"ssh_key_ids,omitempty"`
+	PseudoPath   string   `json:"pseudo_path,omitempty"`
+	Contract     string   `json:"contract,omitempty"`
+	BaseHourly   float64  `json:"base_hourly_cost,omitempty"`
+	MonthlyPrice float64  `json:"monthly_price,omitempty"`
+	Currency     string   `json:"currency,omitempty"`
+}
+
+// SSHKey is the GET /v1/ssh-keys/{id} payload.
+type SSHKey struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Key       string `json:"key,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+}
+
+// Script is the GET /v1/scripts/{id} payload.
+type Script struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Script    string `json:"script,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+}
+
+// InstanceType is an entry in GET /v1/instance-types.
+type InstanceType struct {
+	ID                  string             `json:"id"`
+	InstanceType        string             `json:"instance_type"`
+	Name                string             `json:"name,omitempty"`
+	DisplayName         string             `json:"display_name,omitempty"`
+	Model               string             `json:"model,omitempty"`
+	Description         string             `json:"description,omitempty"`
+	Manufacturer        string             `json:"manufacturer,omitempty"`
+	CPU                 HardwareDescriptor `json:"cpu"`
+	GPU                 HardwareDescriptor `json:"gpu"`
+	GPUMemory           HardwareDescriptor `json:"gpu_memory"`
+	Memory              HardwareDescriptor `json:"memory"`
+	Storage             HardwareDescriptor `json:"storage"`
+	P2P                 string             `json:"p2p,omitempty"`
+	PricePerHour        string             `json:"price_per_hour,omitempty"`
+	SpotPrice           string             `json:"spot_price,omitempty"`
+	ServerlessPrice     string             `json:"serverless_price,omitempty"`
+	ServerlessSpotPrice string             `json:"serverless_spot_price,omitempty"`
+	Currency            string             `json:"currency,omitempty"`
+	BestFor             []string           `json:"best_for,omitempty"`
+	DeployWarning       string             `json:"deploy_warning,omitempty"`
+	SupportedOS         []string           `json:"supported_os,omitempty"`
+}
+
+// Location is an entry in GET /v1/locations.
+type Location struct {
+	Code        string `json:"code"`
+	Name        string `json:"name"`
+	CountryCode string `json:"country_code,omitempty"`
+}
+
+// Balance is the GET /v1/balance payload.
+type Balance struct {
+	Amount   float64 `json:"amount"`
+	Currency string  `json:"currency,omitempty"`
+}
+
+// Image is an entry in GET /v1/images or /v1/images/cluster.
+type Image struct {
+	ID        string   `json:"id,omitempty"`
+	ImageType string   `json:"image_type,omitempty"`
+	Name      string   `json:"name,omitempty"`
+	Category  string   `json:"category,omitempty"`
+	IsDefault bool     `json:"is_default,omitempty"`
+	IsCluster bool     `json:"is_cluster,omitempty"`
+	Details   []string `json:"details,omitempty"`
+}


### PR DESCRIPTION
## Summary
- Adds Verda Cloud (ex-DataCrunch) as a first-class clanker provider, mirroring the shape of the existing cf/do/hetzner/vercel integrations.
- New `clanker verda` command tree (list/get/action/balance + `verda ask`) plus `clanker ask --verda` with keyword routing.
- Adds `verda-instant` Kubernetes cluster provider so `clanker k8s` can provision and pull kubeconfigs from Verda Instant Clusters.
- Exposes `clanker_verda_ask` / `clanker_verda_list` over MCP.

## Details
- OAuth2 Client Credentials flow against `https://api.verda.com/v1`, with `expires_in`-driven refresh, 429 / `Retry-After`, 207 multi-status and `{code,message}` error decoding.
- Credential resolution order matches other providers: `~/.clanker.yaml` → `VERDA_*` env → `~/.verda/credentials` (written by `verda auth login`).
- Pulls kubeconfig off an Instant Cluster's head node via SSH and rewrites the `server:` URL to the public IP.
- Unit tests cover token caching, 429 retry, multi-status decode, and credentials-file parsing (YAML + flat).

## Test plan
- [x] `make fmt vet test-short build`
- [x] `./bin/clanker verda --help` shows the new tree
- [x] `./bin/clanker ask --help` lists `--verda`
- [ ] `./bin/clanker verda list instances` against a real Verda account
- [ ] `./bin/clanker verda ask "what's my balance and running GPUs?"` against a real account
- [ ] `./bin/clanker mcp --transport http --listen :39393` exposes `clanker_verda_*`