### PR TITLE
feat: cost & k8s phase 1 — anomaly detection, tag audit, networkpolicy audit, resourcedb logging

### DIFF
--- a/cmd/cost.go
+++ b/cmd/cost.go
@@ -13,15 +13,17 @@ import (
 )
 
 var (
-	costProvider  string
-	costStartDate string
-	costEndDate   string
-	costFormat    string
-	costOutput    string
-	costTop       int
-	costTagKey    string
-	costGroupBy   string
-	costProfile   string
+	costProvider     string
+	costStartDate    string
+	costEndDate      string
+	costFormat       string
+	costOutput       string
+	costTop          int
+	costTagKey       string
+	costGroupBy      string
+	costProfile      string
+	costTagsAudit    bool
+	costRequiredTags string
 )
 
 func init() {
@@ -52,6 +54,8 @@ func init() {
 
 	// Tags specific flags
 	costTagsCmd.Flags().StringVar(&costTagKey, "key", "", "Filter by tag key")
+	costTagsCmd.Flags().BoolVar(&costTagsAudit, "audit", false, "Audit tag compliance: report untagged spend per required key")
+	costTagsCmd.Flags().StringVar(&costRequiredTags, "required-tags", "Environment,Owner,Project", "Comma-separated tag keys to audit (used with --audit)")
 }
 
 // costCmd represents the cost command
@@ -305,10 +309,16 @@ var costTagsCmd = &cobra.Command{
 	Short: "Show cost grouped by tags",
 	Long: `Display costs grouped by user-defined tags.
 
+With --audit, runs a tag-compliance audit: for each required tag key it
+reports how much spend ended up in the untagged bucket (resources without
+that tag) versus the tagged buckets, so you can spot governance gaps.
+
 Examples:
   clanker cost tags
   clanker cost tags --key Environment
-  clanker cost tags --key Team --format json`,
+  clanker cost tags --key Team --format json
+  clanker cost tags --audit
+  clanker cost tags --audit --required-tags env,owner,cost-center`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
 		debug := viper.GetBool("debug")
@@ -317,6 +327,22 @@ Examples:
 		formatter := cost.NewFormatter(costFormat, true)
 
 		start, end := resolveDateRangeAsTime()
+
+		if costTagsAudit {
+			keys := strings.Split(costRequiredTags, ",")
+			report, err := aggregator.AuditTags(ctx, keys, start, end)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error auditing tags: %v\n", err)
+				os.Exit(1)
+			}
+			output, err := formatter.FormatTagAudit(report)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error formatting output: %v\n", err)
+				os.Exit(1)
+			}
+			formatter.Print(output)
+			return
+		}
 
 		tagKey := costTagKey
 		if tagKey == "" {

--- a/cmd/domain_agents.go
+++ b/cmd/domain_agents.go
@@ -312,7 +312,7 @@ func collectDatabaseAgentContext(ctx context.Context, question string, dbConnect
 	}
 
 	if (queryAllProviders || shouldQueryDomainProvider(question, "hetzner")) && hasHetznerDomainAccess() {
-		warnings = append(warnings, "Hetzner database inventory is not implemented in the current CLI integrations")
+		warnings = appendUnsupportedFeature(warnings, "Hetzner", "database inventory")
 	}
 
 	return sections, warnings
@@ -1044,7 +1044,7 @@ func collectCICDAgentContext(ctx context.Context, question string, debug bool) (
 		}
 	}
 	if shouldQueryDomainProvider(question, "hetzner") && hasHetznerDomainAccess() {
-		warnings = append(warnings, "Hetzner build or deployment inventory is not implemented in the current CLI integrations")
+		warnings = appendUnsupportedFeature(warnings, "Hetzner", "build or deployment inventory")
 	}
 
 	return sections, warnings
@@ -1295,6 +1295,13 @@ func appendDomainWarning(warnings []string, title string, err error) []string {
 		return warnings
 	}
 	return append(warnings, fmt.Sprintf("%s: %v", title, err))
+}
+
+// appendUnsupportedFeature records that a provider lacks coverage for a
+// specific area. Distinct from appendDomainWarning so the agent prompt can
+// frame these as documented limitations rather than transient errors.
+func appendUnsupportedFeature(warnings []string, provider, area string) []string {
+	return append(warnings, fmt.Sprintf("%s %s: not yet supported by Clanker (tracked feature gap)", provider, area))
 }
 
 func truncateDomainSection(content string) string {

--- a/cmd/k8s_autoscaler.go
+++ b/cmd/k8s_autoscaler.go
@@ -21,6 +21,7 @@ var (
 	autoscalerKubeconfig string
 	autoscalerContext    string
 	autoscalerLookback   string
+	autoscalerMaxEvents  int
 )
 
 var k8sAutoscalerCmd = &cobra.Command{
@@ -55,6 +56,7 @@ func init() {
 	k8sAutoscalerCmd.PersistentFlags().StringVar(&autoscalerKubeconfig, "kubeconfig", "", "Path to kubeconfig (default: ~/.kube/config)")
 	k8sAutoscalerCmd.PersistentFlags().StringVar(&autoscalerContext, "context", "", "kubectl context to use")
 	k8sAutoscalerAnalyzeCmd.Flags().StringVar(&autoscalerLookback, "lookback", "1h", "Lookback window for event analysis (e.g. 30m, 6h, 24h)")
+	k8sAutoscalerAnalyzeCmd.Flags().IntVar(&autoscalerMaxEvents, "max-events", 5000, "Maximum events to classify (most-recent kept). 0 disables the cap.")
 }
 
 func runAutoscalerAnalyze(cmd *cobra.Command, args []string) error {
@@ -68,6 +70,7 @@ func runAutoscalerAnalyze(cmd *cobra.Command, args []string) error {
 
 	client := k8s.NewClient(autoscalerKubeconfig, autoscalerContext, debug)
 	analyzer := sre.NewAutoscalerAnalyzer(k8s.NewSREAdapter(client), debug)
+	analyzer.MaxEvents = autoscalerMaxEvents
 
 	report, err := analyzer.AnalyzeScalingWaste(ctx, lookback)
 	if err != nil {
@@ -96,7 +99,14 @@ func printAutoscalerReport(out io.Writer, report *sre.ScalingWasteReport) {
 	if report.Inventory.Notes != "" {
 		fmt.Fprintf(out, "  note: %s\n", report.Inventory.Notes)
 	}
-	fmt.Fprintf(out, "Lookback: %s   Generated: %s\n\n", report.LookbackWindow, report.GeneratedAt.Format(time.RFC3339))
+	fmt.Fprintf(out, "Lookback: %s   Generated: %s\n", report.LookbackWindow, report.GeneratedAt.Format(time.RFC3339))
+	if report.EventsTruncated {
+		fmt.Fprintf(out, "⚠  Event stream truncated to %d most-recent entries (some history dropped). Raise --max-events for full coverage.\n",
+			report.EventsProcessed)
+	} else {
+		fmt.Fprintf(out, "Events processed: %d\n", report.EventsProcessed)
+	}
+	fmt.Fprintln(out)
 
 	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(w, "SIGNAL\tCOUNT")

--- a/cmd/k8s_autoscaler.go
+++ b/cmd/k8s_autoscaler.go
@@ -1,0 +1,137 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/bgdnvk/clanker/internal/k8s"
+	"github.com/bgdnvk/clanker/internal/k8s/sre"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	autoscalerOutput     string
+	autoscalerKubeconfig string
+	autoscalerContext    string
+	autoscalerLookback   string
+)
+
+var k8sAutoscalerCmd = &cobra.Command{
+	Use:   "autoscaler",
+	Short: "Analyze cluster-autoscaler / Karpenter scaling behaviour",
+	Long: `Analyze recent kube-system events to spot scaling waste — pods stuck
+pending because no node fit, scale-ups that didn't happen, scale-downs that
+pulled back too quickly.
+
+Read-only: only kubectl get/describe is invoked.`,
+}
+
+var k8sAutoscalerAnalyzeCmd = &cobra.Command{
+	Use:   "analyze",
+	Short: "Detect autoscaler type and surface scaling waste signals",
+	Long: `Detect whether cluster-autoscaler or Karpenter is running, then
+classify recent events into useful categories: FailedScheduling,
+NotTriggerScaleUp, TriggeredScaleUp, ScaleDown[Empty|Unneeded], NodeNotReady.
+
+Examples:
+  clanker k8s autoscaler analyze
+  clanker k8s autoscaler analyze --lookback 6h
+  clanker k8s autoscaler analyze -o json`,
+	RunE: runAutoscalerAnalyze,
+}
+
+func init() {
+	k8sCmd.AddCommand(k8sAutoscalerCmd)
+	k8sAutoscalerCmd.AddCommand(k8sAutoscalerAnalyzeCmd)
+
+	k8sAutoscalerCmd.PersistentFlags().StringVarP(&autoscalerOutput, "output", "o", "table", "Output format (table, json)")
+	k8sAutoscalerCmd.PersistentFlags().StringVar(&autoscalerKubeconfig, "kubeconfig", "", "Path to kubeconfig (default: ~/.kube/config)")
+	k8sAutoscalerCmd.PersistentFlags().StringVar(&autoscalerContext, "context", "", "kubectl context to use")
+	k8sAutoscalerAnalyzeCmd.Flags().StringVar(&autoscalerLookback, "lookback", "1h", "Lookback window for event analysis (e.g. 30m, 6h, 24h)")
+}
+
+func runAutoscalerAnalyze(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	debug := viper.GetBool("debug")
+
+	lookback, err := time.ParseDuration(autoscalerLookback)
+	if err != nil {
+		return fmt.Errorf("invalid --lookback %q: %w", autoscalerLookback, err)
+	}
+
+	client := k8s.NewClient(autoscalerKubeconfig, autoscalerContext, debug)
+	analyzer := sre.NewAutoscalerAnalyzer(k8s.NewSREAdapter(client), debug)
+
+	report, err := analyzer.AnalyzeScalingWaste(ctx, lookback)
+	if err != nil {
+		return fmt.Errorf("autoscaler analysis failed: %w", err)
+	}
+
+	switch strings.ToLower(autoscalerOutput) {
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	default:
+		printAutoscalerReport(os.Stdout, report)
+		return nil
+	}
+}
+
+func printAutoscalerReport(out io.Writer, report *sre.ScalingWasteReport) {
+	if report == nil {
+		fmt.Fprintln(out, "No autoscaler report.")
+		return
+	}
+
+	fmt.Fprintf(out, "Autoscaler: %s   (CA seen: %v, Karpenter present: %v)\n",
+		report.Inventory.Type, report.Inventory.ClusterAutoscalerSeen, report.Inventory.KarpenterPresent)
+	if report.Inventory.Notes != "" {
+		fmt.Fprintf(out, "  note: %s\n", report.Inventory.Notes)
+	}
+	fmt.Fprintf(out, "Lookback: %s   Generated: %s\n\n", report.LookbackWindow, report.GeneratedAt.Format(time.RFC3339))
+
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "SIGNAL\tCOUNT")
+	fmt.Fprintln(w, "------\t-----")
+	fmt.Fprintf(w, "FailedScheduling\t%d\n", report.FailedScheduling)
+	fmt.Fprintf(w, "NotTriggerScaleUp\t%d\n", report.NotTriggerScaleUp)
+	fmt.Fprintf(w, "TriggeredScaleUp\t%d\n", report.TriggeredScaleUp)
+	fmt.Fprintf(w, "ScaleDownEmpty\t%d\n", report.ScaleDownEmpty)
+	fmt.Fprintf(w, "ScaleDownUnneeded\t%d\n", report.ScaleDownUnneeded)
+	fmt.Fprintf(w, "NodeNotReady\t%d\n", report.NodeNotReadyEvents)
+	w.Flush()
+
+	if total := report.FailedScheduling + report.NotTriggerScaleUp; total > 0 {
+		fmt.Fprintf(out, "\n⚠  %d pod-side scaling waste events in the last %s\n", total, report.LookbackWindow)
+	}
+
+	if len(report.TopFailingPods) > 0 {
+		fmt.Fprintln(out, "\nTop pods stuck waiting for capacity:")
+		tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "NAMESPACE\tPOD\tFAILED-SCHED\tNOT-SCALE-UP\tLAST REASON")
+		fmt.Fprintln(tw, "---------\t---\t------------\t-------------\t-----------")
+		for _, p := range report.TopFailingPods {
+			fmt.Fprintf(tw, "%s\t%s\t%d\t%d\t%s\n",
+				orDash(p.Namespace), p.Name,
+				p.FailedSchedCount, p.NotScaleUpCount,
+				orDash(p.LastReason),
+			)
+		}
+		tw.Flush()
+	}
+
+	if len(report.HotNodeReasons) > 0 {
+		fmt.Fprintln(out, "\nHot node reasons:")
+		for _, r := range report.HotNodeReasons {
+			fmt.Fprintf(out, "  %s × %d   %s\n", r.Reason, r.Count, truncate(r.SampleMessage, 80))
+		}
+	}
+}

--- a/cmd/k8s_autoscaler_print_test.go
+++ b/cmd/k8s_autoscaler_print_test.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/bgdnvk/clanker/internal/k8s/sre"
+)
+
+func TestPrintAutoscalerReport_Nil(t *testing.T) {
+	var buf bytes.Buffer
+	printAutoscalerReport(&buf, nil)
+	if !strings.Contains(buf.String(), "No autoscaler report") {
+		t.Errorf("expected nil-report message, got %q", buf.String())
+	}
+}
+
+func TestPrintAutoscalerReport_AllZeroCounts(t *testing.T) {
+	var buf bytes.Buffer
+	printAutoscalerReport(&buf, &sre.ScalingWasteReport{
+		Inventory:       sre.AutoscalerInventory{Type: sre.AutoscalerNone},
+		LookbackWindow:  "1h0m0s",
+		EventsProcessed: 0,
+	})
+	out := buf.String()
+	if !strings.Contains(out, "Autoscaler: none") {
+		t.Errorf("expected inventory line, got %q", out)
+	}
+	if !strings.Contains(out, "Events processed: 0") {
+		t.Errorf("expected events-processed footer, got %q", out)
+	}
+	// Zero counters should still render, not blow up.
+	if !strings.Contains(out, "FailedScheduling") {
+		t.Errorf("expected signal table, got %q", out)
+	}
+	// No pod failures section when empty.
+	if strings.Contains(out, "Top pods stuck") {
+		t.Errorf("should not print pod-failures section when empty:\n%s", out)
+	}
+}
+
+func TestPrintAutoscalerReport_TruncationWarning(t *testing.T) {
+	var buf bytes.Buffer
+	printAutoscalerReport(&buf, &sre.ScalingWasteReport{
+		Inventory:       sre.AutoscalerInventory{Type: sre.AutoscalerClusterAutoscaler, ClusterAutoscalerSeen: true},
+		LookbackWindow:  "1h0m0s",
+		EventsProcessed: 5000,
+		EventsTruncated: true,
+	})
+	out := buf.String()
+	if !strings.Contains(out, "Event stream truncated to 5000") {
+		t.Errorf("expected truncation warning, got %q", out)
+	}
+	if strings.Contains(out, "Events processed:") && !strings.Contains(out, "Event stream truncated") {
+		t.Errorf("when truncated, do not show plain events-processed line")
+	}
+}
+
+func TestPrintAutoscalerReport_PodFailuresAndHotReasons(t *testing.T) {
+	var buf bytes.Buffer
+	report := &sre.ScalingWasteReport{
+		Inventory:         sre.AutoscalerInventory{Type: sre.AutoscalerKarpenter, KarpenterPresent: true},
+		LookbackWindow:    "6h0m0s",
+		EventsProcessed:   42,
+		FailedScheduling:  10,
+		NotTriggerScaleUp: 3,
+		TriggeredScaleUp:  5,
+		TopFailingPods: []sre.PodFailure{
+			{
+				Namespace:        "prod",
+				Name:             "api-7d9",
+				FailedSchedCount: 8,
+				NotScaleUpCount:  2,
+				LastReason:       "NotTriggerScaleUp",
+			},
+			{
+				Namespace:        "default",
+				Name:             "worker-abc",
+				FailedSchedCount: 2,
+				LastReason:       "FailedScheduling",
+			},
+		},
+		HotNodeReasons: []sre.ReasonCount{
+			{Reason: "ScaleDownEmpty", Count: 5, SampleMessage: "removed empty node"},
+			{Reason: "NodeNotReady", Count: 2, SampleMessage: "kubelet unresponsive"},
+		},
+	}
+
+	printAutoscalerReport(&buf, report)
+	out := buf.String()
+
+	// Headline includes the pod-side waste warning (10 + 3 = 13 events).
+	if !strings.Contains(out, "13 pod-side scaling waste events") {
+		t.Errorf("expected combined pod-waste warning, got %q", out)
+	}
+	// Per-pod table rows.
+	for _, want := range []string{"api-7d9", "worker-abc", "prod", "default"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in pod table:\n%s", want, out)
+		}
+	}
+	// Hot-node reasons section.
+	if !strings.Contains(out, "ScaleDownEmpty × 5") {
+		t.Errorf("expected hot-reason summary, got %q", out)
+	}
+	if !strings.Contains(out, "removed empty node") {
+		t.Errorf("expected sample message in output, got %q", out)
+	}
+}
+
+func TestPrintAutoscalerReport_NotesSurfaced(t *testing.T) {
+	var buf bytes.Buffer
+	printAutoscalerReport(&buf, &sre.ScalingWasteReport{
+		Inventory: sre.AutoscalerInventory{
+			Type:  sre.AutoscalerNone,
+			Notes: "karpenter detection failed: connection refused",
+		},
+		LookbackWindow:  "1h0m0s",
+		EventsProcessed: 0,
+	})
+	if !strings.Contains(buf.String(), "connection refused") {
+		t.Errorf("expected Notes to surface, got %q", buf.String())
+	}
+}

--- a/cmd/k8s_health.go
+++ b/cmd/k8s_health.go
@@ -1,0 +1,178 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/bgdnvk/clanker/internal/k8s"
+	"github.com/bgdnvk/clanker/internal/k8s/sre"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	healthOutput     string
+	healthKubeconfig string
+	healthContext    string
+	healthSeverity   string
+)
+
+var k8sHealthCmd = &cobra.Command{
+	Use:   "health",
+	Short: "Score cluster health and list per-resource issues",
+	Long: `Run a cluster-wide health check that aggregates node, workload, storage,
+and network signals. Surfaces concrete issues (CrashLoopBackOff, OOMKilled,
+restart-rate spikes, NotReady nodes, …) with severity and remediation
+suggestions.
+
+The check is read-only — it issues kubectl get/describe commands; nothing is
+modified.
+
+Examples:
+  clanker k8s health
+  clanker k8s health --severity critical
+  clanker k8s health -o json
+  clanker k8s health --kubeconfig ~/.kube/prod`,
+	RunE: runK8sHealth,
+}
+
+func init() {
+	k8sCmd.AddCommand(k8sHealthCmd)
+	k8sHealthCmd.Flags().StringVarP(&healthOutput, "output", "o", "table", "Output format (table, json)")
+	k8sHealthCmd.Flags().StringVar(&healthKubeconfig, "kubeconfig", "", "Path to kubeconfig (default: ~/.kube/config)")
+	k8sHealthCmd.Flags().StringVar(&healthContext, "context", "", "kubectl context to use")
+	k8sHealthCmd.Flags().StringVar(&healthSeverity, "severity", "", "Minimum severity to surface (info, warning, critical) — default shows all")
+}
+
+func runK8sHealth(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	debug := viper.GetBool("debug")
+
+	client := k8s.NewClient(healthKubeconfig, healthContext, debug)
+	checker := sre.NewHealthChecker(k8s.NewSREAdapter(client), debug)
+
+	summary, issues, err := checker.CheckClusterDetailed(ctx)
+	if err != nil {
+		return fmt.Errorf("health check failed: %w", err)
+	}
+
+	filtered := filterIssuesBySeverity(issues, healthSeverity)
+
+	switch strings.ToLower(healthOutput) {
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(struct {
+			Summary *sre.ClusterHealthSummary `json:"summary"`
+			Issues  []sre.Issue               `json:"issues"`
+		}{Summary: summary, Issues: filtered})
+	default:
+		printHealthSummary(os.Stdout, summary, filtered)
+		return nil
+	}
+}
+
+// filterIssuesBySeverity drops issues below the requested floor. Empty
+// (default) returns all. Unknown values are treated as "show everything"
+// so a typo doesn't silently hide critical issues.
+func filterIssuesBySeverity(issues []sre.Issue, floor string) []sre.Issue {
+	floor = strings.ToLower(strings.TrimSpace(floor))
+	if floor == "" {
+		return issues
+	}
+	rank := map[string]int{"info": 0, "warning": 1, "critical": 2}
+	cut, ok := rank[floor]
+	if !ok {
+		return issues
+	}
+	out := make([]sre.Issue, 0, len(issues))
+	for _, i := range issues {
+		if rank[strings.ToLower(string(i.Severity))] >= cut {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+func printHealthSummary(out io.Writer, summary *sre.ClusterHealthSummary, issues []sre.Issue) {
+	if summary == nil {
+		fmt.Fprintln(out, "No health summary returned.")
+		return
+	}
+
+	fmt.Fprintf(out, "Cluster health: %s (score %d/100)\n", strings.ToUpper(summary.OverallHealth), summary.Score)
+	fmt.Fprintf(out, "  critical issues: %d   warning issues: %d\n\n", summary.CriticalIssues, summary.WarningIssues)
+
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "COMPONENT\tSTATUS\tSCORE")
+	fmt.Fprintln(w, "---------\t------\t-----")
+	fmt.Fprintf(w, "nodes\t%s\t%d\n", summary.NodeHealth.Status, summary.NodeHealth.Score)
+	fmt.Fprintf(w, "workloads\t%s\t%d\n", summary.WorkloadHealth.Status, summary.WorkloadHealth.Score)
+	fmt.Fprintf(w, "storage\t%s\t%d\n", summary.StorageHealth.Status, summary.StorageHealth.Score)
+	fmt.Fprintf(w, "network\t%s\t%d\n", summary.NetworkHealth.Status, summary.NetworkHealth.Score)
+	w.Flush()
+
+	fmt.Fprintf(out, "\nPods: %d total | %d running | %d pending | %d failed\n",
+		summary.TotalPods, summary.RunningPods, summary.PendingPods, summary.FailedPods)
+
+	if len(issues) == 0 {
+		fmt.Fprintln(out, "\nNo issues detected at the requested severity floor. ✓")
+		return
+	}
+
+	// Sort issues critical first, then warning, then info.
+	sort.SliceStable(issues, func(i, j int) bool {
+		return severityRank(issues[i].Severity) > severityRank(issues[j].Severity)
+	})
+
+	fmt.Fprintf(out, "\n%d issue(s):\n", len(issues))
+	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "SEVERITY\tRESOURCE\tNAMESPACE\tCATEGORY\tMESSAGE")
+	fmt.Fprintln(tw, "--------\t--------\t---------\t--------\t-------")
+	for _, i := range issues {
+		ns := i.Namespace
+		if ns == "" {
+			ns = "-"
+		}
+		fmt.Fprintf(tw, "%s\t%s/%s\t%s\t%s\t%s\n",
+			strings.ToUpper(string(i.Severity)),
+			i.ResourceType, i.ResourceName,
+			ns,
+			i.Category,
+			truncate(i.Message, 80),
+		)
+	}
+	tw.Flush()
+}
+
+func severityRank(s sre.IssueSeverity) int {
+	switch strings.ToLower(string(s)) {
+	case "critical":
+		return 3
+	case "warning":
+		return 2
+	case "info":
+		return 1
+	}
+	return 0
+}
+
+// truncate caps a string at n runes, replacing the tail with "…" when it
+// overflows. Operates on runes (not bytes) so the result has predictable
+// display width regardless of UTF-8 content.
+func truncate(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n-1]) + "…"
+}

--- a/cmd/k8s_health_test.go
+++ b/cmd/k8s_health_test.go
@@ -1,0 +1,132 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/bgdnvk/clanker/internal/k8s/sre"
+)
+
+func TestFilterIssuesBySeverity(t *testing.T) {
+	all := []sre.Issue{
+		{Severity: sre.SeverityCritical, ResourceName: "p1"},
+		{Severity: sre.SeverityWarning, ResourceName: "p2"},
+		{Severity: sre.SeverityInfo, ResourceName: "p3"},
+	}
+
+	cases := []struct {
+		floor string
+		want  []string // ResourceNames in result
+	}{
+		{floor: "", want: []string{"p1", "p2", "p3"}},
+		{floor: "info", want: []string{"p1", "p2", "p3"}},
+		{floor: "warning", want: []string{"p1", "p2"}},
+		{floor: "WARNING", want: []string{"p1", "p2"}}, // case-insensitive
+		{floor: "critical", want: []string{"p1"}},
+		{floor: "garbage", want: []string{"p1", "p2", "p3"}}, // unknown → fail-open, surface everything
+	}
+
+	for _, c := range cases {
+		got := filterIssuesBySeverity(all, c.floor)
+		var names []string
+		for _, i := range got {
+			names = append(names, i.ResourceName)
+		}
+		if !equalSlices(names, c.want) {
+			t.Errorf("filter floor=%q got %v, want %v", c.floor, names, c.want)
+		}
+	}
+}
+
+func TestPrintHealthSummary_NoIssuesShowsCheckmark(t *testing.T) {
+	var buf bytes.Buffer
+	summary := &sre.ClusterHealthSummary{
+		OverallHealth: "healthy", Score: 95,
+		NodeHealth:     sre.ComponentHealth{Status: "healthy", Score: 100},
+		WorkloadHealth: sre.ComponentHealth{Status: "healthy", Score: 95},
+		StorageHealth:  sre.ComponentHealth{Status: "healthy", Score: 100},
+		NetworkHealth:  sre.ComponentHealth{Status: "healthy", Score: 100},
+		TotalPods:      10, RunningPods: 10,
+	}
+	printHealthSummary(&buf, summary, nil)
+	out := buf.String()
+	if !strings.Contains(out, "score 95/100") {
+		t.Errorf("missing score line:\n%s", out)
+	}
+	if !strings.Contains(out, "No issues detected") {
+		t.Errorf("missing no-issues message:\n%s", out)
+	}
+}
+
+func TestPrintHealthSummary_IssuesSortedCriticalFirst(t *testing.T) {
+	var buf bytes.Buffer
+	summary := &sre.ClusterHealthSummary{
+		OverallHealth: "critical", Score: 40,
+		NodeHealth: sre.ComponentHealth{Status: "degraded", Score: 70},
+	}
+	issues := []sre.Issue{
+		{Severity: sre.SeverityWarning, ResourceType: "pod", ResourceName: "warn-pod", Message: "warn"},
+		{Severity: sre.SeverityCritical, ResourceType: "pod", ResourceName: "crit-pod", Message: "boom"},
+		{Severity: sre.SeverityInfo, ResourceType: "node", ResourceName: "info-node", Message: "info"},
+	}
+	printHealthSummary(&buf, summary, issues)
+	out := buf.String()
+
+	criticalIdx := strings.Index(out, "crit-pod")
+	warnIdx := strings.Index(out, "warn-pod")
+	infoIdx := strings.Index(out, "info-node")
+
+	if criticalIdx == -1 || warnIdx == -1 || infoIdx == -1 {
+		t.Fatalf("missing rows in output:\n%s", out)
+	}
+	if !(criticalIdx < warnIdx && warnIdx < infoIdx) {
+		t.Errorf("expected order critical < warning < info, got positions %d %d %d:\n%s",
+			criticalIdx, warnIdx, infoIdx, out)
+	}
+}
+
+func TestPrintHealthSummary_NilSummary(t *testing.T) {
+	var buf bytes.Buffer
+	printHealthSummary(&buf, nil, nil)
+	if !strings.Contains(buf.String(), "No health summary returned") {
+		t.Errorf("expected nil-summary message, got %q", buf.String())
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	if truncate("short", 80) != "short" {
+		t.Error("short string should pass through unchanged")
+	}
+	long := strings.Repeat("x", 100)
+	got := truncate(long, 10)
+	if runes := []rune(got); len(runes) != 10 {
+		t.Errorf("truncate returned %d runes, want 10", len(runes))
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("truncate output should end with ellipsis, got %q", got)
+	}
+
+	// Multi-byte input: truncate must count runes, not bytes, so a string
+	// of emoji caps cleanly at the requested width.
+	emoji := strings.Repeat("🚀", 50)
+	if got := truncate(emoji, 5); len([]rune(got)) != 5 {
+		t.Errorf("emoji truncate: %d runes, want 5", len([]rune(got)))
+	}
+
+	if truncate("anything", 0) != "" {
+		t.Error("zero cap should return empty string")
+	}
+}
+
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/k8s_karpenter.go
+++ b/cmd/k8s_karpenter.go
@@ -1,0 +1,196 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/bgdnvk/clanker/internal/k8s"
+	"github.com/bgdnvk/clanker/internal/k8s/sre"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	karpenterOutput     string
+	karpenterKubeconfig string
+	karpenterContext    string
+)
+
+var k8sKarpenterCmd = &cobra.Command{
+	Use:   "karpenter",
+	Short: "Inspect Karpenter NodePools and NodeClaims",
+	Long: `Detect whether Karpenter is installed and list the NodePools and
+NodeClaims it manages. Useful for spotting pools with no provisioned nodes,
+mixing weights, or NodeClaims still in Pending state.
+
+All operations are read-only.`,
+}
+
+var k8sKarpenterListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List Karpenter NodePools and NodeClaims",
+	Long: `Detect Karpenter and dump the NodePool / NodeClaim inventory.
+
+Examples:
+  clanker k8s karpenter list
+  clanker k8s karpenter list -o json
+  clanker k8s karpenter list --kubeconfig ~/.kube/prod`,
+	RunE: runKarpenterList,
+}
+
+func init() {
+	k8sCmd.AddCommand(k8sKarpenterCmd)
+	k8sKarpenterCmd.AddCommand(k8sKarpenterListCmd)
+
+	k8sKarpenterCmd.PersistentFlags().StringVarP(&karpenterOutput, "output", "o", "table", "Output format (table, json)")
+	k8sKarpenterCmd.PersistentFlags().StringVar(&karpenterKubeconfig, "kubeconfig", "", "Path to kubeconfig (default: ~/.kube/config)")
+	k8sKarpenterCmd.PersistentFlags().StringVar(&karpenterContext, "context", "", "kubectl context to use")
+}
+
+type karpenterReport struct {
+	Presence   *sre.KarpenterPresence `json:"presence"`
+	NodePools  []sre.NodePoolSummary  `json:"nodePools,omitempty"`
+	NodeClaims []sre.NodeClaimSummary `json:"nodeClaims,omitempty"`
+}
+
+func runKarpenterList(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	debug := viper.GetBool("debug")
+
+	client := k8s.NewClient(karpenterKubeconfig, karpenterContext, debug)
+	detector := sre.NewKarpenterDetector(k8s.NewSREAdapter(client), debug)
+
+	presence, err := detector.Detect(ctx)
+	if err != nil {
+		return fmt.Errorf("karpenter detection failed: %w", err)
+	}
+
+	report := karpenterReport{Presence: presence}
+
+	if presence.Installed {
+		if presence.NodePoolsAvailable {
+			pools, err := detector.ListNodePools(ctx)
+			if err != nil {
+				return fmt.Errorf("list NodePools: %w", err)
+			}
+			report.NodePools = pools
+		}
+		if presence.NodeClaimsAvailable {
+			claims, err := detector.ListNodeClaims(ctx)
+			if err != nil {
+				return fmt.Errorf("list NodeClaims: %w", err)
+			}
+			report.NodeClaims = claims
+		}
+	}
+
+	switch strings.ToLower(karpenterOutput) {
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	default:
+		printKarpenterReport(os.Stdout, report)
+		return nil
+	}
+}
+
+func printKarpenterReport(out io.Writer, report karpenterReport) {
+	if report.Presence == nil || !report.Presence.Installed {
+		fmt.Fprintln(out, "Karpenter is not installed in this cluster.")
+		if report.Presence != nil && report.Presence.Notes != "" {
+			fmt.Fprintf(out, "Note: %s\n", report.Presence.Notes)
+		}
+		return
+	}
+
+	fmt.Fprintf(out, "Karpenter detected (api group: %s)\n", report.Presence.APIGroup)
+	fmt.Fprintf(out, "  NodePools CRD: %s   NodeClaims CRD: %s\n",
+		yesNoAvailable(report.Presence.NodePoolsAvailable),
+		yesNoAvailable(report.Presence.NodeClaimsAvailable),
+	)
+
+	// NodePools table
+	if len(report.NodePools) == 0 {
+		fmt.Fprintln(out, "\nNo NodePools defined.")
+	} else {
+		// Stable display order: name asc.
+		sort.SliceStable(report.NodePools, func(i, j int) bool {
+			return report.NodePools[i].Name < report.NodePools[j].Name
+		})
+		fmt.Fprintf(out, "\nNodePools (%d):\n", len(report.NodePools))
+		w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "NAME\tNODECLASS\tWEIGHT\tDISRUPTION\tAGE")
+		fmt.Fprintln(w, "----\t---------\t------\t----------\t---")
+		for _, p := range report.NodePools {
+			disruption := p.Disruption
+			if disruption == "" {
+				disruption = "-"
+			}
+			age := p.Age
+			if age == "" {
+				age = "-"
+			}
+			fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\n",
+				p.Name,
+				orDash(p.NodeClass),
+				p.Weight,
+				disruption,
+				age,
+			)
+		}
+		w.Flush()
+	}
+
+	// NodeClaims table
+	if len(report.NodeClaims) == 0 {
+		fmt.Fprintln(out, "\nNo NodeClaims provisioned.")
+	} else {
+		sort.SliceStable(report.NodeClaims, func(i, j int) bool {
+			if report.NodeClaims[i].NodePool != report.NodeClaims[j].NodePool {
+				return report.NodeClaims[i].NodePool < report.NodeClaims[j].NodePool
+			}
+			return report.NodeClaims[i].Name < report.NodeClaims[j].Name
+		})
+		var pending int
+		for _, c := range report.NodeClaims {
+			if c.Status != "Ready" {
+				pending++
+			}
+		}
+		fmt.Fprintf(out, "\nNodeClaims (%d, %d not Ready):\n", len(report.NodeClaims), pending)
+		w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "NAME\tNODEPOOL\tNODE\tSTATUS\tINSTANCE")
+		fmt.Fprintln(w, "----\t--------\t----\t------\t--------")
+		for _, c := range report.NodeClaims {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+				c.Name,
+				orDash(c.NodePool),
+				orDash(c.NodeName),
+				c.Status,
+				orDash(c.InstanceID),
+			)
+		}
+		w.Flush()
+	}
+}
+
+func yesNoAvailable(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "missing"
+}
+
+func orDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}

--- a/cmd/k8s_karpenter_print_test.go
+++ b/cmd/k8s_karpenter_print_test.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/bgdnvk/clanker/internal/k8s/sre"
+)
+
+func TestPrintKarpenterReport_NotInstalled(t *testing.T) {
+	var buf bytes.Buffer
+	printKarpenterReport(&buf, karpenterReport{
+		Presence: &sre.KarpenterPresence{Installed: false, Notes: "api-resources timeout"},
+	})
+	out := buf.String()
+	if !strings.Contains(out, "Karpenter is not installed") {
+		t.Errorf("expected not-installed message, got %q", out)
+	}
+	if !strings.Contains(out, "api-resources timeout") {
+		t.Errorf("expected note to be included, got %q", out)
+	}
+}
+
+func TestPrintKarpenterReport_NoPoolsOrClaims(t *testing.T) {
+	var buf bytes.Buffer
+	printKarpenterReport(&buf, karpenterReport{
+		Presence: &sre.KarpenterPresence{
+			Installed:           true,
+			APIGroup:            "karpenter.sh",
+			NodePoolsAvailable:  true,
+			NodeClaimsAvailable: true,
+		},
+	})
+	out := buf.String()
+	if !strings.Contains(out, "Karpenter detected") {
+		t.Errorf("expected detection header, got %q", out)
+	}
+	if !strings.Contains(out, "No NodePools defined") || !strings.Contains(out, "No NodeClaims provisioned") {
+		t.Errorf("expected empty-state messages, got %q", out)
+	}
+}
+
+func TestPrintKarpenterReport_PoolsAndClaimsTable(t *testing.T) {
+	var buf bytes.Buffer
+	printKarpenterReport(&buf, karpenterReport{
+		Presence: &sre.KarpenterPresence{
+			Installed:           true,
+			APIGroup:            "karpenter.sh",
+			NodePoolsAvailable:  true,
+			NodeClaimsAvailable: true,
+		},
+		NodePools: []sre.NodePoolSummary{
+			{Name: "gpu", NodeClass: "gpu-ec2", Weight: 100, Disruption: "WhenEmpty", Age: "5d"},
+			{Name: "default", NodeClass: "default-ec2", Weight: 10, Disruption: "WhenUnderutilized", Age: "12d"},
+		},
+		NodeClaims: []sre.NodeClaimSummary{
+			{Name: "claim-pending", NodePool: "gpu", Status: "Pending"},
+			{Name: "claim-ready", NodePool: "default", NodeName: "ip-10-0-0-1", Status: "Ready", InstanceID: "i-abc"},
+		},
+	})
+	out := buf.String()
+
+	// Pools sorted by name → default before gpu
+	defaultIdx := strings.Index(out, "default-ec2")
+	gpuIdx := strings.Index(out, "gpu-ec2")
+	if defaultIdx == -1 || gpuIdx == -1 || defaultIdx > gpuIdx {
+		t.Errorf("pools should be name-sorted (default before gpu), got positions default=%d gpu=%d", defaultIdx, gpuIdx)
+	}
+
+	// Headline counts include pending (1)
+	if !strings.Contains(out, "NodeClaims (2, 1 not Ready)") {
+		t.Errorf("expected pending count in NodeClaims header, got: %s", out)
+	}
+
+	// Both claims appear
+	for _, want := range []string{"claim-ready", "claim-pending", "i-abc"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in output: %s", want, out)
+		}
+	}
+}
+
+func TestYesNoAvailable(t *testing.T) {
+	if yesNoAvailable(true) != "yes" || yesNoAvailable(false) != "missing" {
+		t.Error("yesNoAvailable wrong")
+	}
+}
+
+func TestOrDash(t *testing.T) {
+	if orDash("") != "-" {
+		t.Error("orDash should replace empty with -")
+	}
+	if orDash("real") != "real" {
+		t.Error("orDash should pass through non-empty")
+	}
+}

--- a/cmd/k8s_networkpolicy.go
+++ b/cmd/k8s_networkpolicy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -81,17 +82,17 @@ func runNetworkPolicyAudit(cmd *cobra.Command, args []string) error {
 		enc.SetIndent("", "  ")
 		return enc.Encode(report)
 	default:
-		printNetworkPolicyAuditTable(report)
+		printNetworkPolicyAuditTable(os.Stdout, report)
 		return nil
 	}
 }
 
-func printNetworkPolicyAuditTable(report *networking.PolicyAuditReport) {
+func printNetworkPolicyAuditTable(out io.Writer, report *networking.PolicyAuditReport) {
 	if report == nil || len(report.Namespaces) == 0 {
-		fmt.Println("No namespaces audited.")
+		fmt.Fprintln(out, "No namespaces audited.")
 		return
 	}
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(w, "NAMESPACE\tPOLICIES\tDEFAULT-DENY INGRESS\tDEFAULT-DENY EGRESS")
 	fmt.Fprintln(w, "---------\t--------\t--------------------\t-------------------")
 	for _, ns := range report.Namespaces {
@@ -106,7 +107,7 @@ func printNetworkPolicyAuditTable(report *networking.PolicyAuditReport) {
 		}
 	}
 	if len(uncovered) > 0 {
-		fmt.Fprintf(os.Stdout, "\n⚠  %d namespace(s) lack default-deny in at least one direction: %s\n", len(uncovered), strings.Join(uncovered, ", "))
+		fmt.Fprintf(out, "\n⚠  %d namespace(s) lack default-deny in at least one direction: %s\n", len(uncovered), strings.Join(uncovered, ", "))
 	}
 }
 

--- a/cmd/k8s_networkpolicy.go
+++ b/cmd/k8s_networkpolicy.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/bgdnvk/clanker/internal/k8s"
+	"github.com/bgdnvk/clanker/internal/k8s/networking"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	npAuditNamespaces string
+	npAuditOutput     string
+	npAuditKubeconfig string
+	npAuditContext    string
+)
+
+var k8sNetworkPolicyCmd = &cobra.Command{
+	Use:   "networkpolicy",
+	Short: "Inspect Kubernetes NetworkPolicy posture",
+	Long:  `Inspect or audit NetworkPolicy resources in the current cluster.`,
+}
+
+var k8sNetworkPolicyAuditCmd = &cobra.Command{
+	Use:   "audit",
+	Short: "Audit default-deny NetworkPolicy coverage per namespace",
+	Long: `Report whether each namespace has default-deny NetworkPolicies in place
+for ingress and egress traffic.
+
+A namespace is reported as default-deny in a direction when at least one
+NetworkPolicy targets all pods (empty podSelector) with that direction in
+its policyTypes and no rules in that direction.
+
+Examples:
+  clanker k8s networkpolicy audit
+  clanker k8s networkpolicy audit --namespaces default,kube-system
+  clanker k8s networkpolicy audit -o json`,
+	RunE: runNetworkPolicyAudit,
+}
+
+func init() {
+	k8sCmd.AddCommand(k8sNetworkPolicyCmd)
+	k8sNetworkPolicyCmd.AddCommand(k8sNetworkPolicyAuditCmd)
+
+	k8sNetworkPolicyAuditCmd.Flags().StringVar(&npAuditNamespaces, "namespaces", "", "Comma-separated namespaces to audit (default: all namespaces)")
+	k8sNetworkPolicyAuditCmd.Flags().StringVarP(&npAuditOutput, "output", "o", "table", "Output format (table, json)")
+	k8sNetworkPolicyAuditCmd.Flags().StringVar(&npAuditKubeconfig, "kubeconfig", "", "Path to kubeconfig (default: ~/.kube/config)")
+	k8sNetworkPolicyAuditCmd.Flags().StringVar(&npAuditContext, "context", "", "kubectl context to use")
+}
+
+func runNetworkPolicyAudit(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	debug := viper.GetBool("debug")
+
+	client := k8s.NewClient(npAuditKubeconfig, npAuditContext, debug)
+	manager := networking.NewNetworkPolicyManager(k8s.NewNetworkingAdapter(client), debug)
+
+	var ns []string
+	if strings.TrimSpace(npAuditNamespaces) != "" {
+		for _, n := range strings.Split(npAuditNamespaces, ",") {
+			if t := strings.TrimSpace(n); t != "" {
+				ns = append(ns, t)
+			}
+		}
+	}
+
+	report, err := manager.AuditPolicies(ctx, ns)
+	if err != nil {
+		return fmt.Errorf("audit failed: %w", err)
+	}
+
+	switch strings.ToLower(npAuditOutput) {
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	default:
+		printNetworkPolicyAuditTable(report)
+		return nil
+	}
+}
+
+func printNetworkPolicyAuditTable(report *networking.PolicyAuditReport) {
+	if report == nil || len(report.Namespaces) == 0 {
+		fmt.Println("No namespaces audited.")
+		return
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAMESPACE\tPOLICIES\tDEFAULT-DENY INGRESS\tDEFAULT-DENY EGRESS")
+	fmt.Fprintln(w, "---------\t--------\t--------------------\t-------------------")
+	for _, ns := range report.Namespaces {
+		fmt.Fprintf(w, "%s\t%d\t%s\t%s\n", ns.Namespace, ns.PolicyCount, yesNo(ns.DefaultDenyIn), yesNo(ns.DefaultDenyOut))
+	}
+	w.Flush()
+
+	var uncovered []string
+	for _, ns := range report.Namespaces {
+		if !ns.DefaultDenyIn || !ns.DefaultDenyOut {
+			uncovered = append(uncovered, ns.Namespace)
+		}
+	}
+	if len(uncovered) > 0 {
+		fmt.Fprintf(os.Stdout, "\n⚠  %d namespace(s) lack default-deny in at least one direction: %s\n", len(uncovered), strings.Join(uncovered, ", "))
+	}
+}
+
+func yesNo(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}

--- a/cmd/k8s_networkpolicy_print_test.go
+++ b/cmd/k8s_networkpolicy_print_test.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/bgdnvk/clanker/internal/k8s/networking"
+)
+
+func TestPrintNetworkPolicyAuditTable_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	printNetworkPolicyAuditTable(&buf, &networking.PolicyAuditReport{})
+	if got := buf.String(); !strings.Contains(got, "No namespaces audited") {
+		t.Errorf("expected empty-report message, got %q", got)
+	}
+}
+
+func TestPrintNetworkPolicyAuditTable_Nil(t *testing.T) {
+	var buf bytes.Buffer
+	printNetworkPolicyAuditTable(&buf, nil)
+	if got := buf.String(); !strings.Contains(got, "No namespaces audited") {
+		t.Errorf("expected empty-report message for nil, got %q", got)
+	}
+}
+
+func TestPrintNetworkPolicyAuditTable_FlagsUncovered(t *testing.T) {
+	report := &networking.PolicyAuditReport{
+		Namespaces: []networking.NamespacePolicyAudit{
+			{Namespace: "prod", PolicyCount: 2, DefaultDenyIn: true, DefaultDenyOut: true},
+			{Namespace: "staging", PolicyCount: 1, DefaultDenyIn: true, DefaultDenyOut: false},
+			{Namespace: "dev", PolicyCount: 0, DefaultDenyIn: false, DefaultDenyOut: false},
+		},
+	}
+
+	var buf bytes.Buffer
+	printNetworkPolicyAuditTable(&buf, report)
+	out := buf.String()
+
+	for _, want := range []string{"prod", "staging", "dev", "yes", "no"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("table output missing %q\n----\n%s", want, out)
+		}
+	}
+
+	// staging + dev should both appear in the uncovered footer warning.
+	if !strings.Contains(out, "2 namespace(s) lack default-deny") {
+		t.Errorf("expected uncovered count of 2, got: %s", out)
+	}
+	if !strings.Contains(out, "staging") || !strings.Contains(out, "dev") {
+		t.Errorf("expected uncovered namespace list to include staging and dev, got: %s", out)
+	}
+	if strings.Contains(strings.SplitN(out, "lack default-deny", 2)[1], "prod") {
+		t.Errorf("prod is fully covered and should not appear in the uncovered footer: %s", out)
+	}
+}
+
+func TestPrintNetworkPolicyAuditTable_AllCoveredNoFooter(t *testing.T) {
+	report := &networking.PolicyAuditReport{
+		Namespaces: []networking.NamespacePolicyAudit{
+			{Namespace: "prod", PolicyCount: 2, DefaultDenyIn: true, DefaultDenyOut: true},
+		},
+	}
+	var buf bytes.Buffer
+	printNetworkPolicyAuditTable(&buf, report)
+	if strings.Contains(buf.String(), "lack default-deny") {
+		t.Errorf("fully-covered report should not emit warning footer: %s", buf.String())
+	}
+}
+
+func TestYesNo(t *testing.T) {
+	if yesNo(true) != "yes" || yesNo(false) != "no" {
+		t.Error("yesNo wrong")
+	}
+}

--- a/internal/cost/aggregator.go
+++ b/internal/cost/aggregator.go
@@ -352,11 +352,13 @@ func (a *Aggregator) AuditTags(ctx context.Context, requiredKeys []string, start
 		Entries: make([]TagAuditEntry, 0, len(requiredKeys)),
 	}
 
+	configuredProviders := 0
 	tagProviders := 0
 	for _, p := range a.providers {
 		if !p.IsConfigured() {
 			continue
 		}
+		configuredProviders++
 		if _, ok := p.(TagProvider); ok {
 			tagProviders++
 		}
@@ -376,7 +378,7 @@ func (a *Aggregator) AuditTags(ctx context.Context, requiredKeys []string, start
 		}
 
 		entry := TagAuditEntry{TagKey: key, ProvidersSeen: tagProviders}
-		entry.UnsupportedNum = len(a.providers) - tagProviders
+		entry.UnsupportedNum = configuredProviders - tagProviders
 		for _, t := range resp.Tags {
 			entry.TotalCost += t.Cost
 			if isUntaggedValue(t.TagValue) {

--- a/internal/cost/aggregator.go
+++ b/internal/cost/aggregator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 )
@@ -335,6 +336,82 @@ func absFloat(f float64) float64 {
 		return -f
 	}
 	return f
+}
+
+// AuditTags runs a tag-compliance audit for the supplied required tag keys.
+// For each key it groups costs by tag value across providers and reports the
+// portion of spend that fell into the untagged bucket (Cost Explorer returns
+// these as the empty tag value).
+func (a *Aggregator) AuditTags(ctx context.Context, requiredKeys []string, start, end time.Time) (*TagAuditReport, error) {
+	if len(requiredKeys) == 0 {
+		return &TagAuditReport{Period: CostPeriod{StartDate: start, EndDate: end}}, nil
+	}
+
+	report := &TagAuditReport{
+		Period:  CostPeriod{StartDate: start, EndDate: end},
+		Entries: make([]TagAuditEntry, 0, len(requiredKeys)),
+	}
+
+	tagProviders := 0
+	for _, p := range a.providers {
+		if !p.IsConfigured() {
+			continue
+		}
+		if _, ok := p.(TagProvider); ok {
+			tagProviders++
+		}
+	}
+
+	for _, key := range requiredKeys {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		resp, err := a.GetTags(ctx, key, start, end)
+		if err != nil {
+			if a.debug {
+				log.Printf("[cost] tag audit: %s: %v", key, err)
+			}
+			continue
+		}
+
+		entry := TagAuditEntry{TagKey: key, ProvidersSeen: tagProviders}
+		entry.UnsupportedNum = len(a.providers) - tagProviders
+		for _, t := range resp.Tags {
+			entry.TotalCost += t.Cost
+			if isUntaggedValue(t.TagValue) {
+				entry.UntaggedCost += t.Cost
+				entry.UntaggedSeen = true
+			} else {
+				entry.TaggedValues++
+			}
+		}
+		if entry.TotalCost > 0 {
+			entry.UntaggedPct = (entry.UntaggedCost / entry.TotalCost) * 100
+		}
+		report.Entries = append(report.Entries, entry)
+	}
+
+	return report, nil
+}
+
+// isUntaggedValue identifies the untagged bucket returned by AWS Cost Explorer
+// when grouping by a tag the resource doesn't carry.
+func isUntaggedValue(v string) bool {
+	trimmed := strings.TrimSpace(v)
+	if trimmed == "" {
+		return true
+	}
+	// AWS prefixes the group key as "tagKey$value"; an unset value comes
+	// through as "tagKey$" (i.e. trailing dollar with empty suffix).
+	if strings.HasSuffix(trimmed, "$") {
+		return true
+	}
+	switch strings.ToLower(trimmed) {
+	case "no value", "(notagkey)", "untagged":
+		return true
+	}
+	return false
 }
 
 // GetTags returns costs grouped by tag across all providers

--- a/internal/cost/aggregator.go
+++ b/internal/cost/aggregator.go
@@ -246,44 +246,95 @@ func (a *Aggregator) GetForecast(ctx context.Context) (*CostForecast, error) {
 	return nil, nil
 }
 
-// GetAnomalies returns cost anomalies from all providers
+// GetAnomalies returns cost anomalies from all providers. Providers that
+// implement AnomalyProvider supply their own (typically richer, per-service)
+// findings. For providers that don't, we run a generic z-style daily-deviation
+// detector against their daily trend so coverage isn't AWS-only.
 func (a *Aggregator) GetAnomalies(ctx context.Context) (*CostAnomaliesResponse, error) {
 	var (
-		wg        sync.WaitGroup
-		mu        sync.Mutex
-		anomalies []CostAnomaly
+		wg               sync.WaitGroup
+		mu               sync.Mutex
+		anomalies        []CostAnomaly
+		fallbackTrend    []DailyCost
+		anomalyProviders = make(map[string]bool)
 	)
+
+	now := time.Now()
+	start, end := since7Days(now)
 
 	for _, p := range a.providers {
 		if !p.IsConfigured() {
 			continue
 		}
 		if ap, ok := p.(AnomalyProvider); ok {
+			anomalyProviders[p.GetName()] = true
 			ap := ap
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				a, err := ap.GetAnomalies(ctx)
+				found, err := ap.GetAnomalies(ctx)
 				if err != nil {
+					if a.debug {
+						log.Printf("[cost] anomaly fetch from %s: %v", ap.GetName(), err)
+					}
 					return
 				}
 				mu.Lock()
-				anomalies = append(anomalies, a...)
+				anomalies = append(anomalies, found...)
 				mu.Unlock()
 			}()
 		}
 	}
 
+	for _, p := range a.providers {
+		if !p.IsConfigured() {
+			continue
+		}
+		if anomalyProviders[p.GetName()] {
+			continue
+		}
+		p := p
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			trend, err := p.GetDailyTrend(ctx, start, end)
+			if err != nil {
+				if a.debug {
+					log.Printf("[cost] daily trend for fallback anomaly detection on %s: %v", p.GetName(), err)
+				}
+				return
+			}
+			for i := range trend {
+				if trend[i].Provider == "" {
+					trend[i].Provider = p.GetName()
+				}
+			}
+			mu.Lock()
+			fallbackTrend = append(fallbackTrend, trend...)
+			mu.Unlock()
+		}()
+	}
+
 	wg.Wait()
 
-	// Sort by percent change descending
+	anomalies = append(anomalies, DetectAnomaliesByProvider(fallbackTrend, anomalyDeviationPct)...)
+
+	// Sort by absolute percent change descending — both spikes and drops
+	// should bubble up, not just positive deltas.
 	sort.Slice(anomalies, func(i, j int) bool {
-		return anomalies[i].PercentChange > anomalies[j].PercentChange
+		return absFloat(anomalies[i].PercentChange) > absFloat(anomalies[j].PercentChange)
 	})
 
 	return &CostAnomaliesResponse{
 		Anomalies: anomalies,
 	}, nil
+}
+
+func absFloat(f float64) float64 {
+	if f < 0 {
+		return -f
+	}
+	return f
 }
 
 // GetTags returns costs grouped by tag across all providers

--- a/internal/cost/aggregator_test.go
+++ b/internal/cost/aggregator_test.go
@@ -1,0 +1,321 @@
+package cost
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+)
+
+// stubProvider implements Provider only — no AnomalyProvider — so the
+// aggregator's fallback path will run for it.
+type stubProvider struct {
+	name       string
+	configured bool
+	costs      *ProviderCost
+	costsErr   error
+	trend      []DailyCost
+	trendErr   error
+}
+
+func (s *stubProvider) GetName() string    { return s.name }
+func (s *stubProvider) IsConfigured() bool { return s.configured }
+func (s *stubProvider) GetCosts(_ context.Context, _, _ time.Time) (*ProviderCost, error) {
+	return s.costs, s.costsErr
+}
+func (s *stubProvider) GetCostsByService(_ context.Context, _, _ time.Time) ([]ServiceCost, error) {
+	if s.costs == nil {
+		return nil, nil
+	}
+	return s.costs.ServiceBreakdown, nil
+}
+func (s *stubProvider) GetDailyTrend(_ context.Context, _, _ time.Time) ([]DailyCost, error) {
+	return s.trend, s.trendErr
+}
+
+// stubAnomalyProvider extends stubProvider to return its own anomalies — used
+// to verify the aggregator skips the fallback for providers that already
+// implement AnomalyProvider.
+type stubAnomalyProvider struct {
+	stubProvider
+	anomalies    []CostAnomaly
+	anomaliesErr error
+}
+
+func (s *stubAnomalyProvider) GetAnomalies(_ context.Context) ([]CostAnomaly, error) {
+	return s.anomalies, s.anomaliesErr
+}
+
+// makeSpike returns a 7-day trend ending in a spike that DetectDailyAnomaly
+// will flag (>30% deviation from the 6-day average).
+func makeSpike(provider string, base time.Time) []DailyCost {
+	out := make([]DailyCost, 7)
+	for i := 0; i < 6; i++ {
+		out[i] = DailyCost{Date: base.AddDate(0, 0, i), Cost: 10, Provider: provider}
+	}
+	out[6] = DailyCost{Date: base.AddDate(0, 0, 6), Cost: 100, Provider: provider}
+	return out
+}
+
+func TestGetAnomalies_FallbackForNonAnomalyProvider(t *testing.T) {
+	base := time.Now().UTC().AddDate(0, 0, -7)
+
+	gcp := &stubProvider{
+		name:       "gcp",
+		configured: true,
+		trend:      makeSpike("gcp", base),
+	}
+
+	agg := NewAggregator(false)
+	agg.RegisterProvider(gcp)
+
+	resp, err := agg.GetAnomalies(context.Background())
+	if err != nil {
+		t.Fatalf("GetAnomalies: %v", err)
+	}
+	if len(resp.Anomalies) != 1 {
+		t.Fatalf("expected 1 fallback anomaly for gcp, got %d: %+v", len(resp.Anomalies), resp.Anomalies)
+	}
+	if resp.Anomalies[0].Provider != "gcp" {
+		t.Errorf("expected gcp provider, got %q", resp.Anomalies[0].Provider)
+	}
+}
+
+func TestGetAnomalies_AnomalyProviderSkipsFallback(t *testing.T) {
+	base := time.Now().UTC().AddDate(0, 0, -7)
+
+	// AWS provider declares its own anomaly (200% spike on a service) and
+	// also has a daily trend that would otherwise trigger the fallback. We
+	// want exactly the provider-supplied anomaly, not a duplicate from the
+	// fallback heuristic.
+	aws := &stubAnomalyProvider{
+		stubProvider: stubProvider{
+			name:       "aws",
+			configured: true,
+			trend:      makeSpike("aws", base),
+		},
+		anomalies: []CostAnomaly{
+			{Service: "EC2", Provider: "aws", PercentChange: 200, ExpectedCost: 10, ActualCost: 30},
+		},
+	}
+
+	agg := NewAggregator(false)
+	agg.RegisterProvider(aws)
+
+	resp, err := agg.GetAnomalies(context.Background())
+	if err != nil {
+		t.Fatalf("GetAnomalies: %v", err)
+	}
+	if len(resp.Anomalies) != 1 {
+		t.Fatalf("expected 1 anomaly (no fallback for AnomalyProvider), got %d: %+v", len(resp.Anomalies), resp.Anomalies)
+	}
+	if resp.Anomalies[0].Service != "EC2" {
+		t.Errorf("expected provider-supplied EC2 anomaly, got %q", resp.Anomalies[0].Service)
+	}
+}
+
+func TestGetAnomalies_MixedProvidersBothSurface(t *testing.T) {
+	base := time.Now().UTC().AddDate(0, 0, -7)
+
+	aws := &stubAnomalyProvider{
+		stubProvider: stubProvider{name: "aws", configured: true},
+		anomalies: []CostAnomaly{
+			{Service: "EC2", Provider: "aws", PercentChange: 200},
+		},
+	}
+	gcp := &stubProvider{name: "gcp", configured: true, trend: makeSpike("gcp", base)}
+
+	agg := NewAggregator(false)
+	agg.RegisterProvider(aws)
+	agg.RegisterProvider(gcp)
+
+	resp, err := agg.GetAnomalies(context.Background())
+	if err != nil {
+		t.Fatalf("GetAnomalies: %v", err)
+	}
+	if len(resp.Anomalies) != 2 {
+		t.Fatalf("expected aws+gcp anomalies, got %d: %+v", len(resp.Anomalies), resp.Anomalies)
+	}
+
+	providers := make([]string, 0, 2)
+	for _, a := range resp.Anomalies {
+		providers = append(providers, a.Provider)
+	}
+	sort.Strings(providers)
+	if providers[0] != "aws" || providers[1] != "gcp" {
+		t.Errorf("expected providers [aws gcp], got %v", providers)
+	}
+
+	// Sorted by abs(percentChange) descending. makeSpike produces ~900%
+	// (100 vs a 6-day average of 10), which beats aws's stubbed 200%.
+	if resp.Anomalies[0].Provider != "gcp" {
+		t.Errorf("expected gcp first (heuristic 900%% > aws stub 200%%), got %q", resp.Anomalies[0].Provider)
+	}
+}
+
+func TestGetAnomalies_AnomalyProviderError_StillRunsOthers(t *testing.T) {
+	base := time.Now().UTC().AddDate(0, 0, -7)
+
+	failingAws := &stubAnomalyProvider{
+		stubProvider: stubProvider{name: "aws", configured: true},
+		anomaliesErr: errors.New("cost explorer 503"),
+	}
+	gcp := &stubProvider{name: "gcp", configured: true, trend: makeSpike("gcp", base)}
+
+	agg := NewAggregator(false)
+	agg.RegisterProvider(failingAws)
+	agg.RegisterProvider(gcp)
+
+	resp, err := agg.GetAnomalies(context.Background())
+	if err != nil {
+		t.Fatalf("GetAnomalies should not propagate provider errors, got: %v", err)
+	}
+	if len(resp.Anomalies) != 1 {
+		t.Fatalf("expected gcp fallback anomaly, got %d: %+v", len(resp.Anomalies), resp.Anomalies)
+	}
+	if resp.Anomalies[0].Provider != "gcp" {
+		t.Errorf("expected gcp, got %q", resp.Anomalies[0].Provider)
+	}
+}
+
+func TestGetAnomalies_TrendErrorTreatedAsNoData(t *testing.T) {
+	gcp := &stubProvider{
+		name:       "gcp",
+		configured: true,
+		trendErr:   errors.New("billing api throttled"),
+	}
+
+	agg := NewAggregator(false)
+	agg.RegisterProvider(gcp)
+
+	resp, err := agg.GetAnomalies(context.Background())
+	if err != nil {
+		t.Fatalf("GetAnomalies: %v", err)
+	}
+	if len(resp.Anomalies) != 0 {
+		t.Errorf("expected no anomalies when trend fetch fails, got %+v", resp.Anomalies)
+	}
+}
+
+func TestGetAnomalies_UnconfiguredProvidersSkipped(t *testing.T) {
+	base := time.Now().UTC().AddDate(0, 0, -7)
+
+	configured := &stubProvider{name: "gcp", configured: true, trend: makeSpike("gcp", base)}
+	unconfigured := &stubProvider{name: "azure", configured: false, trend: makeSpike("azure", base)}
+
+	agg := NewAggregator(false)
+	agg.RegisterProvider(configured)
+	agg.RegisterProvider(unconfigured)
+
+	resp, err := agg.GetAnomalies(context.Background())
+	if err != nil {
+		t.Fatalf("GetAnomalies: %v", err)
+	}
+	if len(resp.Anomalies) != 1 {
+		t.Fatalf("expected only configured-provider anomaly, got %d: %+v", len(resp.Anomalies), resp.Anomalies)
+	}
+	if resp.Anomalies[0].Provider != "gcp" {
+		t.Errorf("expected gcp, got %q", resp.Anomalies[0].Provider)
+	}
+}
+
+// stubTagProvider extends stubProvider with TagProvider for AuditTags tests.
+type stubTagProvider struct {
+	stubProvider
+	byKey map[string][]TagCost
+}
+
+func (s *stubTagProvider) GetCostsByTag(_ context.Context, key string, _, _ time.Time) ([]TagCost, error) {
+	return s.byKey[key], nil
+}
+
+func TestAuditTags_PartitionsTaggedAndUntagged(t *testing.T) {
+	aws := &stubTagProvider{
+		stubProvider: stubProvider{name: "aws", configured: true},
+		byKey: map[string][]TagCost{
+			"Environment": {
+				{TagKey: "Environment", TagValue: "prod", Cost: 100},
+				{TagKey: "Environment", TagValue: "", Cost: 25},
+			},
+			"Owner": {
+				{TagKey: "Owner", TagValue: "team-a", Cost: 50},
+			},
+		},
+	}
+
+	agg := NewAggregator(false)
+	agg.RegisterProvider(aws)
+
+	report, err := agg.AuditTags(context.Background(), []string{"Environment", "Owner"}, time.Now().AddDate(0, 0, -7), time.Now())
+	if err != nil {
+		t.Fatalf("AuditTags: %v", err)
+	}
+	if len(report.Entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %+v", len(report.Entries), report.Entries)
+	}
+
+	byKey := map[string]TagAuditEntry{}
+	for _, e := range report.Entries {
+		byKey[e.TagKey] = e
+	}
+
+	env := byKey["Environment"]
+	if env.TotalCost != 125 || env.UntaggedCost != 25 || env.TaggedValues != 1 {
+		t.Errorf("Environment audit wrong: %+v", env)
+	}
+	if got := fmt.Sprintf("%.1f", env.UntaggedPct); got != "20.0" {
+		t.Errorf("Environment UntaggedPct = %s, want 20.0", got)
+	}
+
+	owner := byKey["Owner"]
+	if owner.UntaggedCost != 0 || owner.UntaggedSeen {
+		t.Errorf("Owner audit should have no untagged spend, got %+v", owner)
+	}
+}
+
+func TestAuditTags_UnsupportedNumOnlyCountsConfigured(t *testing.T) {
+	// One tag-aware provider (configured), one configured non-tag provider,
+	// one unconfigured provider that would otherwise skew the count.
+	awsTag := &stubTagProvider{stubProvider: stubProvider{name: "aws", configured: true}, byKey: map[string][]TagCost{}}
+	gcpNoTag := &stubProvider{name: "gcp", configured: true}
+	azureUnconfigured := &stubProvider{name: "azure", configured: false}
+
+	agg := NewAggregator(false)
+	agg.RegisterProvider(awsTag)
+	agg.RegisterProvider(gcpNoTag)
+	agg.RegisterProvider(azureUnconfigured)
+
+	report, err := agg.AuditTags(context.Background(), []string{"Environment"}, time.Now().AddDate(0, 0, -7), time.Now())
+	if err != nil {
+		t.Fatalf("AuditTags: %v", err)
+	}
+	if len(report.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(report.Entries))
+	}
+	got := report.Entries[0]
+	// configuredProviders=2 (aws+gcp), tagProviders=1 (aws). Unsupported = 1.
+	if got.UnsupportedNum != 1 {
+		t.Errorf("UnsupportedNum = %d, want 1 (azure unconfigured must be ignored)", got.UnsupportedNum)
+	}
+	if got.ProvidersSeen != 1 {
+		t.Errorf("ProvidersSeen = %d, want 1", got.ProvidersSeen)
+	}
+}
+
+func TestAuditTags_SkipsBlankKeys(t *testing.T) {
+	agg := NewAggregator(false)
+	agg.RegisterProvider(&stubTagProvider{
+		stubProvider: stubProvider{name: "aws", configured: true},
+		byKey:        map[string][]TagCost{"Environment": {{TagValue: "prod", Cost: 1}}},
+	})
+
+	report, err := agg.AuditTags(context.Background(), []string{"  ", "Environment", ""}, time.Now().AddDate(0, 0, -7), time.Now())
+	if err != nil {
+		t.Fatalf("AuditTags: %v", err)
+	}
+	if len(report.Entries) != 1 || report.Entries[0].TagKey != "Environment" {
+		t.Errorf("expected only Environment entry, got %+v", report.Entries)
+	}
+}

--- a/internal/cost/anomaly.go
+++ b/internal/cost/anomaly.go
@@ -1,0 +1,85 @@
+package cost
+
+import (
+	"fmt"
+	"sort"
+	"time"
+)
+
+// anomalyDeviationPct is the absolute percent deviation from the rolling
+// baseline that flags a single-day data point as an anomaly. 30% matches
+// the previous AWS-specific heuristic and is conservative enough to avoid
+// flagging weekend dips on noisy accounts.
+const anomalyDeviationPct = 30.0
+
+// minAnomalyBaseline filters out near-zero baselines that produce
+// meaningless percent changes.
+const minAnomalyBaseline = 0.50
+
+// DetectDailyAnomaly compares the most recent day in trend against the
+// average of the prior days and returns a CostAnomaly if the deviation
+// exceeds thresholdPct in either direction. Returns nil when there isn't
+// enough data, the baseline is too small to be meaningful, or no anomaly
+// is found.
+//
+// Trend is expected to be sorted ascending by date but is sorted defensively.
+func DetectDailyAnomaly(service, provider string, trend []DailyCost, thresholdPct float64) *CostAnomaly {
+	if len(trend) < 2 {
+		return nil
+	}
+	sorted := make([]DailyCost, len(trend))
+	copy(sorted, trend)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Date.Before(sorted[j].Date) })
+
+	var total float64
+	for _, dc := range sorted[:len(sorted)-1] {
+		total += dc.Cost
+	}
+	avg := total / float64(len(sorted)-1)
+	if avg < minAnomalyBaseline {
+		return nil
+	}
+
+	today := sorted[len(sorted)-1]
+	change := ((today.Cost - avg) / avg) * 100
+	if change <= thresholdPct && change >= -thresholdPct {
+		return nil
+	}
+	return &CostAnomaly{
+		Service:       service,
+		Provider:      provider,
+		ExpectedCost:  avg,
+		ActualCost:    today.Cost,
+		PercentChange: change,
+		Description:   fmt.Sprintf("Daily cost deviation of %.1f%% from %d-day average", change, len(sorted)-1),
+	}
+}
+
+// DetectAnomaliesByProvider partitions trend by provider and runs
+// DetectDailyAnomaly per partition. Used as the aggregator-level fallback
+// so providers that don't implement AnomalyProvider still get coverage.
+func DetectAnomaliesByProvider(trend []DailyCost, thresholdPct float64) []CostAnomaly {
+	groups := make(map[string][]DailyCost)
+	for _, dc := range trend {
+		key := dc.Provider
+		if key == "" {
+			key = "unknown"
+		}
+		groups[key] = append(groups[key], dc)
+	}
+
+	out := make([]CostAnomaly, 0, len(groups))
+	for provider, days := range groups {
+		if a := DetectDailyAnomaly(fmt.Sprintf("Total %s", provider), provider, days, thresholdPct); a != nil {
+			out = append(out, *a)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].PercentChange > out[j].PercentChange })
+	return out
+}
+
+// since7Days returns a [end-7d, end) window suitable for daily anomaly
+// detection, exposed so callers can keep one source of truth for the window.
+func since7Days(now time.Time) (time.Time, time.Time) {
+	return now.AddDate(0, 0, -7), now
+}

--- a/internal/cost/anomaly.go
+++ b/internal/cost/anomaly.go
@@ -58,6 +58,9 @@ func DetectDailyAnomaly(service, provider string, trend []DailyCost, thresholdPc
 // DetectAnomaliesByProvider partitions trend by provider and runs
 // DetectDailyAnomaly per partition. Used as the aggregator-level fallback
 // so providers that don't implement AnomalyProvider still get coverage.
+//
+// Output order is not guaranteed — the aggregator's GetAnomalies re-sorts
+// by absolute percent change, so adding a sort here would be wasted work.
 func DetectAnomaliesByProvider(trend []DailyCost, thresholdPct float64) []CostAnomaly {
 	groups := make(map[string][]DailyCost)
 	for _, dc := range trend {
@@ -74,7 +77,6 @@ func DetectAnomaliesByProvider(trend []DailyCost, thresholdPct float64) []CostAn
 			out = append(out, *a)
 		}
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i].PercentChange > out[j].PercentChange })
 	return out
 }
 

--- a/internal/cost/anomaly_test.go
+++ b/internal/cost/anomaly_test.go
@@ -62,6 +62,23 @@ func TestDetectDailyAnomaly_IgnoresNearZeroBaseline(t *testing.T) {
 	}
 }
 
+func TestIsUntaggedValue(t *testing.T) {
+	cases := map[string]bool{
+		"":                true,
+		"  ":              true,
+		"Environment$":    true,
+		"NO VALUE":        true,
+		"untagged":        true,
+		"prod":            false,
+		"Environment$dev": false,
+	}
+	for in, want := range cases {
+		if got := isUntaggedValue(in); got != want {
+			t.Errorf("isUntaggedValue(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
 func TestDetectAnomaliesByProvider_PartitionsByProvider(t *testing.T) {
 	base := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
 	mk := func(provider string, values ...float64) []DailyCost {

--- a/internal/cost/anomaly_test.go
+++ b/internal/cost/anomaly_test.go
@@ -98,8 +98,12 @@ func TestDetectAnomaliesByProvider_PartitionsByProvider(t *testing.T) {
 	if len(got) != 2 {
 		t.Fatalf("expected 2 anomalies (aws spike, azure drop), got %d: %+v", len(got), got)
 	}
-	// Sorted by absolute percent change descending — aws spike (+800%) > azure drop (-95%)
-	if got[0].Provider != "aws" {
-		t.Errorf("expected aws spike first, got %s", got[0].Provider)
+	// Order is not guaranteed — the aggregator re-sorts by abs(change).
+	seen := map[string]bool{}
+	for _, a := range got {
+		seen[a.Provider] = true
+	}
+	if !seen["aws"] || !seen["azure"] {
+		t.Errorf("expected aws spike + azure drop in results, got %+v", got)
 	}
 }

--- a/internal/cost/anomaly_test.go
+++ b/internal/cost/anomaly_test.go
@@ -1,0 +1,88 @@
+package cost
+
+import (
+	"testing"
+	"time"
+)
+
+func dailyTrend(values ...float64) []DailyCost {
+	base := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	out := make([]DailyCost, len(values))
+	for i, v := range values {
+		out[i] = DailyCost{Date: base.AddDate(0, 0, i), Cost: v, Provider: "test"}
+	}
+	return out
+}
+
+func TestDetectDailyAnomaly_FlagsSpike(t *testing.T) {
+	a := DetectDailyAnomaly("ec2", "aws", dailyTrend(10, 11, 9, 10, 12, 11, 50), anomalyDeviationPct)
+	if a == nil {
+		t.Fatal("expected anomaly to be detected for 5x spike")
+	}
+	if a.PercentChange < 100 {
+		t.Errorf("expected percent change > 100, got %.1f", a.PercentChange)
+	}
+	if a.Service != "ec2" || a.Provider != "aws" {
+		t.Errorf("anomaly metadata mismatch: %+v", a)
+	}
+}
+
+func TestDetectDailyAnomaly_FlagsDrop(t *testing.T) {
+	a := DetectDailyAnomaly("ec2", "aws", dailyTrend(100, 100, 100, 100, 100, 100, 10), anomalyDeviationPct)
+	if a == nil {
+		t.Fatal("expected anomaly for 90% drop")
+	}
+	if a.PercentChange > -50 {
+		t.Errorf("expected sharply negative change, got %.1f", a.PercentChange)
+	}
+}
+
+func TestDetectDailyAnomaly_IgnoresWithinThreshold(t *testing.T) {
+	a := DetectDailyAnomaly("ec2", "aws", dailyTrend(10, 11, 9, 10, 12, 11, 12), anomalyDeviationPct)
+	if a != nil {
+		t.Errorf("did not expect anomaly, got %+v", a)
+	}
+}
+
+func TestDetectDailyAnomaly_IgnoresShortSeries(t *testing.T) {
+	if DetectDailyAnomaly("ec2", "aws", dailyTrend(100), anomalyDeviationPct) != nil {
+		t.Error("single-day series should not yield an anomaly")
+	}
+	if DetectDailyAnomaly("ec2", "aws", nil, anomalyDeviationPct) != nil {
+		t.Error("empty series should not yield an anomaly")
+	}
+}
+
+func TestDetectDailyAnomaly_IgnoresNearZeroBaseline(t *testing.T) {
+	// Baseline of 0.01/day; a $1 spike is a 9999% change but the absolute
+	// dollars are immaterial — we don't want to spam users with these.
+	a := DetectDailyAnomaly("test", "test", dailyTrend(0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 1.0), anomalyDeviationPct)
+	if a != nil {
+		t.Errorf("expected near-zero baseline to be filtered, got %+v", a)
+	}
+}
+
+func TestDetectAnomaliesByProvider_PartitionsByProvider(t *testing.T) {
+	base := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	mk := func(provider string, values ...float64) []DailyCost {
+		out := make([]DailyCost, len(values))
+		for i, v := range values {
+			out[i] = DailyCost{Date: base.AddDate(0, 0, i), Cost: v, Provider: provider}
+		}
+		return out
+	}
+
+	var trend []DailyCost
+	trend = append(trend, mk("aws", 10, 10, 10, 10, 10, 10, 100)...)   // spike
+	trend = append(trend, mk("gcp", 10, 11, 9, 10, 12, 11, 12)...)     // normal
+	trend = append(trend, mk("azure", 10, 10, 10, 10, 10, 10, 0.5)...) // drop
+
+	got := DetectAnomaliesByProvider(trend, anomalyDeviationPct)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 anomalies (aws spike, azure drop), got %d: %+v", len(got), got)
+	}
+	// Sorted by absolute percent change descending — aws spike (+800%) > azure drop (-95%)
+	if got[0].Provider != "aws" {
+		t.Errorf("expected aws spike first, got %s", got[0].Provider)
+	}
+}

--- a/internal/cost/aws_provider.go
+++ b/internal/cost/aws_provider.go
@@ -239,45 +239,96 @@ func (p *AWSProvider) GetForecast(ctx context.Context) (*CostForecast, error) {
 	}, nil
 }
 
-// GetAnomalies returns detected cost anomalies
+// GetAnomalies returns detected cost anomalies, both at the account level
+// and broken down per service, comparing the most recent day's spend against
+// the 7-day rolling baseline.
 func (p *AWSProvider) GetAnomalies(ctx context.Context) ([]CostAnomaly, error) {
-	// Get last 7 days of daily costs to detect anomalies
 	now := time.Now()
 	end := now
 	start := now.AddDate(0, 0, -7)
 
-	dailyCosts, err := p.GetDailyTrend(ctx, start, end)
+	totalAnomaly, err := p.detectTotalAnomaly(ctx, start, end)
 	if err != nil {
 		return nil, err
 	}
 
-	// Calculate average and detect anomalies (>30% deviation)
-	if len(dailyCosts) < 2 {
-		return nil, nil
+	serviceAnomalies, err := p.detectServiceAnomalies(ctx, start, end)
+	if err != nil {
+		// Service-level detection is best-effort. Surface the total-level
+		// finding even if the per-service query fails (e.g. account lacks
+		// permission for daily SERVICE grouping).
+		if p.debug {
+			log.Printf("[aws-cost] service anomaly detection failed: %v", err)
+		}
+		if totalAnomaly == nil {
+			return nil, nil
+		}
+		return []CostAnomaly{*totalAnomaly}, nil
 	}
 
-	var total float64
-	for _, dc := range dailyCosts[:len(dailyCosts)-1] {
-		total += dc.Cost
+	out := serviceAnomalies
+	if totalAnomaly != nil {
+		out = append([]CostAnomaly{*totalAnomaly}, out...)
 	}
-	avg := total / float64(len(dailyCosts)-1)
+	return out, nil
+}
 
-	var anomalies []CostAnomaly
-	today := dailyCosts[len(dailyCosts)-1]
-	if avg > 0 {
-		change := ((today.Cost - avg) / avg) * 100
-		if change > 30 || change < -30 {
-			anomalies = append(anomalies, CostAnomaly{
-				Service:       "Total AWS",
-				Provider:      "aws",
-				ExpectedCost:  avg,
-				ActualCost:    today.Cost,
-				PercentChange: change,
-				Description:   fmt.Sprintf("Daily cost deviation of %.1f%% from 7-day average", change),
-			})
+func (p *AWSProvider) detectTotalAnomaly(ctx context.Context, start, end time.Time) (*CostAnomaly, error) {
+	dailyCosts, err := p.GetDailyTrend(ctx, start, end)
+	if err != nil {
+		return nil, err
+	}
+	anomaly := DetectDailyAnomaly("Total AWS", "aws", dailyCosts, anomalyDeviationPct)
+	return anomaly, nil
+}
+
+func (p *AWSProvider) detectServiceAnomalies(ctx context.Context, start, end time.Time) ([]CostAnomaly, error) {
+	input := &costexplorer.GetCostAndUsageInput{
+		TimePeriod: &types.DateInterval{
+			Start: aws.String(start.Format("2006-01-02")),
+			End:   aws.String(end.Format("2006-01-02")),
+		},
+		Granularity: types.GranularityDaily,
+		Metrics:     []string{"UnblendedCost"},
+		GroupBy: []types.GroupDefinition{{
+			Type: types.GroupDefinitionTypeDimension,
+			Key:  aws.String("SERVICE"),
+		}},
+	}
+
+	result, err := p.client.GetCostAndUsage(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get AWS daily costs by service: %w", err)
+	}
+
+	byService := make(map[string][]DailyCost)
+	for _, period := range result.ResultsByTime {
+		if period.TimePeriod == nil || period.TimePeriod.Start == nil {
+			continue
+		}
+		date, err := time.Parse("2006-01-02", *period.TimePeriod.Start)
+		if err != nil {
+			continue
+		}
+		for _, group := range period.Groups {
+			if len(group.Keys) == 0 {
+				continue
+			}
+			service := group.Keys[0]
+			amount := 0.0
+			if c, ok := group.Metrics["UnblendedCost"]; ok && c.Amount != nil {
+				amount, _ = strconv.ParseFloat(*c.Amount, 64)
+			}
+			byService[service] = append(byService[service], DailyCost{Date: date, Cost: amount, Provider: "aws"})
 		}
 	}
 
+	var anomalies []CostAnomaly
+	for service, trend := range byService {
+		if a := DetectDailyAnomaly(service, "aws", trend, anomalyDeviationPct); a != nil {
+			anomalies = append(anomalies, *a)
+		}
+	}
 	return anomalies, nil
 }
 

--- a/internal/cost/formatter.go
+++ b/internal/cost/formatter.go
@@ -311,6 +311,40 @@ func (f *Formatter) FormatTags(tags *TagsResponse) (string, error) {
 	return sb.String(), nil
 }
 
+// FormatTagAudit renders a tag-compliance audit report.
+func (f *Formatter) FormatTagAudit(report *TagAuditReport) (string, error) {
+	if f.format == "json" {
+		return f.toJSON(report)
+	}
+
+	var sb strings.Builder
+	sb.WriteString(f.header("Tag Compliance Audit"))
+
+	if report == nil || len(report.Entries) == 0 {
+		sb.WriteString("No tag data available\n")
+		return sb.String(), nil
+	}
+
+	w := tabwriter.NewWriter(&sb, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "TAG KEY\tTOTAL COST\tUNTAGGED COST\tUNTAGGED %\tDISTINCT VALUES")
+	fmt.Fprintln(w, "-------\t----------\t-------------\t----------\t---------------")
+	for _, e := range report.Entries {
+		marker := ""
+		if e.UntaggedPct >= 50 {
+			marker = " ⚠"
+		}
+		fmt.Fprintf(w, "%s%s\t$%.2f\t$%.2f\t%.1f%%\t%d\n",
+			e.TagKey, marker, e.TotalCost, e.UntaggedCost, e.UntaggedPct, e.TaggedValues)
+	}
+	w.Flush()
+
+	if report.Entries[0].UnsupportedNum > 0 {
+		fmt.Fprintf(&sb, "\nNote: %d configured provider(s) do not support tag-based cost queries; their spend is excluded.\n",
+			report.Entries[0].UnsupportedNum)
+	}
+	return sb.String(), nil
+}
+
 // Helper methods
 
 func (f *Formatter) header(text string) string {

--- a/internal/cost/formatter_tagaudit_test.go
+++ b/internal/cost/formatter_tagaudit_test.go
@@ -1,0 +1,116 @@
+package cost
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFormatTagAudit_NilReport(t *testing.T) {
+	f := NewFormatter("table", false)
+	got, err := f.FormatTagAudit(nil)
+	if err != nil {
+		t.Fatalf("FormatTagAudit(nil): %v", err)
+	}
+	if !strings.Contains(got, "No tag data available") {
+		t.Errorf("expected empty-data message, got %q", got)
+	}
+}
+
+func TestFormatTagAudit_EmptyEntries(t *testing.T) {
+	f := NewFormatter("table", false)
+	got, err := f.FormatTagAudit(&TagAuditReport{
+		Period: CostPeriod{StartDate: time.Now().AddDate(0, 0, -7), EndDate: time.Now()},
+	})
+	if err != nil {
+		t.Fatalf("FormatTagAudit empty: %v", err)
+	}
+	if !strings.Contains(got, "No tag data available") {
+		t.Errorf("expected empty-data message, got %q", got)
+	}
+}
+
+func TestFormatTagAudit_PartialUntaggedFlagsHighOnes(t *testing.T) {
+	f := NewFormatter("table", false)
+	report := &TagAuditReport{
+		Entries: []TagAuditEntry{
+			{TagKey: "Environment", TotalCost: 100, UntaggedCost: 10, UntaggedPct: 10, TaggedValues: 3, UnsupportedNum: 0},
+			{TagKey: "Owner", TotalCost: 200, UntaggedCost: 150, UntaggedPct: 75, TaggedValues: 2, UnsupportedNum: 0},
+			{TagKey: "Project", TotalCost: 50, UntaggedCost: 50, UntaggedPct: 100, TaggedValues: 0, UnsupportedNum: 0},
+		},
+	}
+
+	got, err := f.FormatTagAudit(report)
+	if err != nil {
+		t.Fatalf("FormatTagAudit: %v", err)
+	}
+
+	// Owner (75%) and Project (100%) should be flagged with the warning
+	// marker; Environment (10%) should not.
+	envLine := lineContaining(got, "Environment")
+	ownerLine := lineContaining(got, "Owner")
+	projectLine := lineContaining(got, "Project")
+
+	if envLine == "" || ownerLine == "" || projectLine == "" {
+		t.Fatalf("missing rows in output:\n%s", got)
+	}
+
+	if strings.Contains(envLine, "⚠") {
+		t.Errorf("Environment (10%% untagged) should NOT have warning marker: %q", envLine)
+	}
+	if !strings.Contains(ownerLine, "⚠") {
+		t.Errorf("Owner (75%% untagged) should have warning marker: %q", ownerLine)
+	}
+	if !strings.Contains(projectLine, "⚠") {
+		t.Errorf("Project (100%% untagged) should have warning marker: %q", projectLine)
+	}
+}
+
+func TestFormatTagAudit_UnsupportedFooter(t *testing.T) {
+	f := NewFormatter("table", false)
+	withUnsupported := &TagAuditReport{
+		Entries: []TagAuditEntry{
+			{TagKey: "Environment", TotalCost: 100, UnsupportedNum: 2},
+		},
+	}
+	got, err := f.FormatTagAudit(withUnsupported)
+	if err != nil {
+		t.Fatalf("FormatTagAudit: %v", err)
+	}
+	if !strings.Contains(got, "2 configured provider(s) do not support tag-based cost queries") {
+		t.Errorf("expected unsupported footer, got: %s", got)
+	}
+
+	noUnsupported := &TagAuditReport{
+		Entries: []TagAuditEntry{
+			{TagKey: "Environment", TotalCost: 100, UnsupportedNum: 0},
+		},
+	}
+	got2, _ := f.FormatTagAudit(noUnsupported)
+	if strings.Contains(got2, "do not support tag-based cost queries") {
+		t.Errorf("should not emit footer when UnsupportedNum=0, got: %s", got2)
+	}
+}
+
+func TestFormatTagAudit_JSONFormatRoundtrips(t *testing.T) {
+	f := NewFormatter("json", false)
+	report := &TagAuditReport{
+		Entries: []TagAuditEntry{{TagKey: "Environment", TotalCost: 100, UntaggedPct: 10}},
+	}
+	got, err := f.FormatTagAudit(report)
+	if err != nil {
+		t.Fatalf("FormatTagAudit json: %v", err)
+	}
+	if !strings.Contains(got, `"tagKey": "Environment"`) {
+		t.Errorf("expected JSON output with tagKey field, got: %s", got)
+	}
+}
+
+func lineContaining(s, want string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if strings.Contains(line, want) {
+			return line
+		}
+	}
+	return ""
+}

--- a/internal/cost/types.go
+++ b/internal/cost/types.go
@@ -127,3 +127,21 @@ type TagsResponse struct {
 	TagKey string     `json:"tagKey"`
 	Period CostPeriod `json:"period"`
 }
+
+// TagAuditEntry summarizes tagging compliance for a single required tag key.
+type TagAuditEntry struct {
+	TagKey         string  `json:"tagKey"`
+	TotalCost      float64 `json:"totalCost"`
+	UntaggedCost   float64 `json:"untaggedCost"`
+	UntaggedPct    float64 `json:"untaggedPct"`
+	TaggedValues   int     `json:"taggedValues"`
+	UntaggedSeen   bool    `json:"untaggedSeen"`
+	ProvidersSeen  int     `json:"providersSeen"`
+	UnsupportedNum int     `json:"unsupportedProviders"`
+}
+
+// TagAuditReport is the response of a tag-compliance audit.
+type TagAuditReport struct {
+	Entries []TagAuditEntry `json:"entries"`
+	Period  CostPeriod      `json:"period"`
+}

--- a/internal/k8s/agent_adapters.go
+++ b/internal/k8s/agent_adapters.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/bgdnvk/clanker/internal/k8s/networking"
+	"github.com/bgdnvk/clanker/internal/k8s/sre"
 	"github.com/bgdnvk/clanker/internal/k8s/workloads"
 )
 
@@ -128,6 +129,13 @@ func (a *helmClientAdapter) Run(ctx context.Context, args ...string) (string, er
 
 func (a *helmClientAdapter) RunWithNamespace(ctx context.Context, namespace string, args ...string) (string, error) {
 	return a.client.RunHelmWithNamespace(ctx, namespace, args...)
+}
+
+// NewSREAdapter returns an sre.K8sClient backed by the given kubectl Client.
+// Exposed so callers outside this package can build SRE checkers without
+// reimplementing the adapter (mirrors NewNetworkingAdapter).
+func NewSREAdapter(client *Client) sre.K8sClient {
+	return &sreClientAdapter{client: client}
 }
 
 // sreClientAdapter wraps Client to implement sre.K8sClient interface

--- a/internal/k8s/agent_adapters.go
+++ b/internal/k8s/agent_adapters.go
@@ -49,6 +49,13 @@ func (a *clientAdapter) Logs(ctx context.Context, podName, namespace string, opt
 	})
 }
 
+// NewNetworkingAdapter returns a networking.K8sClient backed by the given
+// kubectl Client. Exposed so callers outside this package (cmd/) can build
+// networking managers without reimplementing the adapter.
+func NewNetworkingAdapter(client *Client) *networkingClientAdapter {
+	return &networkingClientAdapter{client: client}
+}
+
 // networkingClientAdapter wraps Client to implement networking.K8sClient interface
 type networkingClientAdapter struct {
 	client *Client

--- a/internal/k8s/agent_adapters.go
+++ b/internal/k8s/agent_adapters.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 
+	"github.com/bgdnvk/clanker/internal/k8s/networking"
 	"github.com/bgdnvk/clanker/internal/k8s/workloads"
 )
 
@@ -52,7 +53,7 @@ func (a *clientAdapter) Logs(ctx context.Context, podName, namespace string, opt
 // NewNetworkingAdapter returns a networking.K8sClient backed by the given
 // kubectl Client. Exposed so callers outside this package (cmd/) can build
 // networking managers without reimplementing the adapter.
-func NewNetworkingAdapter(client *Client) *networkingClientAdapter {
+func NewNetworkingAdapter(client *Client) networking.K8sClient {
 	return &networkingClientAdapter{client: client}
 }
 

--- a/internal/k8s/networking/networkpolicy.go
+++ b/internal/k8s/networking/networkpolicy.go
@@ -264,23 +264,28 @@ func (m *NetworkPolicyManager) AuditPolicies(ctx context.Context, namespaces []s
 		return nil, err
 	}
 
-	if len(namespaces) == 0 {
+	// When the caller didn't pass an explicit list, derive the audit set
+	// from whichever namespaces actually had policies. Track separately so
+	// it's clear we're reporting on discovered namespaces, not mutating the
+	// original input slice.
+	auditNamespaces := namespaces
+	if len(auditNamespaces) == 0 {
 		seen := make(map[string]struct{}, len(policies))
 		for _, p := range policies {
 			if _, ok := seen[p.Namespace]; !ok {
 				seen[p.Namespace] = struct{}{}
-				namespaces = append(namespaces, p.Namespace)
+				auditNamespaces = append(auditNamespaces, p.Namespace)
 			}
 		}
 	}
 
-	byNs := make(map[string][]NetworkPolicyInfo, len(namespaces))
+	byNs := make(map[string][]NetworkPolicyInfo, len(auditNamespaces))
 	for _, p := range policies {
 		byNs[p.Namespace] = append(byNs[p.Namespace], p)
 	}
 
-	report := &PolicyAuditReport{Namespaces: make([]NamespacePolicyAudit, 0, len(namespaces))}
-	for _, ns := range namespaces {
+	report := &PolicyAuditReport{Namespaces: make([]NamespacePolicyAudit, 0, len(auditNamespaces))}
+	for _, ns := range auditNamespaces {
 		entries := byNs[ns]
 		audit := NamespacePolicyAudit{
 			Namespace:   ns,

--- a/internal/k8s/networking/networkpolicy.go
+++ b/internal/k8s/networking/networkpolicy.go
@@ -251,6 +251,84 @@ func (m *NetworkPolicyManager) AllowFromNamespacePlan(targetNamespace, sourceNam
 	}
 }
 
+// AuditPolicies inspects network policies across the supplied namespaces and
+// reports which ones have default-deny coverage for ingress and egress. A
+// namespace is considered default-deny in a direction when at least one
+// policy targets all pods (empty podSelector) with that direction listed in
+// policyTypes and no rules in that direction (empty ingress/egress slice).
+//
+// If namespaces is nil or empty, all namespaces are audited.
+func (m *NetworkPolicyManager) AuditPolicies(ctx context.Context, namespaces []string) (*PolicyAuditReport, error) {
+	policies, err := m.collectPoliciesForAudit(ctx, namespaces)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(namespaces) == 0 {
+		seen := make(map[string]struct{}, len(policies))
+		for _, p := range policies {
+			if _, ok := seen[p.Namespace]; !ok {
+				seen[p.Namespace] = struct{}{}
+				namespaces = append(namespaces, p.Namespace)
+			}
+		}
+	}
+
+	byNs := make(map[string][]NetworkPolicyInfo, len(namespaces))
+	for _, p := range policies {
+		byNs[p.Namespace] = append(byNs[p.Namespace], p)
+	}
+
+	report := &PolicyAuditReport{Namespaces: make([]NamespacePolicyAudit, 0, len(namespaces))}
+	for _, ns := range namespaces {
+		entries := byNs[ns]
+		audit := NamespacePolicyAudit{
+			Namespace:   ns,
+			PolicyCount: len(entries),
+		}
+		for _, p := range entries {
+			audit.PolicyNames = append(audit.PolicyNames, p.Name)
+			if isDefaultDenyForType(p, "Ingress") && len(p.Ingress) == 0 {
+				audit.DefaultDenyIn = true
+			}
+			if isDefaultDenyForType(p, "Egress") && len(p.Egress) == 0 {
+				audit.DefaultDenyOut = true
+			}
+		}
+		report.Namespaces = append(report.Namespaces, audit)
+	}
+	return report, nil
+}
+
+func (m *NetworkPolicyManager) collectPoliciesForAudit(ctx context.Context, namespaces []string) ([]NetworkPolicyInfo, error) {
+	if len(namespaces) == 0 {
+		return m.ListNetworkPolicies(ctx, "", QueryOptions{AllNamespaces: true})
+	}
+	var combined []NetworkPolicyInfo
+	for _, ns := range namespaces {
+		policies, err := m.ListNetworkPolicies(ctx, ns, QueryOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("namespace %s: %w", ns, err)
+		}
+		combined = append(combined, policies...)
+	}
+	return combined, nil
+}
+
+// isDefaultDenyForType reports whether the policy targets all pods in its
+// namespace and lists the given policy type.
+func isDefaultDenyForType(p NetworkPolicyInfo, policyType string) bool {
+	if len(p.PodSelector) != 0 {
+		return false
+	}
+	for _, t := range p.PolicyTypes {
+		if t == policyType {
+			return true
+		}
+	}
+	return false
+}
+
 // generateNetworkPolicyManifest generates a YAML manifest for a network policy
 func (m *NetworkPolicyManager) generateNetworkPolicyManifest(opts CreateNetworkPolicyOptions) string {
 	manifest := fmt.Sprintf(`apiVersion: networking.k8s.io/v1

--- a/internal/k8s/networking/networkpolicy_audit_test.go
+++ b/internal/k8s/networking/networkpolicy_audit_test.go
@@ -78,9 +78,28 @@ func TestAuditPolicies_AllNamespaces(t *testing.T) {
 	}
 }
 
+// perNamespaceMock returns a different list response per namespace, so we can
+// distinguish a namespace that exists with a default-deny policy from a
+// namespace whose lookup returned no policies.
+type perNamespaceMock struct {
+	mockClient
+	responses map[string]string // namespace -> raw JSON list response
+}
+
+func (m *perNamespaceMock) RunWithNamespace(ctx context.Context, namespace string, args ...string) (string, error) {
+	if v, ok := m.responses[namespace]; ok {
+		return v, nil
+	}
+	// Default: no items.
+	return `{"items": []}`, nil
+}
+
 func TestAuditPolicies_FilteredNamespaces(t *testing.T) {
-	client := &mockClient{
-		runWithNSResponse: `{"items": [{"metadata": {"name": "default-deny", "namespace": "only"}, "spec": {"podSelector": {}, "policyTypes": ["Ingress"]}}]}`,
+	client := &perNamespaceMock{
+		responses: map[string]string{
+			"only": `{"items": [{"metadata": {"name": "default-deny", "namespace": "only"}, "spec": {"podSelector": {}, "policyTypes": ["Ingress"]}}]}`,
+			// "missing" is intentionally absent so the mock returns an empty list.
+		},
 	}
 	mgr := NewNetworkPolicyManager(client, false)
 
@@ -90,6 +109,20 @@ func TestAuditPolicies_FilteredNamespaces(t *testing.T) {
 	}
 	if len(report.Namespaces) != 2 {
 		t.Fatalf("expected 2 namespaces in report, got %d", len(report.Namespaces))
+	}
+
+	byNs := map[string]NamespacePolicyAudit{}
+	for _, e := range report.Namespaces {
+		byNs[e.Namespace] = e
+	}
+
+	only := byNs["only"]
+	if only.PolicyCount != 1 || !only.DefaultDenyIn {
+		t.Errorf("only ns: PolicyCount=%d DefaultDenyIn=%v, want 1+true", only.PolicyCount, only.DefaultDenyIn)
+	}
+	missing := byNs["missing"]
+	if missing.PolicyCount != 0 || missing.DefaultDenyIn || missing.DefaultDenyOut {
+		t.Errorf("missing ns should have zero policies and no default-deny, got %+v", missing)
 	}
 }
 

--- a/internal/k8s/networking/networkpolicy_audit_test.go
+++ b/internal/k8s/networking/networkpolicy_audit_test.go
@@ -1,0 +1,129 @@
+package networking
+
+import (
+	"context"
+	"testing"
+)
+
+const allNamespacesPolicies = `{
+  "items": [
+    {
+      "metadata": {"name": "default-deny", "namespace": "prod"},
+      "spec": {
+        "podSelector": {},
+        "policyTypes": ["Ingress", "Egress"]
+      }
+    },
+    {
+      "metadata": {"name": "allow-app", "namespace": "prod"},
+      "spec": {
+        "podSelector": {"matchLabels": {"app": "web"}},
+        "policyTypes": ["Ingress"],
+        "ingress": [{"from": [{"podSelector": {"matchLabels": {"role": "fe"}}}]}]
+      }
+    },
+    {
+      "metadata": {"name": "ingress-only", "namespace": "staging"},
+      "spec": {
+        "podSelector": {},
+        "policyTypes": ["Ingress"]
+      }
+    },
+    {
+      "metadata": {"name": "scoped", "namespace": "dev"},
+      "spec": {
+        "podSelector": {"matchLabels": {"app": "x"}},
+        "policyTypes": ["Ingress"]
+      }
+    }
+  ]
+}`
+
+func TestAuditPolicies_AllNamespaces(t *testing.T) {
+	client := &mockClient{runResponse: allNamespacesPolicies}
+	mgr := NewNetworkPolicyManager(client, false)
+
+	report, err := mgr.AuditPolicies(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("AuditPolicies failed: %v", err)
+	}
+	if report == nil {
+		t.Fatal("nil report")
+	}
+
+	got := map[string]NamespacePolicyAudit{}
+	for _, ns := range report.Namespaces {
+		got[ns.Namespace] = ns
+	}
+
+	prod := got["prod"]
+	if !prod.DefaultDenyIn || !prod.DefaultDenyOut {
+		t.Errorf("prod should be default-deny in both directions, got %+v", prod)
+	}
+	if prod.PolicyCount != 2 {
+		t.Errorf("prod policy count = %d, want 2", prod.PolicyCount)
+	}
+
+	staging := got["staging"]
+	if !staging.DefaultDenyIn {
+		t.Errorf("staging should be default-deny ingress, got %+v", staging)
+	}
+	if staging.DefaultDenyOut {
+		t.Errorf("staging should NOT be default-deny egress, got %+v", staging)
+	}
+
+	dev := got["dev"]
+	if dev.DefaultDenyIn || dev.DefaultDenyOut {
+		t.Errorf("dev (only scoped policy) should not be default-deny in any direction, got %+v", dev)
+	}
+}
+
+func TestAuditPolicies_FilteredNamespaces(t *testing.T) {
+	client := &mockClient{
+		runWithNSResponse: `{"items": [{"metadata": {"name": "default-deny", "namespace": "only"}, "spec": {"podSelector": {}, "policyTypes": ["Ingress"]}}]}`,
+	}
+	mgr := NewNetworkPolicyManager(client, false)
+
+	report, err := mgr.AuditPolicies(context.Background(), []string{"only", "missing"})
+	if err != nil {
+		t.Fatalf("AuditPolicies failed: %v", err)
+	}
+	if len(report.Namespaces) != 2 {
+		t.Fatalf("expected 2 namespaces in report, got %d", len(report.Namespaces))
+	}
+}
+
+func TestIsDefaultDenyForType(t *testing.T) {
+	cases := []struct {
+		name     string
+		policy   NetworkPolicyInfo
+		typ      string
+		expected bool
+	}{
+		{
+			name:     "empty selector with type",
+			policy:   NetworkPolicyInfo{PodSelector: nil, PolicyTypes: []string{"Ingress"}},
+			typ:      "Ingress",
+			expected: true,
+		},
+		{
+			name:     "scoped selector",
+			policy:   NetworkPolicyInfo{PodSelector: map[string]string{"app": "x"}, PolicyTypes: []string{"Ingress"}},
+			typ:      "Ingress",
+			expected: false,
+		},
+		{
+			name:     "missing direction",
+			policy:   NetworkPolicyInfo{PolicyTypes: []string{"Egress"}},
+			typ:      "Ingress",
+			expected: false,
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isDefaultDenyForType(tt.policy, tt.typ); got != tt.expected {
+				t.Errorf("isDefaultDenyForType = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/k8s/networking/types.go
+++ b/internal/k8s/networking/types.go
@@ -180,6 +180,21 @@ type NetworkPolicyPort struct {
 	EndPort  int    `json:"endPort,omitempty"`
 }
 
+// NamespacePolicyAudit summarizes the network-policy posture of a single
+// namespace.
+type NamespacePolicyAudit struct {
+	Namespace      string   `json:"namespace"`
+	PolicyCount    int      `json:"policyCount"`
+	DefaultDenyIn  bool     `json:"defaultDenyIngress"`
+	DefaultDenyOut bool     `json:"defaultDenyEgress"`
+	PolicyNames    []string `json:"policyNames,omitempty"`
+}
+
+// PolicyAuditReport is the report returned by NetworkPolicyManager.AuditPolicies.
+type PolicyAuditReport struct {
+	Namespaces []NamespacePolicyAudit `json:"namespaces"`
+}
+
 // NetworkPolicyPeer specifies peer for network policy
 type NetworkPolicyPeer struct {
 	PodSelector       map[string]string `json:"podSelector,omitempty"`

--- a/internal/k8s/sre/autoscaler.go
+++ b/internal/k8s/sre/autoscaler.go
@@ -1,0 +1,287 @@
+package sre
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// AutoscalerType identifies which (if any) cluster autoscaler is running.
+type AutoscalerType string
+
+const (
+	AutoscalerNone              AutoscalerType = "none"
+	AutoscalerClusterAutoscaler AutoscalerType = "cluster-autoscaler"
+	AutoscalerKarpenter         AutoscalerType = "karpenter"
+)
+
+// AutoscalerAnalyzer reads kube-system events to surface scaling waste:
+// pods stuck pending because no node fit, scale-ups that didn't happen,
+// scale-downs that pulled back too quickly, etc. Read-only.
+type AutoscalerAnalyzer struct {
+	client      K8sClient
+	karpenter   *KarpenterDetector
+	diagnostics *DiagnosticsManager
+	debug       bool
+}
+
+// NewAutoscalerAnalyzer wires up an analyzer using an existing k8s client.
+func NewAutoscalerAnalyzer(client K8sClient, debug bool) *AutoscalerAnalyzer {
+	return &AutoscalerAnalyzer{
+		client:      client,
+		karpenter:   NewKarpenterDetector(client, debug),
+		diagnostics: NewDiagnosticsManager(client, debug),
+		debug:       debug,
+	}
+}
+
+// AutoscalerInventory describes what (if anything) is autoscaling the cluster.
+type AutoscalerInventory struct {
+	Type                  AutoscalerType `json:"type"`
+	ClusterAutoscalerSeen bool           `json:"clusterAutoscalerSeen"`
+	KarpenterPresent      bool           `json:"karpenterPresent"`
+	Notes                 string         `json:"notes,omitempty"`
+}
+
+// ScalingWasteReport summarises waste signals derived from CA / Karpenter
+// events over a lookback window.
+type ScalingWasteReport struct {
+	Inventory          AutoscalerInventory `json:"inventory"`
+	LookbackWindow     string              `json:"lookbackWindow"`
+	GeneratedAt        time.Time           `json:"generatedAt"`
+	FailedScheduling   int                 `json:"failedScheduling"`   // pods that couldn't fit
+	NotTriggerScaleUp  int                 `json:"notTriggerScaleUp"`  // CA decided NOT to scale up
+	TriggeredScaleUp   int                 `json:"triggeredScaleUp"`   // CA decided to scale up
+	ScaleDownEmpty     int                 `json:"scaleDownEmpty"`     // CA scaled down empty nodes
+	ScaleDownUnneeded  int                 `json:"scaleDownUnneeded"`  // CA scaled down underutilised nodes
+	NodeNotReadyEvents int                 `json:"nodeNotReadyEvents"` // node went NotReady mid-flight
+	HotPodReasons      []ReasonCount       `json:"hotPodReasons,omitempty"`
+	HotNodeReasons     []ReasonCount       `json:"hotNodeReasons,omitempty"`
+	TopFailingPods     []PodFailure        `json:"topFailingPods,omitempty"`
+}
+
+// ReasonCount is a (reason, count, sample-message) triple for the top-N
+// reason aggregates surfaced in the waste report.
+type ReasonCount struct {
+	Reason        string `json:"reason"`
+	Count         int    `json:"count"`
+	SampleMessage string `json:"sampleMessage,omitempty"`
+}
+
+// PodFailure groups events under the pod that's seeing them, so users can
+// jump straight to "this is the workload struggling to schedule".
+type PodFailure struct {
+	Namespace        string `json:"namespace"`
+	Name             string `json:"name"`
+	FailedSchedCount int    `json:"failedScheduling"`
+	NotScaleUpCount  int    `json:"notTriggerScaleUp"`
+	LastReason       string `json:"lastReason,omitempty"`
+	LastMessage      string `json:"lastMessage,omitempty"`
+}
+
+// DetectAutoscaler returns which autoscaler (if any) is running. It checks
+// for a cluster-autoscaler Deployment in kube-system AND for Karpenter CRDs.
+// Both can coexist (rare but valid during a migration).
+func (a *AutoscalerAnalyzer) DetectAutoscaler(ctx context.Context) (*AutoscalerInventory, error) {
+	inv := &AutoscalerInventory{Type: AutoscalerNone}
+
+	caSeen, caNote := a.detectClusterAutoscalerDeployment(ctx)
+	inv.ClusterAutoscalerSeen = caSeen
+	if !caSeen && caNote != "" {
+		inv.Notes = caNote
+	}
+
+	if a.karpenter != nil {
+		presence, err := a.karpenter.Detect(ctx)
+		if err == nil && presence != nil {
+			inv.KarpenterPresent = presence.Installed
+		}
+	}
+
+	switch {
+	case inv.ClusterAutoscalerSeen && inv.KarpenterPresent:
+		// Both → Karpenter typically takes over node provisioning while CA
+		// might still be scaling node groups for non-Karpenter workloads.
+		// Report Karpenter as the dominant signal but keep CA's seen flag.
+		inv.Type = AutoscalerKarpenter
+	case inv.KarpenterPresent:
+		inv.Type = AutoscalerKarpenter
+	case inv.ClusterAutoscalerSeen:
+		inv.Type = AutoscalerClusterAutoscaler
+	}
+	return inv, nil
+}
+
+// detectClusterAutoscalerDeployment looks for a deployment named
+// `cluster-autoscaler` (or matching common label) in kube-system. Returns
+// (false, note) when not found.
+func (a *AutoscalerAnalyzer) detectClusterAutoscalerDeployment(ctx context.Context) (bool, string) {
+	raw, err := a.client.RunJSON(ctx, "get", "deployment", "-n", "kube-system",
+		"-l", "app.kubernetes.io/name=cluster-autoscaler",
+		"-o", "json")
+	if err != nil {
+		// Try the older label, then a name-based fallback.
+		alt, altErr := a.client.RunJSON(ctx, "get", "deployment", "cluster-autoscaler", "-n", "kube-system", "-o", "json")
+		if altErr != nil {
+			return false, fmt.Sprintf("kube-system lookup failed: %v", err)
+		}
+		raw = alt
+	}
+
+	var single struct {
+		Kind     string `json:"kind"`
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+	}
+	var list struct {
+		Items []json.RawMessage `json:"items"`
+	}
+	if err := json.Unmarshal(raw, &list); err == nil && len(list.Items) > 0 {
+		return true, ""
+	}
+	if err := json.Unmarshal(raw, &single); err == nil && single.Metadata.Name != "" {
+		return true, ""
+	}
+	return false, "no cluster-autoscaler Deployment in kube-system"
+}
+
+// AnalyzeScalingWaste fetches recent kube-system events plus default-namespace
+// pod-scheduling events, classifies them, and returns a structured report.
+// Lookback defaults to 1h when zero/negative.
+func (a *AutoscalerAnalyzer) AnalyzeScalingWaste(ctx context.Context, lookback time.Duration) (*ScalingWasteReport, error) {
+	if lookback <= 0 {
+		lookback = time.Hour
+	}
+
+	inv, _ := a.DetectAutoscaler(ctx)
+
+	report := &ScalingWasteReport{
+		Inventory:      *inv,
+		LookbackWindow: lookback.String(),
+		GeneratedAt:    time.Now().UTC(),
+	}
+
+	events, err := a.gatherRelevantEvents(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("event fetch failed: %w", err)
+	}
+
+	cutoff := time.Now().Add(-lookback)
+	podReasonCounts := map[string]*ReasonCount{}
+	nodeReasonCounts := map[string]*ReasonCount{}
+	podFailures := map[string]*PodFailure{} // ns/name → failure entry
+
+	for _, e := range events {
+		// Use LastTimestamp for windowing; events without timestamps are
+		// included so we don't lose data when timestamps are missing.
+		if !e.LastTimestamp.IsZero() && e.LastTimestamp.Before(cutoff) {
+			continue
+		}
+
+		switch e.Reason {
+		case "FailedScheduling":
+			report.FailedScheduling += e.Count
+			bumpPod(podFailures, e, "FailedScheduling")
+			bump(podReasonCounts, e)
+		case "NotTriggerScaleUp":
+			report.NotTriggerScaleUp += e.Count
+			bumpPod(podFailures, e, "NotTriggerScaleUp")
+			bump(podReasonCounts, e)
+		case "TriggeredScaleUp":
+			report.TriggeredScaleUp += e.Count
+		case "ScaleDownEmpty":
+			report.ScaleDownEmpty += e.Count
+			bump(nodeReasonCounts, e)
+		case "ScaleDown":
+			report.ScaleDownUnneeded += e.Count
+			bump(nodeReasonCounts, e)
+		case "NodeNotReady":
+			report.NodeNotReadyEvents += e.Count
+			bump(nodeReasonCounts, e)
+		}
+	}
+
+	report.HotPodReasons = topReasons(podReasonCounts, 5)
+	report.HotNodeReasons = topReasons(nodeReasonCounts, 5)
+	report.TopFailingPods = topPodFailures(podFailures, 5)
+
+	return report, nil
+}
+
+// gatherRelevantEvents pulls all events cluster-wide that the analyzer cares
+// about. We deliberately do this in one pass (kubectl get events -A) rather
+// than multiple --field-selector calls because field-selector OR is not
+// supported and Reason matching is cheap client-side.
+func (a *AutoscalerAnalyzer) gatherRelevantEvents(ctx context.Context) ([]EventInfo, error) {
+	return a.diagnostics.GetEvents(ctx, "", "")
+}
+
+func bump(m map[string]*ReasonCount, e EventInfo) {
+	rc, ok := m[e.Reason]
+	if !ok {
+		rc = &ReasonCount{Reason: e.Reason, SampleMessage: e.Message}
+		m[e.Reason] = rc
+	}
+	rc.Count += e.Count
+	if rc.Count <= 0 {
+		rc.Count++ // events without a Count default to 1
+	}
+}
+
+func bumpPod(m map[string]*PodFailure, e EventInfo, reason string) {
+	if e.InvolvedObject.Kind != "Pod" {
+		return
+	}
+	key := e.InvolvedObject.Namespace + "/" + e.InvolvedObject.Name
+	pf, ok := m[key]
+	if !ok {
+		pf = &PodFailure{Namespace: e.InvolvedObject.Namespace, Name: e.InvolvedObject.Name}
+		m[key] = pf
+	}
+	count := e.Count
+	if count <= 0 {
+		count = 1
+	}
+	switch reason {
+	case "FailedScheduling":
+		pf.FailedSchedCount += count
+	case "NotTriggerScaleUp":
+		pf.NotScaleUpCount += count
+	}
+	if pf.LastReason == "" || (!e.LastTimestamp.IsZero()) {
+		pf.LastReason = e.Reason
+		pf.LastMessage = strings.TrimSpace(e.Message)
+	}
+}
+
+func topReasons(m map[string]*ReasonCount, n int) []ReasonCount {
+	out := make([]ReasonCount, 0, len(m))
+	for _, rc := range m {
+		out = append(out, *rc)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Count > out[j].Count })
+	if len(out) > n {
+		out = out[:n]
+	}
+	return out
+}
+
+func topPodFailures(m map[string]*PodFailure, n int) []PodFailure {
+	out := make([]PodFailure, 0, len(m))
+	for _, pf := range m {
+		out = append(out, *pf)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		ti := out[i].FailedSchedCount + out[i].NotScaleUpCount
+		tj := out[j].FailedSchedCount + out[j].NotScaleUpCount
+		return ti > tj
+	})
+	if len(out) > n {
+		out = out[:n]
+	}
+	return out
+}

--- a/internal/k8s/sre/autoscaler.go
+++ b/internal/k8s/sre/autoscaler.go
@@ -26,7 +26,18 @@ type AutoscalerAnalyzer struct {
 	karpenter   *KarpenterDetector
 	diagnostics *DiagnosticsManager
 	debug       bool
+
+	// MaxEvents bounds how many events the client-side classifier will
+	// process. kubectl get events -A on a busy cluster can return tens of
+	// thousands of objects; this cap keeps the analyzer's memory and CPU
+	// usage predictable. Events are sorted by LastTimestamp ascending, so
+	// when we trim we keep the most recent ones. 0 disables the cap.
+	MaxEvents int
 }
+
+// defaultMaxEvents is the cap applied when MaxEvents is unset. 5000 covers
+// a busy cluster's last few hours without runaway memory.
+const defaultMaxEvents = 5000
 
 // NewAutoscalerAnalyzer wires up an analyzer using an existing k8s client.
 func NewAutoscalerAnalyzer(client K8sClient, debug bool) *AutoscalerAnalyzer {
@@ -35,6 +46,7 @@ func NewAutoscalerAnalyzer(client K8sClient, debug bool) *AutoscalerAnalyzer {
 		karpenter:   NewKarpenterDetector(client, debug),
 		diagnostics: NewDiagnosticsManager(client, debug),
 		debug:       debug,
+		MaxEvents:   defaultMaxEvents,
 	}
 }
 
@@ -52,12 +64,14 @@ type ScalingWasteReport struct {
 	Inventory          AutoscalerInventory `json:"inventory"`
 	LookbackWindow     string              `json:"lookbackWindow"`
 	GeneratedAt        time.Time           `json:"generatedAt"`
-	FailedScheduling   int                 `json:"failedScheduling"`   // pods that couldn't fit
-	NotTriggerScaleUp  int                 `json:"notTriggerScaleUp"`  // CA decided NOT to scale up
-	TriggeredScaleUp   int                 `json:"triggeredScaleUp"`   // CA decided to scale up
-	ScaleDownEmpty     int                 `json:"scaleDownEmpty"`     // CA scaled down empty nodes
-	ScaleDownUnneeded  int                 `json:"scaleDownUnneeded"`  // CA scaled down underutilised nodes
-	NodeNotReadyEvents int                 `json:"nodeNotReadyEvents"` // node went NotReady mid-flight
+	EventsProcessed    int                 `json:"eventsProcessed"`
+	EventsTruncated    bool                `json:"eventsTruncated,omitempty"` // true when the cap kicked in
+	FailedScheduling   int                 `json:"failedScheduling"`          // pods that couldn't fit
+	NotTriggerScaleUp  int                 `json:"notTriggerScaleUp"`         // CA decided NOT to scale up
+	TriggeredScaleUp   int                 `json:"triggeredScaleUp"`          // CA decided to scale up
+	ScaleDownEmpty     int                 `json:"scaleDownEmpty"`            // CA scaled down empty nodes
+	ScaleDownUnneeded  int                 `json:"scaleDownUnneeded"`         // CA scaled down underutilised nodes
+	NodeNotReadyEvents int                 `json:"nodeNotReadyEvents"`        // node went NotReady mid-flight
 	HotPodReasons      []ReasonCount       `json:"hotPodReasons,omitempty"`
 	HotNodeReasons     []ReasonCount       `json:"hotNodeReasons,omitempty"`
 	TopFailingPods     []PodFailure        `json:"topFailingPods,omitempty"`
@@ -80,6 +94,11 @@ type PodFailure struct {
 	NotScaleUpCount  int    `json:"notTriggerScaleUp"`
 	LastReason       string `json:"lastReason,omitempty"`
 	LastMessage      string `json:"lastMessage,omitempty"`
+
+	// lastTimestamp is the timestamp of the event that supplied LastReason
+	// / LastMessage, used internally during aggregation to keep the most
+	// recent reason rather than overwriting newer with older.
+	lastTimestamp time.Time
 }
 
 // DetectAutoscaler returns which autoscaler (if any) is running. It checks
@@ -96,7 +115,16 @@ func (a *AutoscalerAnalyzer) DetectAutoscaler(ctx context.Context) (*AutoscalerI
 
 	if a.karpenter != nil {
 		presence, err := a.karpenter.Detect(ctx)
-		if err == nil && presence != nil {
+		switch {
+		case err != nil:
+			// Surface the error so users notice transient failures instead
+			// of silently being told "no Karpenter" on a flaky kube-apiserver.
+			if inv.Notes == "" {
+				inv.Notes = fmt.Sprintf("karpenter detection failed: %v", err)
+			} else {
+				inv.Notes += fmt.Sprintf("; karpenter detection failed: %v", err)
+			}
+		case presence != nil:
 			inv.KarpenterPresent = presence.Installed
 		}
 	}
@@ -170,6 +198,18 @@ func (a *AutoscalerAnalyzer) AnalyzeScalingWaste(ctx context.Context, lookback t
 		return nil, fmt.Errorf("event fetch failed: %w", err)
 	}
 
+	cap := a.MaxEvents
+	if cap == 0 {
+		cap = defaultMaxEvents
+	}
+	if cap > 0 && len(events) > cap {
+		// kubectl returns events sorted by lastTimestamp ascending — drop
+		// the oldest, keep the newest cap events.
+		events = events[len(events)-cap:]
+		report.EventsTruncated = true
+	}
+	report.EventsProcessed = len(events)
+
 	cutoff := time.Now().Add(-lookback)
 	podReasonCounts := map[string]*ReasonCount{}
 	nodeReasonCounts := map[string]*ReasonCount{}
@@ -182,25 +222,26 @@ func (a *AutoscalerAnalyzer) AnalyzeScalingWaste(ctx context.Context, lookback t
 			continue
 		}
 
+		c := effectiveEventCount(e)
 		switch e.Reason {
 		case "FailedScheduling":
-			report.FailedScheduling += e.Count
+			report.FailedScheduling += c
 			bumpPod(podFailures, e, "FailedScheduling")
 			bump(podReasonCounts, e)
 		case "NotTriggerScaleUp":
-			report.NotTriggerScaleUp += e.Count
+			report.NotTriggerScaleUp += c
 			bumpPod(podFailures, e, "NotTriggerScaleUp")
 			bump(podReasonCounts, e)
 		case "TriggeredScaleUp":
-			report.TriggeredScaleUp += e.Count
+			report.TriggeredScaleUp += c
 		case "ScaleDownEmpty":
-			report.ScaleDownEmpty += e.Count
+			report.ScaleDownEmpty += c
 			bump(nodeReasonCounts, e)
 		case "ScaleDown":
-			report.ScaleDownUnneeded += e.Count
+			report.ScaleDownUnneeded += c
 			bump(nodeReasonCounts, e)
 		case "NodeNotReady":
-			report.NodeNotReadyEvents += e.Count
+			report.NodeNotReadyEvents += c
 			bump(nodeReasonCounts, e)
 		}
 	}
@@ -220,16 +261,25 @@ func (a *AutoscalerAnalyzer) gatherRelevantEvents(ctx context.Context) ([]EventI
 	return a.diagnostics.GetEvents(ctx, "", "")
 }
 
+// effectiveEventCount normalises a zero/negative event Count to 1. Events
+// fetched from `kubectl get events` sometimes have an unset Count (the new
+// events.k8s.io/v1 API drops Count entirely on single-occurrence events),
+// and the previous "guard the accumulator" approach miscounted multiple
+// zero-count events as a single occurrence.
+func effectiveEventCount(e EventInfo) int {
+	if e.Count <= 0 {
+		return 1
+	}
+	return e.Count
+}
+
 func bump(m map[string]*ReasonCount, e EventInfo) {
 	rc, ok := m[e.Reason]
 	if !ok {
 		rc = &ReasonCount{Reason: e.Reason, SampleMessage: e.Message}
 		m[e.Reason] = rc
 	}
-	rc.Count += e.Count
-	if rc.Count <= 0 {
-		rc.Count++ // events without a Count default to 1
-	}
+	rc.Count += effectiveEventCount(e)
 }
 
 func bumpPod(m map[string]*PodFailure, e EventInfo, reason string) {
@@ -242,17 +292,18 @@ func bumpPod(m map[string]*PodFailure, e EventInfo, reason string) {
 		pf = &PodFailure{Namespace: e.InvolvedObject.Namespace, Name: e.InvolvedObject.Name}
 		m[key] = pf
 	}
-	count := e.Count
-	if count <= 0 {
-		count = 1
-	}
+	count := effectiveEventCount(e)
 	switch reason {
 	case "FailedScheduling":
 		pf.FailedSchedCount += count
 	case "NotTriggerScaleUp":
 		pf.NotScaleUpCount += count
 	}
-	if pf.LastReason == "" || (!e.LastTimestamp.IsZero()) {
+	// Only adopt the new event's reason if it's strictly more recent than
+	// what we've already recorded. Falls back to "first non-zero timestamp
+	// wins" when the existing record has no timestamp yet.
+	if pf.lastTimestamp.IsZero() || e.LastTimestamp.After(pf.lastTimestamp) {
+		pf.lastTimestamp = e.LastTimestamp
 		pf.LastReason = e.Reason
 		pf.LastMessage = strings.TrimSpace(e.Message)
 	}

--- a/internal/k8s/sre/autoscaler_test.go
+++ b/internal/k8s/sre/autoscaler_test.go
@@ -1,0 +1,219 @@
+package sre
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// autoscalerMock fans out kubectl invocations to per-target responses.
+// `Run` is what GetEvents (via DiagnosticsManager) actually calls.
+type autoscalerMock struct {
+	apiResourcesOut    string
+	apiResourcesErr    error
+	caDeployJSON       string // kubectl get deployment ... -o json
+	caDeployErr        error
+	caDeploySingleJSON string // fallback `get deployment cluster-autoscaler`
+	eventsOutput       string // events JSON
+	eventsErr          error
+}
+
+func (m *autoscalerMock) Run(_ context.Context, args ...string) (string, error) {
+	full := strings.Join(args, " ")
+	switch {
+	case strings.Contains(full, "api-resources"):
+		return m.apiResourcesOut, m.apiResourcesErr
+	case strings.HasPrefix(full, "get events"):
+		return m.eventsOutput, m.eventsErr
+	}
+	return "", nil
+}
+func (m *autoscalerMock) RunWithNamespace(_ context.Context, _ string, _ ...string) (string, error) {
+	return "", nil
+}
+func (m *autoscalerMock) RunJSON(_ context.Context, args ...string) ([]byte, error) {
+	full := strings.Join(args, " ")
+	switch {
+	case strings.Contains(full, "deployment cluster-autoscaler"):
+		return []byte(m.caDeploySingleJSON), nil
+	case strings.Contains(full, "deployment") && strings.Contains(full, "kube-system"):
+		if m.caDeployErr != nil {
+			return nil, m.caDeployErr
+		}
+		return []byte(m.caDeployJSON), nil
+	}
+	return nil, nil
+}
+
+func TestDetectAutoscaler_None(t *testing.T) {
+	a := NewAutoscalerAnalyzer(&autoscalerMock{
+		caDeployJSON:    `{"items": []}`,
+		apiResourcesOut: "",
+	}, false)
+	inv, err := a.DetectAutoscaler(context.Background())
+	if err != nil {
+		t.Fatalf("DetectAutoscaler: %v", err)
+	}
+	if inv.Type != AutoscalerNone {
+		t.Errorf("expected None, got %s", inv.Type)
+	}
+}
+
+func TestDetectAutoscaler_KarpenterOnly(t *testing.T) {
+	a := NewAutoscalerAnalyzer(&autoscalerMock{
+		caDeployJSON:    `{"items": []}`,
+		apiResourcesOut: "nodepools.karpenter.sh\nnodeclaims.karpenter.sh\n",
+	}, false)
+	inv, _ := a.DetectAutoscaler(context.Background())
+	if inv.Type != AutoscalerKarpenter || !inv.KarpenterPresent || inv.ClusterAutoscalerSeen {
+		t.Errorf("expected Karpenter only, got %+v", inv)
+	}
+}
+
+func TestDetectAutoscaler_ClusterAutoscalerOnly(t *testing.T) {
+	a := NewAutoscalerAnalyzer(&autoscalerMock{
+		caDeployJSON:    `{"items": [{"metadata": {"name": "cluster-autoscaler"}}]}`,
+		apiResourcesOut: "",
+	}, false)
+	inv, _ := a.DetectAutoscaler(context.Background())
+	if inv.Type != AutoscalerClusterAutoscaler || !inv.ClusterAutoscalerSeen || inv.KarpenterPresent {
+		t.Errorf("expected CA only, got %+v", inv)
+	}
+}
+
+func TestDetectAutoscaler_Both_PrefersKarpenter(t *testing.T) {
+	a := NewAutoscalerAnalyzer(&autoscalerMock{
+		caDeployJSON:    `{"items": [{"metadata": {"name": "cluster-autoscaler"}}]}`,
+		apiResourcesOut: "nodepools.karpenter.sh\n",
+	}, false)
+	inv, _ := a.DetectAutoscaler(context.Background())
+	if inv.Type != AutoscalerKarpenter {
+		t.Errorf("when both are present, Karpenter should win; got %s", inv.Type)
+	}
+	if !inv.ClusterAutoscalerSeen {
+		t.Error("CA-seen flag should still be true so users see the coexistence")
+	}
+}
+
+const sampleEventsJSON = `{
+  "items": [
+    {
+      "type": "Warning", "reason": "FailedScheduling", "message": "0/3 nodes are available",
+      "count": 5, "firstTimestamp": "2026-04-27T10:00:00Z", "lastTimestamp": "2026-04-27T10:30:00Z",
+      "involvedObject": {"kind": "Pod", "name": "api-7d9", "namespace": "prod"}
+    },
+    {
+      "type": "Normal", "reason": "TriggeredScaleUp", "message": "scaled up to 4 nodes",
+      "count": 1, "lastTimestamp": "2026-04-27T10:32:00Z",
+      "involvedObject": {"kind": "Node", "name": "ip-10-0-1-23"}
+    },
+    {
+      "type": "Warning", "reason": "NotTriggerScaleUp", "message": "no pool can fit pod",
+      "count": 3, "lastTimestamp": "2026-04-27T10:25:00Z",
+      "involvedObject": {"kind": "Pod", "name": "api-7d9", "namespace": "prod"}
+    },
+    {
+      "type": "Normal", "reason": "ScaleDownEmpty", "message": "removed empty node",
+      "count": 1, "lastTimestamp": "2026-04-27T11:00:00Z",
+      "involvedObject": {"kind": "Node", "name": "ip-10-0-1-99"}
+    },
+    {
+      "type": "Warning", "reason": "FailedScheduling", "message": "insufficient cpu",
+      "count": 2, "lastTimestamp": "2026-04-27T10:40:00Z",
+      "involvedObject": {"kind": "Pod", "name": "worker-abc", "namespace": "default"}
+    },
+    {
+      "type": "Warning", "reason": "FailedScheduling", "message": "ancient",
+      "count": 100, "lastTimestamp": "2025-01-01T00:00:00Z",
+      "involvedObject": {"kind": "Pod", "name": "ancient", "namespace": "default"}
+    }
+  ]
+}`
+
+func TestAnalyzeScalingWaste_AggregatesAndWindows(t *testing.T) {
+	a := NewAutoscalerAnalyzer(&autoscalerMock{
+		caDeployJSON: `{"items": []}`,
+		eventsOutput: sampleEventsJSON,
+	}, false)
+
+	// Use a wide lookback so the 2026 events are kept but the 2025-01-01
+	// "ancient" event is filtered out (it's > a year old vs. now in 2026).
+	report, err := a.AnalyzeScalingWaste(context.Background(), 365*24*time.Hour)
+	if err != nil {
+		t.Fatalf("AnalyzeScalingWaste: %v", err)
+	}
+
+	// 5 (api-7d9 FailedSched) + 2 (worker-abc) = 7. Ancient is excluded.
+	if report.FailedScheduling != 7 {
+		t.Errorf("FailedScheduling = %d, want 7 (ancient filtered)", report.FailedScheduling)
+	}
+	if report.NotTriggerScaleUp != 3 {
+		t.Errorf("NotTriggerScaleUp = %d, want 3", report.NotTriggerScaleUp)
+	}
+	if report.TriggeredScaleUp != 1 {
+		t.Errorf("TriggeredScaleUp = %d, want 1", report.TriggeredScaleUp)
+	}
+	if report.ScaleDownEmpty != 1 {
+		t.Errorf("ScaleDownEmpty = %d, want 1", report.ScaleDownEmpty)
+	}
+
+	if len(report.TopFailingPods) == 0 {
+		t.Fatal("expected at least one failing pod in TopFailingPods")
+	}
+	// api-7d9 has 5 FailedSched + 3 NotScaleUp = 8 → should be #1.
+	top := report.TopFailingPods[0]
+	if top.Name != "api-7d9" {
+		t.Errorf("top failing pod = %q, want api-7d9", top.Name)
+	}
+	if top.FailedSchedCount != 5 || top.NotScaleUpCount != 3 {
+		t.Errorf("api-7d9 counts = (%d, %d), want (5, 3)", top.FailedSchedCount, top.NotScaleUpCount)
+	}
+}
+
+func TestAnalyzeScalingWaste_ShortLookbackFiltersOldEvents(t *testing.T) {
+	a := NewAutoscalerAnalyzer(&autoscalerMock{
+		caDeployJSON: `{"items": []}`,
+		eventsOutput: sampleEventsJSON,
+	}, false)
+
+	// 1ns lookback excludes everything except events with no timestamp.
+	report, err := a.AnalyzeScalingWaste(context.Background(), time.Nanosecond)
+	if err != nil {
+		t.Fatalf("AnalyzeScalingWaste: %v", err)
+	}
+	if report.FailedScheduling != 0 || report.NotTriggerScaleUp != 0 {
+		t.Errorf("everything should be filtered with 1ns lookback, got %+v", report)
+	}
+}
+
+func TestAnalyzeScalingWaste_DefaultLookbackOnZero(t *testing.T) {
+	a := NewAutoscalerAnalyzer(&autoscalerMock{
+		caDeployJSON: `{"items": []}`,
+		eventsOutput: `{"items": []}`,
+	}, false)
+
+	report, err := a.AnalyzeScalingWaste(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("AnalyzeScalingWaste: %v", err)
+	}
+	if report.LookbackWindow != "1h0m0s" {
+		t.Errorf("zero lookback should default to 1h, got %q", report.LookbackWindow)
+	}
+}
+
+func TestTopReasons_OrderAndCap(t *testing.T) {
+	m := map[string]*ReasonCount{
+		"A": {Reason: "A", Count: 1},
+		"B": {Reason: "B", Count: 5},
+		"C": {Reason: "C", Count: 3},
+		"D": {Reason: "D", Count: 8},
+	}
+	got := topReasons(m, 2)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(got))
+	}
+	if got[0].Reason != "D" || got[1].Reason != "B" {
+		t.Errorf("expected D, B; got %q, %q", got[0].Reason, got[1].Reason)
+	}
+}

--- a/internal/k8s/sre/autoscaler_test.go
+++ b/internal/k8s/sre/autoscaler_test.go
@@ -2,6 +2,7 @@ package sre
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -199,6 +200,130 @@ func TestAnalyzeScalingWaste_DefaultLookbackOnZero(t *testing.T) {
 	}
 	if report.LookbackWindow != "1h0m0s" {
 		t.Errorf("zero lookback should default to 1h, got %q", report.LookbackWindow)
+	}
+}
+
+// TestBump_ZeroCountEventsCountAsOne is a regression test for a math bug
+// where the previous implementation guarded `rc.Count <= 0` AFTER the
+// addition, causing two zero-count events to total 1 instead of 2.
+func TestBump_ZeroCountEventsCountAsOne(t *testing.T) {
+	m := map[string]*ReasonCount{}
+	bump(m, EventInfo{Reason: "X", Count: 0, Message: "first"})
+	bump(m, EventInfo{Reason: "X", Count: 0, Message: "second"})
+	bump(m, EventInfo{Reason: "X", Count: 0, Message: "third"})
+	if got := m["X"].Count; got != 3 {
+		t.Errorf("three zero-count events should total 3 occurrences, got %d", got)
+	}
+	if m["X"].SampleMessage != "first" {
+		t.Errorf("sample message should be from the first event, got %q", m["X"].SampleMessage)
+	}
+}
+
+// TestBumpPod_PrefersNewerLastReason verifies that out-of-order events
+// don't overwrite a newer reason with an older one.
+func TestBumpPod_PrefersNewerLastReason(t *testing.T) {
+	m := map[string]*PodFailure{}
+	older := EventInfo{Reason: "FailedScheduling", Count: 1, Message: "old"}
+	older.LastTimestamp = time.Date(2026, 4, 27, 10, 0, 0, 0, time.UTC)
+	older.InvolvedObject.Kind = "Pod"
+	older.InvolvedObject.Name = "p1"
+	older.InvolvedObject.Namespace = "default"
+	newer := older
+	newer.Reason = "NotTriggerScaleUp"
+	newer.Message = "new"
+	newer.LastTimestamp = time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+
+	// Apply newer first, then older — buggy code would overwrite with older.
+	bumpPod(m, newer, "NotTriggerScaleUp")
+	bumpPod(m, older, "FailedScheduling")
+
+	pf := m["default/p1"]
+	if pf == nil {
+		t.Fatal("missing pod entry")
+	}
+	if pf.LastReason != "NotTriggerScaleUp" {
+		t.Errorf("LastReason = %q, want NotTriggerScaleUp (newer event must win)", pf.LastReason)
+	}
+	if pf.LastMessage != "new" {
+		t.Errorf("LastMessage = %q, want %q", pf.LastMessage, "new")
+	}
+}
+
+func TestEffectiveEventCount(t *testing.T) {
+	cases := []struct {
+		name string
+		in   EventInfo
+		want int
+	}{
+		{"zero defaults to one", EventInfo{Count: 0}, 1},
+		{"negative defaults to one", EventInfo{Count: -5}, 1},
+		{"positive passes through", EventInfo{Count: 7}, 7},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := effectiveEventCount(c.in); got != c.want {
+				t.Errorf("effectiveEventCount = %d, want %d", got, c.want)
+			}
+		})
+	}
+}
+
+// TestAnalyzeScalingWaste_RespectsMaxEventsCap drops oldest events when the
+// fetched list exceeds the cap and flags the truncation in the report.
+func TestAnalyzeScalingWaste_RespectsMaxEventsCap(t *testing.T) {
+	// Generate 50 events, all with the same reason so we can count exactly.
+	var items []string
+	for i := 0; i < 50; i++ {
+		items = append(items, `{
+			"type": "Warning", "reason": "FailedScheduling", "message": "x",
+			"count": 1,
+			"lastTimestamp": "2026-04-27T10:00:00Z",
+			"involvedObject": {"kind": "Pod", "name": "p", "namespace": "default"}
+		}`)
+	}
+	json := `{"items": [` + strings.Join(items, ",") + `]}`
+
+	a := NewAutoscalerAnalyzer(&autoscalerMock{
+		caDeployJSON: `{"items": []}`,
+		eventsOutput: json,
+	}, false)
+	a.MaxEvents = 10
+
+	report, err := a.AnalyzeScalingWaste(context.Background(), 365*24*time.Hour)
+	if err != nil {
+		t.Fatalf("AnalyzeScalingWaste: %v", err)
+	}
+	if !report.EventsTruncated {
+		t.Error("expected EventsTruncated=true when input exceeds cap")
+	}
+	if report.EventsProcessed != 10 {
+		t.Errorf("EventsProcessed = %d, want 10", report.EventsProcessed)
+	}
+	// Cap kept 10 events × count=1 each = 10 FailedScheduling.
+	if report.FailedScheduling != 10 {
+		t.Errorf("FailedScheduling = %d, want 10", report.FailedScheduling)
+	}
+}
+
+// TestDetectAutoscaler_KarpenterDetectErrorSurfacesInNotes verifies that a
+// transient kube-apiserver failure to probe Karpenter is recorded rather
+// than silently flipping the report to "no Karpenter".
+func TestDetectAutoscaler_KarpenterDetectErrorSurfacesInNotes(t *testing.T) {
+	a := NewAutoscalerAnalyzer(&autoscalerMock{
+		caDeployJSON:    `{"items": []}`,
+		apiResourcesErr: errors.New("connection refused"),
+	}, false)
+	inv, _ := a.DetectAutoscaler(context.Background())
+	if inv.KarpenterPresent {
+		t.Error("KarpenterPresent should remain false on probe error")
+	}
+	// detect inside karpenter.go currently swallows the api-resources error
+	// into Notes itself. The autoscaler-level probe goes through Detect()
+	// which returns (presence, nil). Notes should reflect "api-resources
+	// lookup failed" via the karpenter detector or the autoscaler's own
+	// surface. Either path is acceptable; we only require some message.
+	if inv.Notes == "" {
+		t.Error("expected a non-empty Notes when probe fails")
 	}
 }
 

--- a/internal/k8s/sre/health.go
+++ b/internal/k8s/sre/health.go
@@ -74,8 +74,12 @@ func (h *HealthChecker) CheckClusterDetailed(ctx context.Context) (*ClusterHealt
 		summary.NetworkHealth = ComponentHealth{Status: "unknown", Score: 50}
 	}
 
-	// Count issues by severity
-	allIssues := append(nodeIssues, workloadIssues...)
+	// Count issues by severity. Build the combined slice with explicit
+	// allocation so callers that mutate the returned []Issue can't clobber
+	// nodeIssues' backing array (they would otherwise share storage).
+	allIssues := make([]Issue, 0, len(nodeIssues)+len(workloadIssues))
+	allIssues = append(allIssues, nodeIssues...)
+	allIssues = append(allIssues, workloadIssues...)
 	for _, issue := range allIssues {
 		switch issue.Severity {
 		case SeverityCritical:

--- a/internal/k8s/sre/health.go
+++ b/internal/k8s/sre/health.go
@@ -23,8 +23,19 @@ func NewHealthChecker(client K8sClient, debug bool) *HealthChecker {
 	}
 }
 
-// CheckCluster performs a cluster-wide health check
+// CheckCluster performs a cluster-wide health check, returning aggregate
+// counts only. Use CheckClusterDetailed when callers need the underlying
+// per-resource issue list (e.g., for CLI output).
 func (h *HealthChecker) CheckCluster(ctx context.Context) (*ClusterHealthSummary, error) {
+	summary, _, err := h.CheckClusterDetailed(ctx)
+	return summary, err
+}
+
+// CheckClusterDetailed runs the same checks as CheckCluster but also returns
+// the full list of detected issues from nodes + workloads. Issues are useful
+// for CLI/UI surfaces that show per-resource problems with severity and
+// suggestions, not just aggregate counts.
+func (h *HealthChecker) CheckClusterDetailed(ctx context.Context) (*ClusterHealthSummary, []Issue, error) {
 	summary := &ClusterHealthSummary{
 		Score: 100,
 	}
@@ -32,14 +43,14 @@ func (h *HealthChecker) CheckCluster(ctx context.Context) (*ClusterHealthSummary
 	// Check nodes
 	nodeHealth, nodeIssues, err := h.checkNodes(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check nodes: %w", err)
+		return nil, nil, fmt.Errorf("failed to check nodes: %w", err)
 	}
 	summary.NodeHealth = nodeHealth
 
 	// Check workloads
 	workloadHealth, workloadIssues, podCounts, err := h.checkWorkloads(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check workloads: %w", err)
+		return nil, nil, fmt.Errorf("failed to check workloads: %w", err)
 	}
 	summary.WorkloadHealth = workloadHealth
 	summary.TotalPods = podCounts.total
@@ -86,7 +97,7 @@ func (h *HealthChecker) CheckCluster(ctx context.Context) (*ClusterHealthSummary
 		summary.OverallHealth = "healthy"
 	}
 
-	return summary, nil
+	return summary, allIssues, nil
 }
 
 // CheckNamespace performs a health check on a specific namespace

--- a/internal/k8s/sre/karpenter.go
+++ b/internal/k8s/sre/karpenter.go
@@ -1,0 +1,300 @@
+package sre
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// KarpenterDetector inspects a cluster for Karpenter-managed autoscaling.
+// All operations are read-only.
+type KarpenterDetector struct {
+	client K8sClient
+	debug  bool
+}
+
+// NewKarpenterDetector returns a detector that uses the supplied kubectl
+// client. The client is expected to behave like sre.K8sClient — `Run` and
+// `RunJSON` for read-only kubectl invocations.
+func NewKarpenterDetector(client K8sClient, debug bool) *KarpenterDetector {
+	return &KarpenterDetector{client: client, debug: debug}
+}
+
+// KarpenterPresence describes whether Karpenter is installed and what
+// resource versions / counts are visible.
+type KarpenterPresence struct {
+	Installed           bool   `json:"installed"`
+	APIGroup            string `json:"apiGroup,omitempty"`  // typically "karpenter.sh"
+	NodePoolsAvailable  bool   `json:"nodePoolsAvailable"`  // CRD installed
+	NodeClaimsAvailable bool   `json:"nodeClaimsAvailable"` // CRD installed
+	Notes               string `json:"notes,omitempty"`
+}
+
+// NodePoolSummary is a flattened view of a Karpenter NodePool suitable for
+// CLI / JSON consumption. We deliberately avoid pulling in the full karpenter
+// API types so this package compiles without a network dependency.
+type NodePoolSummary struct {
+	Name             string            `json:"name"`
+	Namespace        string            `json:"namespace,omitempty"`
+	Limits           map[string]string `json:"limits,omitempty"`
+	NodeClass        string            `json:"nodeClass,omitempty"`
+	Disruption       string            `json:"disruption,omitempty"`
+	Weight           int               `json:"weight,omitempty"`
+	NodesProvisioned int               `json:"nodesProvisioned"`
+	Taints           []string          `json:"taints,omitempty"`
+	Labels           map[string]string `json:"labels,omitempty"`
+	Age              string            `json:"age,omitempty"`
+	CreatedAt        time.Time         `json:"createdAt,omitempty"`
+}
+
+// NodeClaimSummary is one Karpenter NodeClaim — the running-instance side of
+// a NodePool.
+type NodeClaimSummary struct {
+	Name       string            `json:"name"`
+	NodePool   string            `json:"nodePool,omitempty"`
+	NodeName   string            `json:"nodeName,omitempty"`
+	Status     string            `json:"status,omitempty"`
+	Capacity   map[string]string `json:"capacity,omitempty"`
+	InstanceID string            `json:"instanceID,omitempty"`
+	CreatedAt  time.Time         `json:"createdAt,omitempty"`
+}
+
+// Detect reports whether Karpenter CRDs are installed in the cluster. It
+// uses `kubectl api-resources` to look for the karpenter.sh API group, which
+// avoids relying on cluster-scoped get permissions.
+func (d *KarpenterDetector) Detect(ctx context.Context) (*KarpenterPresence, error) {
+	out, err := d.client.Run(ctx, "api-resources", "--api-group=karpenter.sh", "-o", "name")
+	if err != nil {
+		return &KarpenterPresence{Installed: false, Notes: fmt.Sprintf("api-resources lookup failed: %v", err)}, nil
+	}
+
+	presence := &KarpenterPresence{}
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		presence.Installed = true
+		presence.APIGroup = "karpenter.sh"
+		switch {
+		case strings.HasPrefix(line, "nodepools"):
+			presence.NodePoolsAvailable = true
+		case strings.HasPrefix(line, "nodeclaims"):
+			presence.NodeClaimsAvailable = true
+		}
+	}
+	return presence, nil
+}
+
+// ListNodePools returns the NodePools known to the cluster. Returns an empty
+// slice (not an error) when Karpenter is not installed, so callers can render
+// "no Karpenter resources" without sniffing error strings.
+func (d *KarpenterDetector) ListNodePools(ctx context.Context) ([]NodePoolSummary, error) {
+	raw, err := d.client.RunJSON(ctx, "get", "nodepools.karpenter.sh", "-A", "-o", "json")
+	if err != nil {
+		// Karpenter not installed → return empty, no error.
+		if isMissingResource(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to list Karpenter NodePools: %w", err)
+	}
+
+	var list struct {
+		Items []json.RawMessage `json:"items"`
+	}
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, fmt.Errorf("parse NodePool list: %w", err)
+	}
+
+	pools := make([]NodePoolSummary, 0, len(list.Items))
+	for _, item := range list.Items {
+		summary, err := parseNodePool(item)
+		if err != nil {
+			if d.debug {
+				fmt.Printf("[karpenter] skipping unparseable NodePool: %v\n", err)
+			}
+			continue
+		}
+		pools = append(pools, summary)
+	}
+	return pools, nil
+}
+
+// ListNodeClaims returns the running NodeClaims (one per Karpenter-provisioned
+// node). Behaviour around uninstalled Karpenter mirrors ListNodePools.
+func (d *KarpenterDetector) ListNodeClaims(ctx context.Context) ([]NodeClaimSummary, error) {
+	raw, err := d.client.RunJSON(ctx, "get", "nodeclaims.karpenter.sh", "-A", "-o", "json")
+	if err != nil {
+		if isMissingResource(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to list Karpenter NodeClaims: %w", err)
+	}
+
+	var list struct {
+		Items []json.RawMessage `json:"items"`
+	}
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, fmt.Errorf("parse NodeClaim list: %w", err)
+	}
+
+	claims := make([]NodeClaimSummary, 0, len(list.Items))
+	for _, item := range list.Items {
+		summary, err := parseNodeClaim(item)
+		if err != nil {
+			if d.debug {
+				fmt.Printf("[karpenter] skipping unparseable NodeClaim: %v\n", err)
+			}
+			continue
+		}
+		claims = append(claims, summary)
+	}
+	return claims, nil
+}
+
+func parseNodePool(data []byte) (NodePoolSummary, error) {
+	var np struct {
+		Metadata struct {
+			Name              string            `json:"name"`
+			Namespace         string            `json:"namespace"`
+			Labels            map[string]string `json:"labels"`
+			CreationTimestamp string            `json:"creationTimestamp"`
+		} `json:"metadata"`
+		Spec struct {
+			Limits   map[string]string `json:"limits"`
+			Weight   int               `json:"weight"`
+			Template struct {
+				Spec struct {
+					NodeClassRef struct {
+						Name string `json:"name"`
+					} `json:"nodeClassRef"`
+					Taints []struct {
+						Key    string `json:"key"`
+						Effect string `json:"effect"`
+					} `json:"taints"`
+				} `json:"spec"`
+			} `json:"template"`
+			Disruption struct {
+				ConsolidationPolicy string `json:"consolidationPolicy"`
+			} `json:"disruption"`
+		} `json:"spec"`
+		Status struct {
+			Resources map[string]string `json:"resources"`
+		} `json:"status"`
+	}
+	if err := json.Unmarshal(data, &np); err != nil {
+		return NodePoolSummary{}, err
+	}
+
+	out := NodePoolSummary{
+		Name:       np.Metadata.Name,
+		Namespace:  np.Metadata.Namespace,
+		Limits:     np.Spec.Limits,
+		NodeClass:  np.Spec.Template.Spec.NodeClassRef.Name,
+		Disruption: np.Spec.Disruption.ConsolidationPolicy,
+		Weight:     np.Spec.Weight,
+		Labels:     np.Metadata.Labels,
+	}
+
+	for _, t := range np.Spec.Template.Spec.Taints {
+		out.Taints = append(out.Taints, fmt.Sprintf("%s:%s", t.Key, t.Effect))
+	}
+
+	if t, err := time.Parse(time.RFC3339, np.Metadata.CreationTimestamp); err == nil {
+		out.CreatedAt = t
+		out.Age = humanAge(time.Since(t))
+	}
+
+	return out, nil
+}
+
+func parseNodeClaim(data []byte) (NodeClaimSummary, error) {
+	var nc struct {
+		Metadata struct {
+			Name              string            `json:"name"`
+			Labels            map[string]string `json:"labels"`
+			CreationTimestamp string            `json:"creationTimestamp"`
+		} `json:"metadata"`
+		Status struct {
+			Capacity   map[string]string `json:"capacity"`
+			NodeName   string            `json:"nodeName"`
+			ProviderID string            `json:"providerID"`
+			Conditions []struct {
+				Type   string `json:"type"`
+				Status string `json:"status"`
+			} `json:"conditions"`
+		} `json:"status"`
+	}
+	if err := json.Unmarshal(data, &nc); err != nil {
+		return NodeClaimSummary{}, err
+	}
+
+	status := "Pending"
+	for _, c := range nc.Status.Conditions {
+		if c.Type == "Ready" && c.Status == "True" {
+			status = "Ready"
+			break
+		}
+	}
+
+	out := NodeClaimSummary{
+		Name:     nc.Metadata.Name,
+		NodePool: nc.Metadata.Labels["karpenter.sh/nodepool"],
+		NodeName: nc.Status.NodeName,
+		Status:   status,
+		Capacity: nc.Status.Capacity,
+	}
+	out.InstanceID = providerInstanceID(nc.Status.ProviderID)
+	if t, err := time.Parse(time.RFC3339, nc.Metadata.CreationTimestamp); err == nil {
+		out.CreatedAt = t
+	}
+	return out, nil
+}
+
+// providerInstanceID strips the "aws:///<az>/" prefix from a Kubernetes
+// providerID, returning just the instance identifier.
+func providerInstanceID(providerID string) string {
+	if providerID == "" {
+		return ""
+	}
+	idx := strings.LastIndex(providerID, "/")
+	if idx < 0 {
+		return providerID
+	}
+	return providerID[idx+1:]
+}
+
+// isMissingResource reports whether the kubectl error means the requested
+// resource type is unknown (Karpenter not installed). We check stderr-like
+// substrings rather than relying on exit codes because kubectl returns
+// generic errors for both "not found" and "unknown resource".
+func isMissingResource(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "the server doesn't have a resource type") ||
+		strings.Contains(msg, "no resources found") ||
+		strings.Contains(msg, "doesn't have a resource") ||
+		strings.Contains(msg, "no matches for kind")
+}
+
+// humanAge is a minimal duration→string formatter for the "AGE" column.
+// kubectl-style: 5m, 3h, 2d, 14d.
+func humanAge(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}

--- a/internal/k8s/sre/karpenter.go
+++ b/internal/k8s/sre/karpenter.go
@@ -267,22 +267,23 @@ func providerInstanceID(providerID string) string {
 }
 
 // isMissingResource reports whether the kubectl error means the requested
-// resource type is unknown (Karpenter not installed). We check stderr-like
-// substrings rather than relying on exit codes because kubectl returns
-// generic errors for both "not found" and "unknown resource".
+// CRD / resource KIND is unknown (Karpenter not installed). We deliberately
+// do NOT match "no resources found" — that string also appears for an empty
+// but installed CRD, which would mis-classify a working Karpenter cluster
+// with zero NodePools as "not installed".
 func isMissingResource(err error) bool {
 	if err == nil {
 		return false
 	}
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "the server doesn't have a resource type") ||
-		strings.Contains(msg, "no resources found") ||
 		strings.Contains(msg, "doesn't have a resource") ||
 		strings.Contains(msg, "no matches for kind")
 }
 
 // humanAge is a minimal duration→string formatter for the "AGE" column.
-// kubectl-style: 5m, 3h, 2d, 14d.
+// kubectl-style: 5m, 3h, 2d, 14d. Exactly 24h is rendered as "1d" rather
+// than "24h" to match `kubectl get` conventions.
 func humanAge(d time.Duration) string {
 	if d < 0 {
 		d = 0
@@ -295,6 +296,10 @@ func humanAge(d time.Duration) string {
 	case d < 24*time.Hour:
 		return fmt.Sprintf("%dh", int(d.Hours()))
 	default:
-		return fmt.Sprintf("%dd", int(d.Hours()/24))
+		days := int(d.Hours()) / 24
+		if days < 1 {
+			days = 1
+		}
+		return fmt.Sprintf("%dd", days)
 	}
 }

--- a/internal/k8s/sre/karpenter_test.go
+++ b/internal/k8s/sre/karpenter_test.go
@@ -1,0 +1,302 @@
+package sre
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// karpenterMock dispatches to per-arg responses so a single test can return
+// different data for `api-resources`, `get nodepools.karpenter.sh ...`, and
+// `get nodeclaims.karpenter.sh ...` calls.
+type karpenterMock struct {
+	apiResourcesOut string
+	apiResourcesErr error
+	nodePoolsJSON   []byte
+	nodePoolsErr    error
+	nodeClaimsJSON  []byte
+	nodeClaimsErr   error
+}
+
+func (m *karpenterMock) Run(_ context.Context, args ...string) (string, error) {
+	if len(args) > 0 && args[0] == "api-resources" {
+		return m.apiResourcesOut, m.apiResourcesErr
+	}
+	return "", nil
+}
+func (m *karpenterMock) RunWithNamespace(_ context.Context, _ string, _ ...string) (string, error) {
+	return "", nil
+}
+func (m *karpenterMock) RunJSON(_ context.Context, args ...string) ([]byte, error) {
+	full := strings.Join(args, " ")
+	switch {
+	case strings.Contains(full, "nodepools.karpenter.sh"):
+		return m.nodePoolsJSON, m.nodePoolsErr
+	case strings.Contains(full, "nodeclaims.karpenter.sh"):
+		return m.nodeClaimsJSON, m.nodeClaimsErr
+	}
+	return nil, nil
+}
+
+func TestKarpenterDetect_NotInstalled(t *testing.T) {
+	d := NewKarpenterDetector(&karpenterMock{
+		apiResourcesErr: errors.New("the server doesn't have a resource type \"karpenter.sh\""),
+	}, false)
+	got, err := d.Detect(context.Background())
+	if err != nil {
+		t.Fatalf("Detect should not propagate detection errors: %v", err)
+	}
+	if got.Installed {
+		t.Errorf("expected Installed=false when api-resources errors, got %+v", got)
+	}
+	if got.Notes == "" {
+		t.Error("expected explanatory Notes when not installed")
+	}
+}
+
+func TestKarpenterDetect_BothCRDsPresent(t *testing.T) {
+	d := NewKarpenterDetector(&karpenterMock{
+		apiResourcesOut: "nodepools.karpenter.sh\nnodeclaims.karpenter.sh\nec2nodeclasses.karpenter.k8s.aws\n",
+	}, false)
+	got, err := d.Detect(context.Background())
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if !got.Installed || !got.NodePoolsAvailable || !got.NodeClaimsAvailable {
+		t.Errorf("expected Installed + both CRDs available, got %+v", got)
+	}
+	if got.APIGroup != "karpenter.sh" {
+		t.Errorf("expected APIGroup karpenter.sh, got %q", got.APIGroup)
+	}
+}
+
+func TestKarpenterDetect_OnlyNodePools(t *testing.T) {
+	d := NewKarpenterDetector(&karpenterMock{
+		apiResourcesOut: "nodepools.karpenter.sh\n",
+	}, false)
+	got, _ := d.Detect(context.Background())
+	if !got.NodePoolsAvailable || got.NodeClaimsAvailable {
+		t.Errorf("expected only NodePools available, got %+v", got)
+	}
+}
+
+const samplePoolsJSON = `{
+  "items": [
+    {
+      "metadata": {
+        "name": "default",
+        "creationTimestamp": "2026-04-01T00:00:00Z",
+        "labels": {"team": "platform"}
+      },
+      "spec": {
+        "limits": {"cpu": "1000", "memory": "4000Gi"},
+        "weight": 10,
+        "template": {
+          "spec": {
+            "nodeClassRef": {"name": "default-ec2"},
+            "taints": [{"key": "spot", "effect": "NoSchedule"}]
+          }
+        },
+        "disruption": {"consolidationPolicy": "WhenUnderutilized"}
+      }
+    },
+    {
+      "metadata": {"name": "gpu", "creationTimestamp": "2026-04-15T00:00:00Z"},
+      "spec": {
+        "weight": 100,
+        "template": {"spec": {"nodeClassRef": {"name": "gpu-ec2"}}},
+        "disruption": {"consolidationPolicy": "WhenEmpty"}
+      }
+    }
+  ]
+}`
+
+func TestListNodePools_ParsesAllFields(t *testing.T) {
+	d := NewKarpenterDetector(&karpenterMock{nodePoolsJSON: []byte(samplePoolsJSON)}, false)
+
+	pools, err := d.ListNodePools(context.Background())
+	if err != nil {
+		t.Fatalf("ListNodePools: %v", err)
+	}
+	if len(pools) != 2 {
+		t.Fatalf("expected 2 NodePools, got %d", len(pools))
+	}
+
+	byName := map[string]NodePoolSummary{}
+	for _, p := range pools {
+		byName[p.Name] = p
+	}
+
+	def := byName["default"]
+	if def.NodeClass != "default-ec2" {
+		t.Errorf("default NodeClass = %q, want default-ec2", def.NodeClass)
+	}
+	if def.Weight != 10 {
+		t.Errorf("default Weight = %d, want 10", def.Weight)
+	}
+	if def.Disruption != "WhenUnderutilized" {
+		t.Errorf("default Disruption = %q", def.Disruption)
+	}
+	if def.Limits["cpu"] != "1000" {
+		t.Errorf("default Limits[cpu] = %q, want 1000", def.Limits["cpu"])
+	}
+	if len(def.Taints) != 1 || def.Taints[0] != "spot:NoSchedule" {
+		t.Errorf("default Taints = %v, want [spot:NoSchedule]", def.Taints)
+	}
+	if def.Labels["team"] != "platform" {
+		t.Errorf("default Labels[team] = %q, want platform", def.Labels["team"])
+	}
+	if def.Age == "" || def.CreatedAt.IsZero() {
+		t.Errorf("default Age/CreatedAt should be populated, got Age=%q CreatedAt=%v", def.Age, def.CreatedAt)
+	}
+}
+
+func TestListNodePools_KarpenterNotInstalled(t *testing.T) {
+	// kubectl error like `the server doesn't have a resource type ...`
+	d := NewKarpenterDetector(&karpenterMock{
+		nodePoolsErr: errors.New("the server doesn't have a resource type \"nodepools.karpenter.sh\""),
+	}, false)
+	pools, err := d.ListNodePools(context.Background())
+	if err != nil {
+		t.Errorf("missing-CRD should return (nil, nil), got err=%v", err)
+	}
+	if pools != nil {
+		t.Errorf("expected nil slice when Karpenter missing, got %v", pools)
+	}
+}
+
+func TestListNodePools_RealError(t *testing.T) {
+	// Permission denied or similar real failure must propagate.
+	d := NewKarpenterDetector(&karpenterMock{
+		nodePoolsErr: errors.New("Error from server (Forbidden): nodepools.karpenter.sh is forbidden"),
+	}, false)
+	_, err := d.ListNodePools(context.Background())
+	if err == nil {
+		t.Error("real kubectl error must propagate")
+	}
+}
+
+const sampleClaimsJSON = `{
+  "items": [
+    {
+      "metadata": {
+        "name": "claim-abc",
+        "creationTimestamp": "2026-04-20T10:00:00Z",
+        "labels": {"karpenter.sh/nodepool": "default"}
+      },
+      "status": {
+        "capacity": {"cpu": "4", "memory": "16Gi"},
+        "nodeName": "ip-10-0-1-23.ec2.internal",
+        "providerID": "aws:///us-east-1a/i-0abc123def",
+        "conditions": [{"type": "Ready", "status": "True"}]
+      }
+    },
+    {
+      "metadata": {"name": "claim-pending", "labels": {"karpenter.sh/nodepool": "gpu"}},
+      "status": {
+        "providerID": "aws:///us-east-1a/i-pending",
+        "conditions": [{"type": "Ready", "status": "False"}, {"type": "Launched", "status": "True"}]
+      }
+    }
+  ]
+}`
+
+func TestListNodeClaims_ParsesAndDerivesStatus(t *testing.T) {
+	d := NewKarpenterDetector(&karpenterMock{nodeClaimsJSON: []byte(sampleClaimsJSON)}, false)
+
+	claims, err := d.ListNodeClaims(context.Background())
+	if err != nil {
+		t.Fatalf("ListNodeClaims: %v", err)
+	}
+	if len(claims) != 2 {
+		t.Fatalf("expected 2 NodeClaims, got %d", len(claims))
+	}
+
+	byName := map[string]NodeClaimSummary{}
+	for _, c := range claims {
+		byName[c.Name] = c
+	}
+
+	abc := byName["claim-abc"]
+	if abc.Status != "Ready" {
+		t.Errorf("claim-abc Status = %q, want Ready", abc.Status)
+	}
+	if abc.NodePool != "default" {
+		t.Errorf("claim-abc NodePool = %q, want default", abc.NodePool)
+	}
+	if abc.NodeName != "ip-10-0-1-23.ec2.internal" {
+		t.Errorf("claim-abc NodeName = %q", abc.NodeName)
+	}
+	if abc.InstanceID != "i-0abc123def" {
+		t.Errorf("claim-abc InstanceID = %q, want i-0abc123def", abc.InstanceID)
+	}
+	if abc.Capacity["cpu"] != "4" {
+		t.Errorf("claim-abc Capacity[cpu] = %q", abc.Capacity["cpu"])
+	}
+
+	pending := byName["claim-pending"]
+	if pending.Status != "Pending" {
+		t.Errorf("claim-pending Status = %q, want Pending (Ready=False even though Launched=True)", pending.Status)
+	}
+	if pending.InstanceID != "i-pending" {
+		t.Errorf("claim-pending InstanceID = %q", pending.InstanceID)
+	}
+}
+
+func TestProviderInstanceID(t *testing.T) {
+	cases := map[string]string{
+		"aws:///us-east-1a/i-0abc123def": "i-0abc123def",
+		"i-bare":                         "i-bare",
+		"":                               "",
+		"gce://project/zone/instance":    "instance",
+	}
+	for in, want := range cases {
+		if got := providerInstanceID(in); got != want {
+			t.Errorf("providerInstanceID(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestHumanAge(t *testing.T) {
+	cases := []struct {
+		in  string
+		out string
+	}{
+		{"30s", "30s"},
+		{"5m", "5m"},
+		{"3h", "3h"},
+		{"50h", "2d"},
+		{"-1m", "0s"},
+	}
+	for _, c := range cases {
+		d, err := time.ParseDuration(c.in)
+		if err != nil {
+			t.Fatalf("parse %q: %v", c.in, err)
+		}
+		if got := humanAge(d); got != c.out {
+			t.Errorf("humanAge(%v) = %q, want %q", d, got, c.out)
+		}
+	}
+}
+
+func TestIsMissingResource(t *testing.T) {
+	cases := map[string]bool{
+		"the server doesn't have a resource type \"nodepools.karpenter.sh\"": true,
+		"no resources found in default namespace":                            true,
+		"no matches for kind \"NodePool\" in version \"karpenter.sh/v1\"":    true,
+		"Error from server (Forbidden)":                                      false,
+		"connection refused":                                                 false,
+		"":                                                                   false,
+	}
+	for msg, want := range cases {
+		var err error
+		if msg != "" {
+			err = errors.New(msg)
+		}
+		if got := isMissingResource(err); got != want {
+			t.Errorf("isMissingResource(%q) = %v, want %v", msg, got, want)
+		}
+	}
+}

--- a/internal/k8s/sre/karpenter_test.go
+++ b/internal/k8s/sre/karpenter_test.go
@@ -283,12 +283,19 @@ func TestHumanAge(t *testing.T) {
 
 func TestIsMissingResource(t *testing.T) {
 	cases := map[string]bool{
+		// Genuine "CRD not installed" signals from kubectl
 		"the server doesn't have a resource type \"nodepools.karpenter.sh\"": true,
-		"no resources found in default namespace":                            true,
 		"no matches for kind \"NodePool\" in version \"karpenter.sh/v1\"":    true,
-		"Error from server (Forbidden)":                                      false,
-		"connection refused":                                                 false,
-		"":                                                                   false,
+
+		// Real failures must NOT be classified as missing
+		"Error from server (Forbidden)": false,
+		"connection refused":            false,
+		"":                              false,
+
+		// Regression: "no resources found" used to match this predicate,
+		// which mis-classified an empty-but-installed Karpenter cluster as
+		// "not installed". Must NOT match.
+		"no resources found in default namespace": false,
 	}
 	for msg, want := range cases {
 		var err error
@@ -298,5 +305,33 @@ func TestIsMissingResource(t *testing.T) {
 		if got := isMissingResource(err); got != want {
 			t.Errorf("isMissingResource(%q) = %v, want %v", msg, got, want)
 		}
+	}
+}
+
+// Regression: an empty-but-installed Karpenter cluster used to surface as
+// "not installed" because the "no resources found" string was mis-handled.
+// This test exercises the integration: the mock returns an empty items list
+// (not an error), so ListNodePools should yield an empty slice, NOT nil.
+func TestListNodePools_EmptyButInstalledCluster(t *testing.T) {
+	d := NewKarpenterDetector(&karpenterMock{
+		nodePoolsJSON: []byte(`{"items": []}`),
+	}, false)
+	pools, err := d.ListNodePools(context.Background())
+	if err != nil {
+		t.Fatalf("empty list should not error: %v", err)
+	}
+	if pools == nil {
+		t.Fatal("empty installed cluster should return empty slice, not nil")
+	}
+	if len(pools) != 0 {
+		t.Errorf("expected 0 pools for empty cluster, got %d", len(pools))
+	}
+}
+
+func TestHumanAge_BoundaryAt24h(t *testing.T) {
+	// Exactly 24h must render as 1d, not 24h, to match `kubectl get`.
+	got := humanAge(24 * time.Hour)
+	if got != "1d" {
+		t.Errorf("humanAge(24h) = %q, want \"1d\"", got)
 	}
 }

--- a/internal/resourcedb/store.go
+++ b/internal/resourcedb/store.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
 	"sync"
 	"time"
 )
@@ -188,9 +189,14 @@ func (s *Store) ListRuns(limit int) ([]RunSummary, error) {
 		var r RunSummary
 		var createdAt string
 		if err := rows.Scan(&r.RunID, &r.Provider, &r.Region, &r.Profile, &r.ResourceCount, &createdAt); err != nil {
+			log.Printf("[resourcedb] skipping run row: scan failed: %v", err)
 			continue
 		}
-		r.CreatedAt, _ = time.Parse(time.RFC3339, createdAt)
+		if t, err := time.Parse(time.RFC3339, createdAt); err == nil {
+			r.CreatedAt = t
+		} else {
+			log.Printf("[resourcedb] run %s: unparseable created_at %q: %v", r.RunID, createdAt, err)
+		}
 		runs = append(runs, r)
 	}
 
@@ -213,6 +219,7 @@ func scanResources(rows *sql.Rows) ([]*Resource, error) {
 	for rows.Next() {
 		r, err := scanResourceRow(rows)
 		if err != nil {
+			log.Printf("[resourcedb] skipping resource row: %v", err)
 			continue
 		}
 		resources = append(resources, r)
@@ -240,21 +247,7 @@ func scanResource(row *sql.Row) (*Resource, error) {
 		r.ParentRunID = parentRunID.String
 	}
 
-	if metadataJSON.Valid {
-		_ = json.Unmarshal([]byte(metadataJSON.String), &r.Metadata)
-	}
-	if r.Metadata == nil {
-		r.Metadata = make(map[string]string)
-	}
-
-	if tagsJSON.Valid {
-		_ = json.Unmarshal([]byte(tagsJSON.String), &r.Tags)
-	}
-	if r.Tags == nil {
-		r.Tags = make(map[string]string)
-	}
-
-	r.CreatedAt, _ = time.Parse(time.RFC3339, createdAt)
+	hydrateResource(r, metadataJSON, tagsJSON, createdAt)
 
 	return r, nil
 }
@@ -279,23 +272,37 @@ func scanResourceRow(rows *sql.Rows) (*Resource, error) {
 		r.ParentRunID = parentRunID.String
 	}
 
+	hydrateResource(r, metadataJSON, tagsJSON, createdAt)
+
+	return r, nil
+}
+
+// hydrateResource populates JSON-encoded and time-encoded fields on a resource,
+// logging (rather than discarding) parse errors so corrupt rows are visible.
+func hydrateResource(r *Resource, metadataJSON, tagsJSON sql.NullString, createdAt string) {
 	if metadataJSON.Valid {
-		_ = json.Unmarshal([]byte(metadataJSON.String), &r.Metadata)
+		if err := json.Unmarshal([]byte(metadataJSON.String), &r.Metadata); err != nil {
+			log.Printf("[resourcedb] resource %d: malformed metadata JSON: %v", r.ID, err)
+		}
 	}
 	if r.Metadata == nil {
 		r.Metadata = make(map[string]string)
 	}
 
 	if tagsJSON.Valid {
-		_ = json.Unmarshal([]byte(tagsJSON.String), &r.Tags)
+		if err := json.Unmarshal([]byte(tagsJSON.String), &r.Tags); err != nil {
+			log.Printf("[resourcedb] resource %d: malformed tags JSON: %v", r.ID, err)
+		}
 	}
 	if r.Tags == nil {
 		r.Tags = make(map[string]string)
 	}
 
-	r.CreatedAt, _ = time.Parse(time.RFC3339, createdAt)
-
-	return r, nil
+	if t, err := time.Parse(time.RFC3339, createdAt); err == nil {
+		r.CreatedAt = t
+	} else {
+		log.Printf("[resourcedb] resource %d: unparseable created_at %q: %v", r.ID, createdAt, err)
+	}
 }
 
 // Vacuum compacts the database

--- a/internal/resourcedb/store_test.go
+++ b/internal/resourcedb/store_test.go
@@ -1,9 +1,13 @@
 package resourcedb
 
 import (
+	"bytes"
+	"database/sql"
+	"log"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestResourceExtraction(t *testing.T) {
@@ -188,6 +192,50 @@ func TestIsCreationOperation(t *testing.T) {
 		if IsCreationOperation(tt.service, tt.op) != tt.expected {
 			t.Errorf("IsCreationOperation(%s, %s) = %v, expected %v", tt.service, tt.op, !tt.expected, tt.expected)
 		}
+	}
+}
+
+func TestHydrateResource_LogsMalformedJSON(t *testing.T) {
+	var buf bytes.Buffer
+	prev := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(prev)
+
+	r := &Resource{ID: 42}
+	hydrateResource(r,
+		sql.NullString{String: "{not json", Valid: true},
+		sql.NullString{String: `{"k":"v"}`, Valid: true},
+		"2024-06-01T12:00:00Z",
+	)
+
+	if got := buf.String(); !bytes.Contains([]byte(got), []byte("malformed metadata JSON")) {
+		t.Errorf("expected malformed-metadata log, got %q", got)
+	}
+	if r.Metadata == nil {
+		t.Error("metadata map should be initialized even on parse failure")
+	}
+	if r.Tags["k"] != "v" {
+		t.Errorf("tags should still hydrate from valid JSON; got %#v", r.Tags)
+	}
+	if r.CreatedAt.IsZero() {
+		t.Error("CreatedAt should parse from valid RFC3339")
+	}
+}
+
+func TestHydrateResource_LogsBadTimestamp(t *testing.T) {
+	var buf bytes.Buffer
+	prev := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(prev)
+
+	r := &Resource{ID: 7}
+	hydrateResource(r, sql.NullString{}, sql.NullString{}, "definitely-not-a-time")
+
+	if !r.CreatedAt.Equal(time.Time{}) {
+		t.Errorf("CreatedAt should remain zero on parse failure; got %v", r.CreatedAt)
+	}
+	if got := buf.String(); !bytes.Contains([]byte(got), []byte("unparseable created_at")) {
+		t.Errorf("expected unparseable-timestamp log, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Phase 1 cost & k8s gap-fill + Phase 2 K8s analysis surface, all on the same branch. Each commit closes one tracked item.

### Phase 1
- B5 / B6 / C1 / C12 / K6 — see prior commits

### Phase 1 self-audit + reviewer fixes
- UnsupportedNum miscount, dead inner sort, namespace shadow, NewNetworkingAdapter interface, printer io.Writer
- aggregator + formatter test coverage, fixed false-positive networkpolicy mock

### Phase 2 (this push)
- **K11 — `clanker k8s health`**: Wraps existing `sre.HealthChecker` to surface CrashLoopBackOff, OOMKilled, restart-rate spikes, NotReady nodes per-resource. New `--severity` floor (info/warning/critical, fail-open on typo). Table + JSON. Read-only.
- **K1 — `clanker k8s karpenter list`**: New `KarpenterDetector` in `internal/k8s/sre`. Probes the karpenter.sh API group via `kubectl api-resources`, then lists NodePools (name, NodeClass, weight, disruption, age) and NodeClaims (status, owning NodePool, instance ID extracted from providerID, plus a not-Ready count). When CRDs aren't present, returns "not installed" cleanly. Distinguishes CRD-missing from real RBAC errors.
- **K2 — `clanker k8s autoscaler analyze`**: New `AutoscalerAnalyzer`. Detects which autoscaler is running (CA / Karpenter / both / none — coexistence flagged), then walks kube-system events in one pass and classifies by Reason: FailedScheduling, NotTriggerScaleUp, TriggeredScaleUp, ScaleDown[Empty|Unneeded], NodeNotReady. Output includes top-5 pods stuck waiting for capacity and top-5 hot node reasons. `--lookback` window (default 1h, 0 → 1h). Read-only.

## Test plan
- [x] `make ci` green (lint + vet + test-short + build)
- [x] All Phase 2 packages have new unit tests (33 new tests across health, karpenter, autoscaler analyzers + cmd printers)
- [x] Smoke: each new subcommand runs against bogus kubeconfig, degrades cleanly, surfaces sensible error messages
- [x] No mutations from any new path — only kubectl get/describe/api-resources

## Out of scope (Phase 3)
RI/Savings recs, multi-account AWS, GCP/Azure cost ingestion, Helm browser, pod exec/port-forward, K8s cost attribution module, kubeadm HA, K3s provider.