### PR TITLE
feat(k8s): Phase 3 — autoscaler validate + storage audit + Phase 2 review fixes

### DIFF
--- a/cmd/k8s_autoscaler.go
+++ b/cmd/k8s_autoscaler.go
@@ -138,6 +138,13 @@ func printAutoscalerReport(out io.Writer, report *sre.ScalingWasteReport) {
 		tw.Flush()
 	}
 
+	if len(report.HotPodReasons) > 0 {
+		fmt.Fprintln(out, "\nHot pod reasons (why pods couldn't fit):")
+		for _, r := range report.HotPodReasons {
+			fmt.Fprintf(out, "  %s × %d   %s\n", r.Reason, r.Count, truncate(r.SampleMessage, 80))
+		}
+	}
+
 	if len(report.HotNodeReasons) > 0 {
 		fmt.Fprintln(out, "\nHot node reasons:")
 		for _, r := range report.HotNodeReasons {

--- a/cmd/k8s_hpa_validate.go
+++ b/cmd/k8s_hpa_validate.go
@@ -1,0 +1,147 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/bgdnvk/clanker/internal/k8s"
+	"github.com/bgdnvk/clanker/internal/k8s/sre"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	hpaValidateOutput     string
+	hpaValidateKubeconfig string
+	hpaValidateContext    string
+	hpaValidateSeverity   string
+)
+
+var k8sAutoscalerValidateCmd = &cobra.Command{
+	Use:   "validate",
+	Short: "Lint HorizontalPodAutoscalers + KEDA ScaledObjects for config smells",
+	Long: `Inspect every HPA and KEDA ScaledObject in the cluster and surface
+configuration issues that would otherwise show up only at scale-out time:
+
+  • minReplicas absent / minReplicas > maxReplicas / minReplicas == maxReplicas
+  • metrics block missing or malformed
+  • scaleTargetRef.name empty
+  • KEDA: idleReplicaCount >= minReplicaCount, missing trigger types,
+    aggressively-low polling intervals
+
+Read-only — no kubectl mutations.
+
+Examples:
+  clanker k8s autoscaler validate
+  clanker k8s autoscaler validate --severity warning
+  clanker k8s autoscaler validate -o json`,
+	RunE: runHPAValidate,
+}
+
+func init() {
+	k8sAutoscalerCmd.AddCommand(k8sAutoscalerValidateCmd)
+	k8sAutoscalerValidateCmd.Flags().StringVarP(&hpaValidateOutput, "output", "o", "table", "Output format (table, json)")
+	k8sAutoscalerValidateCmd.Flags().StringVar(&hpaValidateKubeconfig, "kubeconfig", "", "Path to kubeconfig (default: ~/.kube/config)")
+	k8sAutoscalerValidateCmd.Flags().StringVar(&hpaValidateContext, "context", "", "kubectl context to use")
+	k8sAutoscalerValidateCmd.Flags().StringVar(&hpaValidateSeverity, "severity", "", "Minimum severity to surface (info, warning, critical) — default shows all")
+}
+
+func runHPAValidate(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	debug := viper.GetBool("debug")
+
+	client := k8s.NewClient(hpaValidateKubeconfig, hpaValidateContext, debug)
+	validator := sre.NewHPAValidator(k8s.NewSREAdapter(client), debug)
+
+	report, err := validator.Validate(ctx)
+	if err != nil {
+		return fmt.Errorf("validation failed: %w", err)
+	}
+
+	report.Findings = filterHPAFindingsBySeverity(report.Findings, hpaValidateSeverity)
+
+	switch strings.ToLower(hpaValidateOutput) {
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	default:
+		printHPAValidationReport(os.Stdout, report)
+		return nil
+	}
+}
+
+func filterHPAFindingsBySeverity(findings []sre.HPAFinding, floor string) []sre.HPAFinding {
+	floor = strings.ToLower(strings.TrimSpace(floor))
+	if floor == "" {
+		return findings
+	}
+	rank := map[string]int{"info": 0, "warning": 1, "critical": 2}
+	cut, ok := rank[floor]
+	if !ok {
+		return findings
+	}
+	out := make([]sre.HPAFinding, 0, len(findings))
+	for _, f := range findings {
+		if rank[strings.ToLower(string(f.Severity))] >= cut {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+func printHPAValidationReport(out io.Writer, report *sre.HPAValidationReport) {
+	if report == nil {
+		fmt.Fprintln(out, "No validation report.")
+		return
+	}
+
+	keda := "not detected"
+	if report.KEDAInstalled {
+		keda = "detected"
+	}
+	fmt.Fprintf(out, "Scanned %d HPA(s) + %d KEDA ScaledObject(s)   KEDA: %s\n\n",
+		report.HPAsScanned, report.ScaledObjectsScanned, keda)
+
+	if len(report.Findings) == 0 {
+		fmt.Fprintln(out, "No configuration issues detected. ✓")
+		return
+	}
+
+	// Sort critical → warning → info, then by resource for stable output.
+	sort.SliceStable(report.Findings, func(i, j int) bool {
+		ri := severityRank(report.Findings[i].Severity)
+		rj := severityRank(report.Findings[j].Severity)
+		if ri != rj {
+			return ri > rj
+		}
+		if report.Findings[i].Namespace != report.Findings[j].Namespace {
+			return report.Findings[i].Namespace < report.Findings[j].Namespace
+		}
+		return report.Findings[i].Name < report.Findings[j].Name
+	})
+
+	fmt.Fprintf(out, "%d issue(s):\n", len(report.Findings))
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "SEVERITY\tKIND\tNAMESPACE/NAME\tISSUE")
+	fmt.Fprintln(w, "--------\t----\t--------------\t-----")
+	for _, f := range report.Findings {
+		ns := f.Namespace
+		if ns == "" {
+			ns = "-"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s/%s\t%s\n",
+			strings.ToUpper(string(f.Severity)),
+			f.Resource,
+			ns, f.Name,
+			truncate(f.Issue, 70),
+		)
+	}
+	w.Flush()
+}

--- a/cmd/k8s_hpa_validate.go
+++ b/cmd/k8s_hpa_validate.go
@@ -16,12 +16,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var (
-	hpaValidateOutput     string
-	hpaValidateKubeconfig string
-	hpaValidateContext    string
-	hpaValidateSeverity   string
-)
+var hpaValidateSeverity string
 
 var k8sAutoscalerValidateCmd = &cobra.Command{
 	Use:   "validate",
@@ -46,9 +41,8 @@ Examples:
 
 func init() {
 	k8sAutoscalerCmd.AddCommand(k8sAutoscalerValidateCmd)
-	k8sAutoscalerValidateCmd.Flags().StringVarP(&hpaValidateOutput, "output", "o", "table", "Output format (table, json)")
-	k8sAutoscalerValidateCmd.Flags().StringVar(&hpaValidateKubeconfig, "kubeconfig", "", "Path to kubeconfig (default: ~/.kube/config)")
-	k8sAutoscalerValidateCmd.Flags().StringVar(&hpaValidateContext, "context", "", "kubectl context to use")
+	// --output / --kubeconfig / --context come from k8sAutoscalerCmd's
+	// PersistentFlags. Only --severity is local to validate.
 	k8sAutoscalerValidateCmd.Flags().StringVar(&hpaValidateSeverity, "severity", "", "Minimum severity to surface (info, warning, critical) — default shows all")
 }
 
@@ -56,7 +50,7 @@ func runHPAValidate(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 	debug := viper.GetBool("debug")
 
-	client := k8s.NewClient(hpaValidateKubeconfig, hpaValidateContext, debug)
+	client := k8s.NewClient(autoscalerKubeconfig, autoscalerContext, debug)
 	validator := sre.NewHPAValidator(k8s.NewSREAdapter(client), debug)
 
 	report, err := validator.Validate(ctx)
@@ -66,7 +60,7 @@ func runHPAValidate(cmd *cobra.Command, args []string) error {
 
 	report.Findings = filterHPAFindingsBySeverity(report.Findings, hpaValidateSeverity)
 
-	switch strings.ToLower(hpaValidateOutput) {
+	switch strings.ToLower(autoscalerOutput) {
 	case "json":
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")

--- a/cmd/k8s_hpa_validate_print_test.go
+++ b/cmd/k8s_hpa_validate_print_test.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/bgdnvk/clanker/internal/k8s/sre"
+)
+
+func TestPrintHPAValidationReport_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	printHPAValidationReport(&buf, &sre.HPAValidationReport{})
+	out := buf.String()
+	if !strings.Contains(out, "No configuration issues detected") {
+		t.Errorf("expected clean-bill message, got %q", out)
+	}
+}
+
+func TestPrintHPAValidationReport_Nil(t *testing.T) {
+	var buf bytes.Buffer
+	printHPAValidationReport(&buf, nil)
+	if !strings.Contains(buf.String(), "No validation report") {
+		t.Errorf("expected nil-report message, got %q", buf.String())
+	}
+}
+
+func TestPrintHPAValidationReport_KEDADetectionLine(t *testing.T) {
+	var buf bytes.Buffer
+	printHPAValidationReport(&buf, &sre.HPAValidationReport{
+		HPAsScanned: 3, ScaledObjectsScanned: 1, KEDAInstalled: true,
+	})
+	out := buf.String()
+	if !strings.Contains(out, "Scanned 3 HPA(s) + 1 KEDA ScaledObject(s)") {
+		t.Errorf("expected counts in header, got %q", out)
+	}
+	if !strings.Contains(out, "KEDA: detected") {
+		t.Errorf("expected 'KEDA: detected', got %q", out)
+	}
+}
+
+func TestPrintHPAValidationReport_FindingsSortedCriticalFirst(t *testing.T) {
+	var buf bytes.Buffer
+	printHPAValidationReport(&buf, &sre.HPAValidationReport{
+		HPAsScanned: 3,
+		Findings: []sre.HPAFinding{
+			{Severity: sre.SeverityWarning, Resource: "hpa", Namespace: "default", Name: "warn", Issue: "min == max"},
+			{Severity: sre.SeverityCritical, Resource: "hpa", Namespace: "prod", Name: "crit", Issue: "no metrics configured"},
+			{Severity: sre.SeverityInfo, Resource: "scaledobject", Namespace: "default", Name: "info", Issue: "fast polling"},
+		},
+	})
+	out := buf.String()
+
+	critIdx := strings.Index(out, "crit")
+	warnIdx := strings.Index(out, "warn")
+	infoIdx := strings.Index(out, "info")
+
+	if critIdx == -1 || warnIdx == -1 || infoIdx == -1 {
+		t.Fatalf("missing rows in output:\n%s", out)
+	}
+	if !(critIdx < warnIdx && warnIdx < infoIdx) {
+		t.Errorf("findings should sort critical → warning → info; got positions %d %d %d", critIdx, warnIdx, infoIdx)
+	}
+}
+
+func TestFilterHPAFindingsBySeverity(t *testing.T) {
+	all := []sre.HPAFinding{
+		{Severity: sre.SeverityCritical, Name: "c"},
+		{Severity: sre.SeverityWarning, Name: "w"},
+		{Severity: sre.SeverityInfo, Name: "i"},
+	}
+	cases := []struct {
+		floor string
+		want  []string
+	}{
+		{"", []string{"c", "w", "i"}},
+		{"info", []string{"c", "w", "i"}},
+		{"warning", []string{"c", "w"}},
+		{"WARNING", []string{"c", "w"}}, // case-insensitive
+		{"critical", []string{"c"}},
+		{"unknown", []string{"c", "w", "i"}}, // fail-open on typo
+	}
+	for _, tt := range cases {
+		got := filterHPAFindingsBySeverity(all, tt.floor)
+		var names []string
+		for _, f := range got {
+			names = append(names, f.Name)
+		}
+		if !equalSlices(names, tt.want) {
+			t.Errorf("floor=%q got %v, want %v", tt.floor, names, tt.want)
+		}
+	}
+}

--- a/cmd/k8s_storage_audit.go
+++ b/cmd/k8s_storage_audit.go
@@ -1,0 +1,116 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/bgdnvk/clanker/internal/k8s"
+	"github.com/bgdnvk/clanker/internal/k8s/storage"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	storageAuditOutput     string
+	storageAuditKubeconfig string
+	storageAuditContext    string
+)
+
+var k8sStorageCmd = &cobra.Command{
+	Use:   "storage",
+	Short: "Inspect Kubernetes storage posture",
+	Long:  `Inspect or audit PersistentVolume / PersistentVolumeClaim health and waste.`,
+}
+
+var k8sStorageAuditCmd = &cobra.Command{
+	Use:   "audit",
+	Short: "Detect orphaned, Released, and stuck PVCs/PVs",
+	Long: `Surface storage waste and configuration issues:
+
+  • PVCs stuck Pending (no PV bound — provisioner missing or wrong class)
+  • PVCs in Lost state (underlying PV deleted, data gone)
+  • PVCs Bound but not referenced by any pod (orphaned spend)
+  • PVs in Released state with Retain reclaim policy (manual cleanup needed)
+  • PVs in Available state never bound (verify intent)
+  • PVs in Failed state (provisioner unhealthy)
+
+Read-only — only kubectl get is invoked.
+
+Examples:
+  clanker k8s storage audit
+  clanker k8s storage audit -o json
+  clanker k8s storage audit --kubeconfig ~/.kube/prod`,
+	RunE: runStorageAudit,
+}
+
+func init() {
+	k8sCmd.AddCommand(k8sStorageCmd)
+	k8sStorageCmd.AddCommand(k8sStorageAuditCmd)
+
+	k8sStorageCmd.PersistentFlags().StringVarP(&storageAuditOutput, "output", "o", "table", "Output format (table, json)")
+	k8sStorageCmd.PersistentFlags().StringVar(&storageAuditKubeconfig, "kubeconfig", "", "Path to kubeconfig (default: ~/.kube/config)")
+	k8sStorageCmd.PersistentFlags().StringVar(&storageAuditContext, "context", "", "kubectl context to use")
+}
+
+func runStorageAudit(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	debug := viper.GetBool("debug")
+
+	client := k8s.NewClient(storageAuditKubeconfig, storageAuditContext, debug)
+	auditor := storage.NewAuditor(k8s.NewStorageAdapter(client), debug)
+
+	report, err := auditor.Audit(ctx)
+	if err != nil {
+		return fmt.Errorf("storage audit failed: %w", err)
+	}
+
+	switch strings.ToLower(storageAuditOutput) {
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	default:
+		printStorageAuditReport(os.Stdout, report)
+		return nil
+	}
+}
+
+func printStorageAuditReport(out io.Writer, report *storage.AuditReport) {
+	if report == nil {
+		fmt.Fprintln(out, "No audit report.")
+		return
+	}
+
+	fmt.Fprintf(out, "Scanned %d PV(s), %d PVC(s), %d pod(s)\n", report.PVsScanned, report.PVCsScanned, report.PodsScanned)
+	fmt.Fprintf(out, "Waste signals: %d orphaned PVC(s), %d Pending PVC(s), %d unbound PV(s)\n\n",
+		report.OrphanedPVCs, report.PendingPVCs, report.OrphanedPVs)
+
+	if len(report.Findings) == 0 {
+		fmt.Fprintln(out, "No storage issues detected. ✓")
+		return
+	}
+
+	fmt.Fprintf(out, "%d finding(s):\n", len(report.Findings))
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "KIND\tNAMESPACE/NAME\tCAPACITY\tISSUE")
+	fmt.Fprintln(w, "----\t--------------\t--------\t-----")
+	for _, f := range report.Findings {
+		ns := f.Namespace
+		if ns == "" {
+			ns = "-"
+		}
+		cap := f.Capacity
+		if cap == "" {
+			cap = "-"
+		}
+		fmt.Fprintf(w, "%s\t%s/%s\t%s\t%s\n",
+			strings.ToUpper(f.Kind), ns, f.Name, cap, truncate(f.Issue, 60),
+		)
+	}
+	w.Flush()
+}

--- a/cmd/k8s_storage_audit.go
+++ b/cmd/k8s_storage_audit.go
@@ -87,8 +87,12 @@ func printStorageAuditReport(out io.Writer, report *storage.AuditReport) {
 	}
 
 	fmt.Fprintf(out, "Scanned %d PV(s), %d PVC(s), %d pod(s)\n", report.PVsScanned, report.PVCsScanned, report.PodsScanned)
-	fmt.Fprintf(out, "Waste signals: %d orphaned PVC(s), %d Pending PVC(s), %d unbound PV(s)\n\n",
-		report.OrphanedPVCs, report.PendingPVCs, report.OrphanedPVs)
+	fmt.Fprintf(out, "Waste signals: %d orphaned PVC(s), %d Pending PVC(s), %d unused PV(s)\n",
+		report.OrphanedPVCs, report.PendingPVCs, report.UnusedPVs)
+	if report.Notes != "" {
+		fmt.Fprintf(out, "Notes: %s\n", report.Notes)
+	}
+	fmt.Fprintln(out)
 
 	if len(report.Findings) == 0 {
 		fmt.Fprintln(out, "No storage issues detected. ✓")

--- a/cmd/k8s_storage_audit_print_test.go
+++ b/cmd/k8s_storage_audit_print_test.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/bgdnvk/clanker/internal/k8s/storage"
+)
+
+func TestPrintStorageAuditReport_Nil(t *testing.T) {
+	var buf bytes.Buffer
+	printStorageAuditReport(&buf, nil)
+	if !strings.Contains(buf.String(), "No audit report") {
+		t.Errorf("expected nil-report message, got %q", buf.String())
+	}
+}
+
+func TestPrintStorageAuditReport_Clean(t *testing.T) {
+	var buf bytes.Buffer
+	printStorageAuditReport(&buf, &storage.AuditReport{
+		PVsScanned: 5, PVCsScanned: 3, PodsScanned: 12,
+	})
+	out := buf.String()
+	if !strings.Contains(out, "Scanned 5 PV(s), 3 PVC(s), 12 pod(s)") {
+		t.Errorf("expected scan summary in header, got %q", out)
+	}
+	if !strings.Contains(out, "No storage issues detected") {
+		t.Errorf("expected clean-bill message, got %q", out)
+	}
+}
+
+func TestPrintStorageAuditReport_RendersFindings(t *testing.T) {
+	var buf bytes.Buffer
+	printStorageAuditReport(&buf, &storage.AuditReport{
+		PVsScanned: 1, PVCsScanned: 2, PodsScanned: 4,
+		OrphanedPVCs: 1, PendingPVCs: 1, OrphanedPVs: 1,
+		Findings: []storage.AuditFinding{
+			{Kind: "pv", Name: "pv-released", Issue: "PV Released and not reclaimed", Capacity: "20Gi"},
+			{Kind: "pvc", Namespace: "prod", Name: "orphan", Issue: "PVC not referenced by any pod", Capacity: "10Gi"},
+			{Kind: "pvc", Namespace: "default", Name: "stuck", Issue: "PVC stuck Pending", Capacity: "5Gi"},
+		},
+	})
+	out := buf.String()
+
+	for _, want := range []string{
+		"3 finding(s)",
+		"KIND",
+		"NAMESPACE/NAME",
+		"CAPACITY",
+		"-/pv-released",
+		"prod/orphan",
+		"default/stuck",
+		"PVC stuck Pending",
+		"20Gi",
+		"5Gi",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintStorageAuditReport_DashesForEmptyFields(t *testing.T) {
+	var buf bytes.Buffer
+	printStorageAuditReport(&buf, &storage.AuditReport{
+		Findings: []storage.AuditFinding{
+			{Kind: "pv", Name: "pv-no-cap", Issue: "PV Failed"},
+		},
+	})
+	out := buf.String()
+	// PVs have no namespace and we render "-" as namespace placeholder.
+	if !strings.Contains(out, "-/pv-no-cap") {
+		t.Errorf("expected '-/pv-no-cap' for PV without namespace, got:\n%s", out)
+	}
+}

--- a/cmd/k8s_storage_audit_print_test.go
+++ b/cmd/k8s_storage_audit_print_test.go
@@ -34,7 +34,7 @@ func TestPrintStorageAuditReport_RendersFindings(t *testing.T) {
 	var buf bytes.Buffer
 	printStorageAuditReport(&buf, &storage.AuditReport{
 		PVsScanned: 1, PVCsScanned: 2, PodsScanned: 4,
-		OrphanedPVCs: 1, PendingPVCs: 1, OrphanedPVs: 1,
+		OrphanedPVCs: 1, PendingPVCs: 1, UnusedPVs: 1,
 		Findings: []storage.AuditFinding{
 			{Kind: "pv", Name: "pv-released", Issue: "PV Released and not reclaimed", Capacity: "20Gi"},
 			{Kind: "pvc", Namespace: "prod", Name: "orphan", Issue: "PVC not referenced by any pod", Capacity: "10Gi"},

--- a/internal/k8s/agent_adapters.go
+++ b/internal/k8s/agent_adapters.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/bgdnvk/clanker/internal/k8s/networking"
 	"github.com/bgdnvk/clanker/internal/k8s/sre"
+	"github.com/bgdnvk/clanker/internal/k8s/storage"
 	"github.com/bgdnvk/clanker/internal/k8s/workloads"
 )
 
@@ -86,6 +87,13 @@ func (a *networkingClientAdapter) Delete(ctx context.Context, resourceType, name
 func (a *networkingClientAdapter) Apply(ctx context.Context, manifest string) (string, error) {
 	// Pass empty namespace - kubectl will use the namespace from the manifest
 	return a.client.Apply(ctx, manifest, "")
+}
+
+// NewStorageAdapter returns a storage.K8sClient backed by the given kubectl
+// Client. Exposed so callers outside this package (cmd/) can build storage
+// auditors without poking at the unexported adapter type.
+func NewStorageAdapter(client *Client) storage.K8sClient {
+	return &storageClientAdapter{client: client}
 }
 
 // storageClientAdapter wraps Client to implement storage.K8sClient interface

--- a/internal/k8s/sre/autoscaler.go
+++ b/internal/k8s/sre/autoscaler.go
@@ -185,7 +185,24 @@ func (a *AutoscalerAnalyzer) AnalyzeScalingWaste(ctx context.Context, lookback t
 		lookback = time.Hour
 	}
 
-	inv, _ := a.DetectAutoscaler(ctx)
+	inv, detectErr := a.DetectAutoscaler(ctx)
+	if inv == nil {
+		// Belt-and-braces: DetectAutoscaler currently always returns a
+		// non-nil pointer, but a future signature change shouldn't crash
+		// the analyzer with a nil deref on the next line.
+		inv = &AutoscalerInventory{Type: AutoscalerNone}
+	}
+	if detectErr != nil {
+		// DetectAutoscaler may carry meaningful diagnostic notes (karpenter
+		// probe failure, kube-system unreachable). Surface them on the
+		// report so users see why detection went sideways instead of the
+		// inventory silently flipping to "no autoscaler".
+		if inv.Notes == "" {
+			inv.Notes = fmt.Sprintf("autoscaler detection failed: %v", detectErr)
+		} else {
+			inv.Notes += fmt.Sprintf("; autoscaler detection failed: %v", detectErr)
+		}
+	}
 
 	report := &ScalingWasteReport{
 		Inventory:      *inv,

--- a/internal/k8s/sre/autoscaler_test.go
+++ b/internal/k8s/sre/autoscaler_test.go
@@ -97,45 +97,56 @@ func TestDetectAutoscaler_Both_PrefersKarpenter(t *testing.T) {
 	}
 }
 
-const sampleEventsJSON = `{
+// sampleEventsJSON renders a fixture whose timestamps are relative to
+// time.Now() so the test stays correct as wall-clock advances. The previous
+// hardcoded 2026 fixture would silently start failing in 2027 once the
+// "current" events fell outside a 365-day lookback.
+func sampleEventsJSON() string {
+	now := time.Now().UTC()
+	recent := now.Add(-30 * time.Minute).Format(time.RFC3339)
+	scaleUp := now.Add(-28 * time.Minute).Format(time.RFC3339)
+	scaleDown := now.Add(-15 * time.Minute).Format(time.RFC3339)
+	ancient := now.AddDate(-2, 0, 0).Format(time.RFC3339)
+	return `{
   "items": [
     {
       "type": "Warning", "reason": "FailedScheduling", "message": "0/3 nodes are available",
-      "count": 5, "firstTimestamp": "2026-04-27T10:00:00Z", "lastTimestamp": "2026-04-27T10:30:00Z",
+      "count": 5, "firstTimestamp": "` + recent + `", "lastTimestamp": "` + recent + `",
       "involvedObject": {"kind": "Pod", "name": "api-7d9", "namespace": "prod"}
     },
     {
       "type": "Normal", "reason": "TriggeredScaleUp", "message": "scaled up to 4 nodes",
-      "count": 1, "lastTimestamp": "2026-04-27T10:32:00Z",
+      "count": 1, "lastTimestamp": "` + scaleUp + `",
       "involvedObject": {"kind": "Node", "name": "ip-10-0-1-23"}
     },
     {
       "type": "Warning", "reason": "NotTriggerScaleUp", "message": "no pool can fit pod",
-      "count": 3, "lastTimestamp": "2026-04-27T10:25:00Z",
+      "count": 3, "lastTimestamp": "` + recent + `",
       "involvedObject": {"kind": "Pod", "name": "api-7d9", "namespace": "prod"}
     },
     {
       "type": "Normal", "reason": "ScaleDownEmpty", "message": "removed empty node",
-      "count": 1, "lastTimestamp": "2026-04-27T11:00:00Z",
+      "count": 1, "lastTimestamp": "` + scaleDown + `",
       "involvedObject": {"kind": "Node", "name": "ip-10-0-1-99"}
     },
     {
       "type": "Warning", "reason": "FailedScheduling", "message": "insufficient cpu",
-      "count": 2, "lastTimestamp": "2026-04-27T10:40:00Z",
+      "count": 2, "lastTimestamp": "` + recent + `",
       "involvedObject": {"kind": "Pod", "name": "worker-abc", "namespace": "default"}
     },
     {
       "type": "Warning", "reason": "FailedScheduling", "message": "ancient",
-      "count": 100, "lastTimestamp": "2025-01-01T00:00:00Z",
+      "count": 100, "lastTimestamp": "` + ancient + `",
       "involvedObject": {"kind": "Pod", "name": "ancient", "namespace": "default"}
     }
   ]
 }`
+}
 
 func TestAnalyzeScalingWaste_AggregatesAndWindows(t *testing.T) {
 	a := NewAutoscalerAnalyzer(&autoscalerMock{
 		caDeployJSON: `{"items": []}`,
-		eventsOutput: sampleEventsJSON,
+		eventsOutput: sampleEventsJSON(),
 	}, false)
 
 	// Use a wide lookback so the 2026 events are kept but the 2025-01-01
@@ -175,7 +186,7 @@ func TestAnalyzeScalingWaste_AggregatesAndWindows(t *testing.T) {
 func TestAnalyzeScalingWaste_ShortLookbackFiltersOldEvents(t *testing.T) {
 	a := NewAutoscalerAnalyzer(&autoscalerMock{
 		caDeployJSON: `{"items": []}`,
-		eventsOutput: sampleEventsJSON,
+		eventsOutput: sampleEventsJSON(),
 	}, false)
 
 	// 1ns lookback excludes everything except events with no timestamp.

--- a/internal/k8s/sre/autoscaler_test.go
+++ b/internal/k8s/sre/autoscaler_test.go
@@ -149,8 +149,8 @@ func TestAnalyzeScalingWaste_AggregatesAndWindows(t *testing.T) {
 		eventsOutput: sampleEventsJSON(),
 	}, false)
 
-	// Use a wide lookback so the 2026 events are kept but the 2025-01-01
-	// "ancient" event is filtered out (it's > a year old vs. now in 2026).
+	// Use a 365d lookback so the recent (now-relative) events are kept
+	// but the explicitly "ancient" event (2 years old) is filtered out.
 	report, err := a.AnalyzeScalingWaste(context.Background(), 365*24*time.Hour)
 	if err != nil {
 		t.Fatalf("AnalyzeScalingWaste: %v", err)

--- a/internal/k8s/sre/hpa_validator.go
+++ b/internal/k8s/sre/hpa_validator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 )
@@ -37,6 +38,7 @@ type HPAValidationReport struct {
 	HPAsScanned          int          `json:"hpasScanned"`
 	ScaledObjectsScanned int          `json:"scaledObjectsScanned"`
 	KEDAInstalled        bool         `json:"kedaInstalled"`
+	Notes                string       `json:"notes,omitempty"`
 	Findings             []HPAFinding `json:"findings,omitempty"`
 }
 
@@ -55,16 +57,24 @@ func (v *HPAValidator) Validate(ctx context.Context) (*HPAValidationReport, erro
 	}
 
 	keda, err := v.kedaInstalled(ctx)
-	if err == nil && keda {
+	if err != nil {
+		appendNote(&report.Notes, fmt.Sprintf("keda detection failed: %v", err))
+		if v.debug {
+			fmt.Fprintln(os.Stderr, "[hpa-validator] keda detection failed:", err)
+		}
+	} else if keda {
 		report.KEDAInstalled = true
 		sos, err := v.listScaledObjects(ctx)
-		if err == nil {
+		if err != nil {
+			appendNote(&report.Notes, fmt.Sprintf("keda detected but scaledobjects fetch failed: %v", err))
+			if v.debug {
+				fmt.Fprintln(os.Stderr, "[hpa-validator] keda detected but scaledobjects fetch failed:", err)
+			}
+		} else {
 			report.ScaledObjectsScanned = len(sos)
 			for _, s := range sos {
 				report.Findings = append(report.Findings, v.validateScaledObject(s)...)
 			}
-		} else if v.debug {
-			fmt.Println("[hpa-validator] keda detected but scaledobjects fetch failed:", err)
 		}
 	}
 
@@ -311,4 +321,18 @@ func (v *HPAValidator) validateScaledObject(s scaledObjectSpec) []HPAFinding {
 	}
 
 	return out
+}
+
+// appendNote concatenates a non-empty diagnostic note onto an accumulator
+// using "; " as the separator. Used so the report carries operator-visible
+// detection failures alongside its findings instead of dropping them.
+func appendNote(dst *string, note string) {
+	if note == "" {
+		return
+	}
+	if *dst == "" {
+		*dst = note
+		return
+	}
+	*dst += "; " + note
 }

--- a/internal/k8s/sre/hpa_validator.go
+++ b/internal/k8s/sre/hpa_validator.go
@@ -1,0 +1,314 @@
+package sre
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// HPAValidator inspects HorizontalPodAutoscalers and KEDA ScaledObjects for
+// configuration smells that surface as silent reliability issues at
+// scale-out time. Read-only.
+type HPAValidator struct {
+	client K8sClient
+	debug  bool
+}
+
+func NewHPAValidator(client K8sClient, debug bool) *HPAValidator {
+	return &HPAValidator{client: client, debug: debug}
+}
+
+// HPAFinding is one configuration issue on an HPA or KEDA ScaledObject.
+// Severity follows the same vocabulary as the rest of the sre package.
+type HPAFinding struct {
+	Severity  IssueSeverity `json:"severity"`
+	Resource  string        `json:"resource"` // "hpa" or "scaledobject"
+	Namespace string        `json:"namespace"`
+	Name      string        `json:"name"`
+	Issue     string        `json:"issue"`
+	Detail    string        `json:"detail,omitempty"`
+}
+
+// HPAValidationReport is the aggregate output.
+type HPAValidationReport struct {
+	GeneratedAt          time.Time    `json:"generatedAt"`
+	HPAsScanned          int          `json:"hpasScanned"`
+	ScaledObjectsScanned int          `json:"scaledObjectsScanned"`
+	KEDAInstalled        bool         `json:"kedaInstalled"`
+	Findings             []HPAFinding `json:"findings,omitempty"`
+}
+
+// Validate scans HPAs cluster-wide plus KEDA ScaledObjects (if KEDA's CRDs
+// are installed) and returns a report of configuration smells.
+func (v *HPAValidator) Validate(ctx context.Context) (*HPAValidationReport, error) {
+	report := &HPAValidationReport{GeneratedAt: time.Now().UTC()}
+
+	hpas, err := v.listHPAs(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list HPAs: %w", err)
+	}
+	report.HPAsScanned = len(hpas)
+	for _, h := range hpas {
+		report.Findings = append(report.Findings, v.validateHPA(h)...)
+	}
+
+	keda, err := v.kedaInstalled(ctx)
+	if err == nil && keda {
+		report.KEDAInstalled = true
+		sos, err := v.listScaledObjects(ctx)
+		if err == nil {
+			report.ScaledObjectsScanned = len(sos)
+			for _, s := range sos {
+				report.Findings = append(report.Findings, v.validateScaledObject(s)...)
+			}
+		} else if v.debug {
+			fmt.Println("[hpa-validator] keda detected but scaledobjects fetch failed:", err)
+		}
+	}
+
+	return report, nil
+}
+
+// hpaSpec is the subset of the HPA v2 schema the validator inspects.
+type hpaSpec struct {
+	Metadata struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	} `json:"metadata"`
+	Spec struct {
+		MinReplicas    *int `json:"minReplicas"`
+		MaxReplicas    int  `json:"maxReplicas"`
+		ScaleTargetRef struct {
+			Kind string `json:"kind"`
+			Name string `json:"name"`
+		} `json:"scaleTargetRef"`
+		Metrics []struct {
+			Type     string `json:"type"`
+			Resource *struct {
+				Name   string `json:"name"`
+				Target struct {
+					Type               string `json:"type"`
+					AverageUtilization *int   `json:"averageUtilization"`
+					AverageValue       string `json:"averageValue"`
+					Value              string `json:"value"`
+				} `json:"target"`
+			} `json:"resource,omitempty"`
+			ContainerResource *struct {
+				Name string `json:"name"`
+			} `json:"containerResource,omitempty"`
+			External *struct {
+				Metric struct {
+					Name string `json:"name"`
+				} `json:"metric"`
+			} `json:"external,omitempty"`
+		} `json:"metrics"`
+		Behavior *struct {
+			ScaleUp   *struct{} `json:"scaleUp,omitempty"`
+			ScaleDown *struct{} `json:"scaleDown,omitempty"`
+		} `json:"behavior,omitempty"`
+	} `json:"spec"`
+}
+
+func (v *HPAValidator) listHPAs(ctx context.Context) ([]hpaSpec, error) {
+	raw, err := v.client.RunJSON(ctx, "get", "hpa", "-A", "-o", "json")
+	if err != nil {
+		return nil, err
+	}
+	var list struct {
+		Items []hpaSpec `json:"items"`
+	}
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, fmt.Errorf("parse hpa list: %w", err)
+	}
+	return list.Items, nil
+}
+
+func (v *HPAValidator) validateHPA(h hpaSpec) []HPAFinding {
+	var out []HPAFinding
+	emit := func(sev IssueSeverity, issue, detail string) {
+		out = append(out, HPAFinding{
+			Severity:  sev,
+			Resource:  "hpa",
+			Namespace: h.Metadata.Namespace,
+			Name:      h.Metadata.Name,
+			Issue:     issue,
+			Detail:    detail,
+		})
+	}
+
+	// minReplicas absent → defaults to 1, which is usually fine but not
+	// what users assume on stateful workloads.
+	if h.Spec.MinReplicas == nil {
+		emit(SeverityInfo, "minReplicas not set",
+			"defaults to 1; set explicitly so the autoscaler floor is auditable")
+	} else {
+		min := *h.Spec.MinReplicas
+		if min < 1 {
+			emit(SeverityCritical, "minReplicas < 1",
+				fmt.Sprintf("minReplicas=%d permits scaling to zero — only valid with KEDA fronting", min))
+		}
+		if min > h.Spec.MaxReplicas {
+			emit(SeverityCritical, "minReplicas > maxReplicas",
+				fmt.Sprintf("min=%d > max=%d; HPA will permanently report errors", min, h.Spec.MaxReplicas))
+		}
+		if min == h.Spec.MaxReplicas && h.Spec.MaxReplicas > 0 {
+			emit(SeverityWarning, "min == max replicas",
+				"autoscaling has no headroom — the HPA is effectively a static replica count")
+		}
+	}
+
+	if h.Spec.MaxReplicas <= 0 {
+		emit(SeverityCritical, "maxReplicas not set",
+			"HPA cannot scale up; set maxReplicas explicitly")
+	}
+
+	if len(h.Spec.Metrics) == 0 {
+		emit(SeverityCritical, "no metrics configured",
+			"HPA must declare at least one metric to drive scaling decisions")
+	}
+
+	for i, m := range h.Spec.Metrics {
+		switch m.Type {
+		case "Resource", "ContainerResource":
+			if m.Resource == nil && m.ContainerResource == nil {
+				emit(SeverityWarning, fmt.Sprintf("metric[%d] type=%s with no spec", i, m.Type),
+					"resource block is required when type is Resource/ContainerResource")
+				continue
+			}
+			if m.Resource != nil {
+				targ := m.Resource.Target
+				if targ.Type == "Utilization" && targ.AverageUtilization == nil {
+					emit(SeverityWarning, fmt.Sprintf("metric[%d] %s utilisation with no target", i, m.Resource.Name),
+						"averageUtilization required when target.type is Utilization")
+				}
+				if targ.Type == "AverageValue" && strings.TrimSpace(targ.AverageValue) == "" {
+					emit(SeverityWarning, fmt.Sprintf("metric[%d] %s average-value with no target", i, m.Resource.Name),
+						"averageValue required when target.type is AverageValue")
+				}
+			}
+		case "External":
+			if m.External == nil || m.External.Metric.Name == "" {
+				emit(SeverityWarning, fmt.Sprintf("metric[%d] external metric without a name", i),
+					"external.metric.name required for external metric sources")
+			}
+		case "":
+			emit(SeverityWarning, fmt.Sprintf("metric[%d] type missing", i),
+				"each metric entry must specify a type (Resource / ContainerResource / External / Pods / Object)")
+		}
+	}
+
+	// Empty scaleTargetRef.Name = misconfigured.
+	if strings.TrimSpace(h.Spec.ScaleTargetRef.Name) == "" {
+		emit(SeverityCritical, "scaleTargetRef.name empty",
+			"HPA has no workload to scale")
+	}
+
+	return out
+}
+
+// scaledObjectSpec is the KEDA v1 subset we inspect.
+type scaledObjectSpec struct {
+	Metadata struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	} `json:"metadata"`
+	Spec struct {
+		ScaleTargetRef struct {
+			Name string `json:"name"`
+		} `json:"scaleTargetRef"`
+		MinReplicaCount  *int `json:"minReplicaCount"`
+		MaxReplicaCount  *int `json:"maxReplicaCount"`
+		IdleReplicaCount *int `json:"idleReplicaCount"`
+		PollingInterval  *int `json:"pollingInterval"`
+		CooldownPeriod   *int `json:"cooldownPeriod"`
+		Triggers         []struct {
+			Type     string            `json:"type"`
+			Metadata map[string]string `json:"metadata"`
+		} `json:"triggers"`
+	} `json:"spec"`
+}
+
+func (v *HPAValidator) kedaInstalled(ctx context.Context) (bool, error) {
+	out, err := v.client.Run(ctx, "api-resources", "--api-group=keda.sh", "-o", "name")
+	if err != nil {
+		return false, nil // treat as "not installed" — same convention as Karpenter detector.
+	}
+	return strings.Contains(out, "scaledobjects"), nil
+}
+
+func (v *HPAValidator) listScaledObjects(ctx context.Context) ([]scaledObjectSpec, error) {
+	raw, err := v.client.RunJSON(ctx, "get", "scaledobjects.keda.sh", "-A", "-o", "json")
+	if err != nil {
+		return nil, err
+	}
+	var list struct {
+		Items []scaledObjectSpec `json:"items"`
+	}
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, fmt.Errorf("parse scaledobjects: %w", err)
+	}
+	return list.Items, nil
+}
+
+func (v *HPAValidator) validateScaledObject(s scaledObjectSpec) []HPAFinding {
+	var out []HPAFinding
+	emit := func(sev IssueSeverity, issue, detail string) {
+		out = append(out, HPAFinding{
+			Severity:  sev,
+			Resource:  "scaledobject",
+			Namespace: s.Metadata.Namespace,
+			Name:      s.Metadata.Name,
+			Issue:     issue,
+			Detail:    detail,
+		})
+	}
+
+	if strings.TrimSpace(s.Spec.ScaleTargetRef.Name) == "" {
+		emit(SeverityCritical, "scaleTargetRef.name empty",
+			"ScaledObject has no workload to scale")
+	}
+
+	if len(s.Spec.Triggers) == 0 {
+		emit(SeverityCritical, "no triggers configured",
+			"ScaledObject must declare at least one trigger to drive scaling")
+	}
+	for i, t := range s.Spec.Triggers {
+		if strings.TrimSpace(t.Type) == "" {
+			emit(SeverityWarning, fmt.Sprintf("trigger[%d] type missing", i),
+				"every trigger must specify a type (e.g. cron, prometheus, kafka)")
+		}
+	}
+
+	if s.Spec.MinReplicaCount != nil && s.Spec.MaxReplicaCount != nil {
+		if *s.Spec.MinReplicaCount > *s.Spec.MaxReplicaCount {
+			emit(SeverityCritical, "min > max",
+				fmt.Sprintf("min=%d > max=%d; KEDA will permanently log validation errors",
+					*s.Spec.MinReplicaCount, *s.Spec.MaxReplicaCount))
+		}
+	}
+
+	// idleReplicaCount must be strictly less than minReplicaCount when both
+	// are set; else KEDA logs a continuous validation error.
+	if s.Spec.IdleReplicaCount != nil {
+		idle := *s.Spec.IdleReplicaCount
+		if idle < 0 {
+			emit(SeverityCritical, "idleReplicaCount < 0",
+				"idleReplicaCount must be 0 or a positive integer")
+		}
+		if s.Spec.MinReplicaCount != nil && idle >= *s.Spec.MinReplicaCount {
+			emit(SeverityWarning, "idleReplicaCount >= minReplicaCount",
+				fmt.Sprintf("idle=%d ≥ min=%d; KEDA requires idle < min for scale-to-idle to engage",
+					idle, *s.Spec.MinReplicaCount))
+		}
+	}
+
+	if s.Spec.PollingInterval != nil && *s.Spec.PollingInterval < 5 {
+		emit(SeverityInfo, "pollingInterval < 5s",
+			fmt.Sprintf("polling=%ds is unusually aggressive — verify the trigger backend can keep up",
+				*s.Spec.PollingInterval))
+	}
+
+	return out
+}

--- a/internal/k8s/sre/hpa_validator_test.go
+++ b/internal/k8s/sre/hpa_validator_test.go
@@ -1,0 +1,281 @@
+package sre
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// hpaValidatorMock fans kubectl invocations to per-target responses.
+type hpaValidatorMock struct {
+	hpaList            string
+	hpaErr             error
+	apiResourcesOutput string
+	apiResourcesErr    error
+	scaledObjectsList  string
+	scaledObjectsErr   error
+}
+
+func (m *hpaValidatorMock) Run(_ context.Context, args ...string) (string, error) {
+	full := strings.Join(args, " ")
+	if strings.Contains(full, "api-resources") {
+		return m.apiResourcesOutput, m.apiResourcesErr
+	}
+	return "", nil
+}
+func (m *hpaValidatorMock) RunWithNamespace(_ context.Context, _ string, _ ...string) (string, error) {
+	return "", nil
+}
+func (m *hpaValidatorMock) RunJSON(_ context.Context, args ...string) ([]byte, error) {
+	full := strings.Join(args, " ")
+	switch {
+	case strings.Contains(full, "scaledobjects.keda.sh"):
+		return []byte(m.scaledObjectsList), m.scaledObjectsErr
+	case strings.Contains(full, "get hpa"):
+		return []byte(m.hpaList), m.hpaErr
+	}
+	return []byte(`{"items": []}`), nil
+}
+
+func TestValidate_HappyHPA(t *testing.T) {
+	v := NewHPAValidator(&hpaValidatorMock{
+		hpaList: `{
+		  "items": [{
+		    "metadata": {"name": "good", "namespace": "prod"},
+		    "spec": {
+		      "minReplicas": 2, "maxReplicas": 10,
+		      "scaleTargetRef": {"kind": "Deployment", "name": "api"},
+		      "metrics": [
+		        {"type": "Resource", "resource": {"name": "cpu", "target": {"type": "Utilization", "averageUtilization": 60}}}
+		      ]
+		    }
+		  }]
+		}`,
+	}, false)
+
+	report, err := v.Validate(context.Background())
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if report.HPAsScanned != 1 {
+		t.Errorf("HPAsScanned = %d, want 1", report.HPAsScanned)
+	}
+	if len(report.Findings) != 0 {
+		t.Errorf("expected 0 findings, got %+v", report.Findings)
+	}
+}
+
+func TestValidate_HPAFlagsMisconfig(t *testing.T) {
+	v := NewHPAValidator(&hpaValidatorMock{
+		hpaList: `{
+		  "items": [{
+		    "metadata": {"name": "broken", "namespace": "default"},
+		    "spec": {
+		      "minReplicas": 5, "maxReplicas": 3,
+		      "scaleTargetRef": {"kind": "Deployment", "name": ""},
+		      "metrics": []
+		    }
+		  }]
+		}`,
+	}, false)
+
+	report, err := v.Validate(context.Background())
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	issues := map[string]bool{}
+	for _, f := range report.Findings {
+		issues[f.Issue] = true
+	}
+
+	for _, want := range []string{"minReplicas > maxReplicas", "scaleTargetRef.name empty", "no metrics configured"} {
+		if !issues[want] {
+			t.Errorf("expected issue %q in findings %+v", want, report.Findings)
+		}
+	}
+}
+
+func TestValidate_HPAMinEqualsMaxIsWarning(t *testing.T) {
+	v := NewHPAValidator(&hpaValidatorMock{
+		hpaList: `{
+		  "items": [{
+		    "metadata": {"name": "static", "namespace": "default"},
+		    "spec": {
+		      "minReplicas": 5, "maxReplicas": 5,
+		      "scaleTargetRef": {"kind": "Deployment", "name": "x"},
+		      "metrics": [{"type": "Resource", "resource": {"name": "cpu", "target": {"type": "Utilization", "averageUtilization": 80}}}]
+		    }
+		  }]
+		}`,
+	}, false)
+	report, _ := v.Validate(context.Background())
+	found := false
+	for _, f := range report.Findings {
+		if f.Issue == "min == max replicas" && f.Severity == SeverityWarning {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected min==max warning, got %+v", report.Findings)
+	}
+}
+
+func TestValidate_HPAMissingMinReplicasIsInfo(t *testing.T) {
+	v := NewHPAValidator(&hpaValidatorMock{
+		hpaList: `{
+		  "items": [{
+		    "metadata": {"name": "implicit", "namespace": "default"},
+		    "spec": {
+		      "maxReplicas": 5,
+		      "scaleTargetRef": {"kind": "Deployment", "name": "x"},
+		      "metrics": [{"type": "Resource", "resource": {"name": "cpu", "target": {"type": "Utilization", "averageUtilization": 80}}}]
+		    }
+		  }]
+		}`,
+	}, false)
+	report, _ := v.Validate(context.Background())
+	found := false
+	for _, f := range report.Findings {
+		if strings.Contains(f.Issue, "minReplicas not set") && f.Severity == SeverityInfo {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected minReplicas-not-set info, got %+v", report.Findings)
+	}
+}
+
+func TestValidate_HPAUtilizationWithoutTargetWarns(t *testing.T) {
+	v := NewHPAValidator(&hpaValidatorMock{
+		hpaList: `{
+		  "items": [{
+		    "metadata": {"name": "missing-util", "namespace": "default"},
+		    "spec": {
+		      "minReplicas": 1, "maxReplicas": 5,
+		      "scaleTargetRef": {"kind": "Deployment", "name": "x"},
+		      "metrics": [{"type": "Resource", "resource": {"name": "cpu", "target": {"type": "Utilization"}}}]
+		    }
+		  }]
+		}`,
+	}, false)
+	report, _ := v.Validate(context.Background())
+	found := false
+	for _, f := range report.Findings {
+		if strings.Contains(f.Issue, "utilisation with no target") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected utilisation warning, got %+v", report.Findings)
+	}
+}
+
+func TestValidate_KEDANotInstalledScansHPAOnly(t *testing.T) {
+	v := NewHPAValidator(&hpaValidatorMock{
+		hpaList:            `{"items": []}`,
+		apiResourcesOutput: "",
+	}, false)
+	report, _ := v.Validate(context.Background())
+	if report.KEDAInstalled {
+		t.Error("KEDAInstalled should be false when api-resources returns nothing")
+	}
+	if report.ScaledObjectsScanned != 0 {
+		t.Errorf("ScaledObjectsScanned = %d, want 0", report.ScaledObjectsScanned)
+	}
+}
+
+func TestValidate_KEDAInstalledScansScaledObjects(t *testing.T) {
+	v := NewHPAValidator(&hpaValidatorMock{
+		hpaList:            `{"items": []}`,
+		apiResourcesOutput: "scaledobjects.keda.sh\n",
+		scaledObjectsList: `{
+		  "items": [
+		    {
+		      "metadata": {"name": "good", "namespace": "default"},
+		      "spec": {
+		        "scaleTargetRef": {"name": "api"},
+		        "minReplicaCount": 1, "maxReplicaCount": 10,
+		        "triggers": [{"type": "cron", "metadata": {"timezone": "UTC"}}]
+		      }
+		    },
+		    {
+		      "metadata": {"name": "broken", "namespace": "default"},
+		      "spec": {
+		        "scaleTargetRef": {"name": ""},
+		        "minReplicaCount": 5, "maxReplicaCount": 1,
+		        "triggers": []
+		      }
+		    },
+		    {
+		      "metadata": {"name": "idle-bad", "namespace": "default"},
+		      "spec": {
+		        "scaleTargetRef": {"name": "x"},
+		        "minReplicaCount": 1, "maxReplicaCount": 5, "idleReplicaCount": 1,
+		        "triggers": [{"type": "prometheus"}]
+		      }
+		    }
+		  ]
+		}`,
+	}, false)
+	report, _ := v.Validate(context.Background())
+
+	if !report.KEDAInstalled {
+		t.Fatal("KEDAInstalled should be true")
+	}
+	if report.ScaledObjectsScanned != 3 {
+		t.Errorf("ScaledObjectsScanned = %d, want 3", report.ScaledObjectsScanned)
+	}
+
+	issues := map[string]bool{}
+	for _, f := range report.Findings {
+		if f.Resource == "scaledobject" {
+			issues[f.Name+":"+f.Issue] = true
+		}
+	}
+
+	for _, want := range []string{
+		"broken:scaleTargetRef.name empty",
+		"broken:no triggers configured",
+		"broken:min > max",
+		"idle-bad:idleReplicaCount >= minReplicaCount",
+	} {
+		if !issues[want] {
+			t.Errorf("expected scaledobject issue %q in %+v", want, issues)
+		}
+	}
+}
+
+func TestValidate_KEDAAggressivePollingIsInfo(t *testing.T) {
+	pi := 1
+	min := 1
+	max := 5
+	_ = pi
+	_ = min
+	_ = max
+	v := NewHPAValidator(&hpaValidatorMock{
+		hpaList:            `{"items": []}`,
+		apiResourcesOutput: "scaledobjects.keda.sh\n",
+		scaledObjectsList: `{
+		  "items": [{
+		    "metadata": {"name": "fast-poll", "namespace": "default"},
+		    "spec": {
+		      "scaleTargetRef": {"name": "x"},
+		      "minReplicaCount": 1, "maxReplicaCount": 5,
+		      "pollingInterval": 1,
+		      "triggers": [{"type": "cron"}]
+		    }
+		  }]
+		}`,
+	}, false)
+	report, _ := v.Validate(context.Background())
+	found := false
+	for _, f := range report.Findings {
+		if strings.Contains(f.Issue, "pollingInterval < 5s") && f.Severity == SeverityInfo {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected polling-interval info, got %+v", report.Findings)
+	}
+}

--- a/internal/k8s/sre/hpa_validator_test.go
+++ b/internal/k8s/sre/hpa_validator_test.go
@@ -247,12 +247,6 @@ func TestValidate_KEDAInstalledScansScaledObjects(t *testing.T) {
 }
 
 func TestValidate_KEDAAggressivePollingIsInfo(t *testing.T) {
-	pi := 1
-	min := 1
-	max := 5
-	_ = pi
-	_ = min
-	_ = max
 	v := NewHPAValidator(&hpaValidatorMock{
 		hpaList:            `{"items": []}`,
 		apiResourcesOutput: "scaledobjects.keda.sh\n",

--- a/internal/k8s/sre/karpenter.go
+++ b/internal/k8s/sre/karpenter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 )
@@ -113,7 +114,9 @@ func (d *KarpenterDetector) ListNodePools(ctx context.Context) ([]NodePoolSummar
 		summary, err := parseNodePool(item)
 		if err != nil {
 			if d.debug {
-				fmt.Printf("[karpenter] skipping unparseable NodePool: %v\n", err)
+				// stderr so we don't corrupt stdout when the caller is consuming
+				// `-o json` output.
+				fmt.Fprintf(os.Stderr, "[karpenter] skipping unparseable NodePool: %v\n", err)
 			}
 			continue
 		}
@@ -145,7 +148,7 @@ func (d *KarpenterDetector) ListNodeClaims(ctx context.Context) ([]NodeClaimSumm
 		summary, err := parseNodeClaim(item)
 		if err != nil {
 			if d.debug {
-				fmt.Printf("[karpenter] skipping unparseable NodeClaim: %v\n", err)
+				fmt.Fprintf(os.Stderr, "[karpenter] skipping unparseable NodeClaim: %v\n", err)
 			}
 			continue
 		}

--- a/internal/k8s/storage/auditor.go
+++ b/internal/k8s/storage/auditor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -40,7 +41,10 @@ type AuditFinding struct {
 	Capacity  string `json:"capacity,omitempty"`
 }
 
-// AuditReport rolls up the audit results.
+// AuditReport rolls up the audit results. UnusedPVs counts every PV that
+// landed in a non-Bound phase the auditor flags (Released, Available, or
+// Failed) — useful as a single rollup but operators should still read
+// Findings for the per-PV reason.
 type AuditReport struct {
 	GeneratedAt  time.Time      `json:"generatedAt"`
 	PVsScanned   int            `json:"pvsScanned"`
@@ -48,7 +52,8 @@ type AuditReport struct {
 	PodsScanned  int            `json:"podsScanned"`
 	OrphanedPVCs int            `json:"orphanedPvcs"`
 	PendingPVCs  int            `json:"pendingPvcs"`
-	OrphanedPVs  int            `json:"orphanedPvs"`
+	UnusedPVs    int            `json:"unusedPvs"`
+	Notes        string         `json:"notes,omitempty"`
 	Findings     []AuditFinding `json:"findings,omitempty"`
 }
 
@@ -74,9 +79,11 @@ func (a *Auditor) Audit(ctx context.Context) (*AuditReport, error) {
 	usedPVCs, podsScanned, err := a.collectPVCsInUseByPods(ctx)
 	if err != nil {
 		// Pod listing failure shouldn't block the entire audit; we just
-		// can't detect orphaned PVCs without it.
+		// can't detect orphaned PVCs without it. Surface in Notes so the
+		// operator knows the orphan signal was suppressed.
+		report.Notes = fmt.Sprintf("pod scan failed, orphaned-PVC detection disabled: %v", err)
 		if a.debug {
-			fmt.Println("[storage-audit] pod scan failed, orphaned-PVC detection disabled:", err)
+			fmt.Fprintln(os.Stderr, "[storage-audit] pod scan failed, orphaned-PVC detection disabled:", err)
 		}
 	}
 	report.PodsScanned = podsScanned
@@ -95,7 +102,7 @@ func (a *Auditor) Audit(ctx context.Context) (*AuditReport, error) {
 		case f.Kind == "pvc" && strings.Contains(f.Issue, "Pending"):
 			report.PendingPVCs++
 		case f.Kind == "pv":
-			report.OrphanedPVs++
+			report.UnusedPVs++
 		}
 	}
 

--- a/internal/k8s/storage/auditor.go
+++ b/internal/k8s/storage/auditor.go
@@ -1,0 +1,222 @@
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Auditor inspects PersistentVolume + PersistentVolumeClaim posture for
+// waste signals: orphaned PVCs (paying storage for nothing), orphaned PVs
+// (Released or never-used Available), and stuck (Pending) PVCs.
+//
+// Read-only — only kubectl get/list is invoked.
+type Auditor struct {
+	client K8sClient
+	pvm    *PVManager
+	pvcm   *PVCManager
+	debug  bool
+}
+
+func NewAuditor(client K8sClient, debug bool) *Auditor {
+	return &Auditor{
+		client: client,
+		pvm:    NewPVManager(client, debug),
+		pvcm:   NewPVCManager(client, debug),
+		debug:  debug,
+	}
+}
+
+// AuditFinding is one waste signal.
+type AuditFinding struct {
+	Kind      string `json:"kind"` // "pv" or "pvc"
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name"`
+	Issue     string `json:"issue"`
+	Detail    string `json:"detail,omitempty"`
+	Capacity  string `json:"capacity,omitempty"`
+}
+
+// AuditReport rolls up the audit results.
+type AuditReport struct {
+	GeneratedAt  time.Time      `json:"generatedAt"`
+	PVsScanned   int            `json:"pvsScanned"`
+	PVCsScanned  int            `json:"pvcsScanned"`
+	PodsScanned  int            `json:"podsScanned"`
+	OrphanedPVCs int            `json:"orphanedPvcs"`
+	PendingPVCs  int            `json:"pendingPvcs"`
+	OrphanedPVs  int            `json:"orphanedPvs"`
+	Findings     []AuditFinding `json:"findings,omitempty"`
+}
+
+// Audit lists PVs, PVCs, and pods cluster-wide and produces a list of waste
+// findings. Pods are scanned to determine which PVCs are referenced by at
+// least one workload — PVCs not referenced by any pod are flagged as
+// orphaned (paying storage for nothing).
+func (a *Auditor) Audit(ctx context.Context) (*AuditReport, error) {
+	report := &AuditReport{GeneratedAt: time.Now().UTC()}
+
+	pvs, err := a.pvm.ListPVs(ctx, QueryOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list PVs: %w", err)
+	}
+	report.PVsScanned = len(pvs)
+
+	pvcs, err := a.pvcm.ListPVCs(ctx, "", QueryOptions{AllNamespaces: true})
+	if err != nil {
+		return nil, fmt.Errorf("list PVCs: %w", err)
+	}
+	report.PVCsScanned = len(pvcs)
+
+	usedPVCs, podsScanned, err := a.collectPVCsInUseByPods(ctx)
+	if err != nil {
+		// Pod listing failure shouldn't block the entire audit; we just
+		// can't detect orphaned PVCs without it.
+		if a.debug {
+			fmt.Println("[storage-audit] pod scan failed, orphaned-PVC detection disabled:", err)
+		}
+	}
+	report.PodsScanned = podsScanned
+
+	for _, pvc := range pvcs {
+		report.Findings = append(report.Findings, a.checkPVC(pvc, usedPVCs)...)
+	}
+	for _, pv := range pvs {
+		report.Findings = append(report.Findings, a.checkPV(pv)...)
+	}
+
+	for _, f := range report.Findings {
+		switch {
+		case f.Kind == "pvc" && strings.Contains(f.Issue, "not referenced"):
+			report.OrphanedPVCs++
+		case f.Kind == "pvc" && strings.Contains(f.Issue, "Pending"):
+			report.PendingPVCs++
+		case f.Kind == "pv":
+			report.OrphanedPVs++
+		}
+	}
+
+	sort.SliceStable(report.Findings, func(i, j int) bool {
+		if report.Findings[i].Kind != report.Findings[j].Kind {
+			return report.Findings[i].Kind < report.Findings[j].Kind
+		}
+		if report.Findings[i].Namespace != report.Findings[j].Namespace {
+			return report.Findings[i].Namespace < report.Findings[j].Namespace
+		}
+		return report.Findings[i].Name < report.Findings[j].Name
+	})
+
+	return report, nil
+}
+
+func (a *Auditor) checkPVC(pvc PVCInfo, usedPVCs map[string]bool) []AuditFinding {
+	var out []AuditFinding
+	key := pvc.Namespace + "/" + pvc.Name
+
+	switch strings.ToLower(pvc.Status) {
+	case "pending":
+		out = append(out, AuditFinding{
+			Kind:      "pvc",
+			Namespace: pvc.Namespace,
+			Name:      pvc.Name,
+			Issue:     "PVC stuck Pending",
+			Detail:    fmt.Sprintf("requested %s, no PV has bound — provisioner may be missing or the storage class is wrong", pvc.RequestedStorage),
+			Capacity:  pvc.RequestedStorage,
+		})
+	case "lost":
+		out = append(out, AuditFinding{
+			Kind:      "pvc",
+			Namespace: pvc.Namespace,
+			Name:      pvc.Name,
+			Issue:     "PVC Lost",
+			Detail:    "underlying PV was deleted; data is gone but the PVC reference still exists",
+			Capacity:  pvc.RequestedStorage,
+		})
+	}
+
+	// Bound PVCs not referenced by any pod = orphaned. Only check when
+	// the pod scan ran (usedPVCs is nil if it failed).
+	if usedPVCs != nil && strings.EqualFold(pvc.Status, "Bound") && !usedPVCs[key] {
+		out = append(out, AuditFinding{
+			Kind:      "pvc",
+			Namespace: pvc.Namespace,
+			Name:      pvc.Name,
+			Issue:     "PVC not referenced by any pod",
+			Detail:    fmt.Sprintf("bound to PV %q but no pod mounts it — likely orphaned spend", pvc.Volume),
+			Capacity:  pvc.Capacity,
+		})
+	}
+	return out
+}
+
+func (a *Auditor) checkPV(pv PVInfo) []AuditFinding {
+	var out []AuditFinding
+	switch strings.ToLower(pv.Status) {
+	case "released":
+		out = append(out, AuditFinding{
+			Kind:     "pv",
+			Name:     pv.Name,
+			Issue:    "PV Released and not reclaimed",
+			Detail:   fmt.Sprintf("reclaim policy %q — Retain leaks unless cleaned up by hand", pv.ReclaimPolicy),
+			Capacity: pv.Capacity,
+		})
+	case "available":
+		out = append(out, AuditFinding{
+			Kind:     "pv",
+			Name:     pv.Name,
+			Issue:    "PV Available (never bound)",
+			Detail:   "static PV with no PVC claim — verify it's still intentional",
+			Capacity: pv.Capacity,
+		})
+	case "failed":
+		out = append(out, AuditFinding{
+			Kind:     "pv",
+			Name:     pv.Name,
+			Issue:    "PV Failed",
+			Detail:   "PV moved to Failed state — provisioner or storage backend is unhealthy",
+			Capacity: pv.Capacity,
+		})
+	}
+	return out
+}
+
+// collectPVCsInUseByPods walks every pod cluster-wide and records which
+// PVCs they reference. Returns a map keyed by "namespace/pvc-name".
+func (a *Auditor) collectPVCsInUseByPods(ctx context.Context) (map[string]bool, int, error) {
+	out, err := a.client.Run(ctx, "get", "pods", "-A", "-o", "json")
+	if err != nil {
+		return nil, 0, err
+	}
+	raw := []byte(out)
+	var list struct {
+		Items []struct {
+			Metadata struct {
+				Namespace string `json:"namespace"`
+			} `json:"metadata"`
+			Spec struct {
+				Volumes []struct {
+					PersistentVolumeClaim *struct {
+						ClaimName string `json:"claimName"`
+					} `json:"persistentVolumeClaim,omitempty"`
+				} `json:"volumes"`
+			} `json:"spec"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, 0, fmt.Errorf("parse pod list: %w", err)
+	}
+
+	used := make(map[string]bool)
+	for _, p := range list.Items {
+		for _, v := range p.Spec.Volumes {
+			if v.PersistentVolumeClaim == nil {
+				continue
+			}
+			used[p.Metadata.Namespace+"/"+v.PersistentVolumeClaim.ClaimName] = true
+		}
+	}
+	return used, len(list.Items), nil
+}

--- a/internal/k8s/storage/auditor_test.go
+++ b/internal/k8s/storage/auditor_test.go
@@ -1,0 +1,263 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// auditMock fans kubectl invocations to per-resource responses based on args.
+type auditMock struct {
+	pvList   string
+	pvErr    error
+	pvcList  string
+	pvcErr   error
+	podsList string
+	podsErr  error
+}
+
+func (m *auditMock) Run(_ context.Context, args ...string) (string, error) {
+	full := strings.Join(args, " ")
+	switch {
+	case strings.Contains(full, "get pv "), strings.HasSuffix(full, "get pv -o json"):
+		return m.pvList, m.pvErr
+	case strings.Contains(full, "get pvc"):
+		return m.pvcList, m.pvcErr
+	case strings.Contains(full, "get pods"):
+		return m.podsList, m.podsErr
+	}
+	return "", nil
+}
+
+func (m *auditMock) RunWithNamespace(_ context.Context, _ string, _ ...string) (string, error) {
+	return "", nil
+}
+func (m *auditMock) GetJSON(_ context.Context, _, _, _ string) ([]byte, error) {
+	return nil, nil
+}
+func (m *auditMock) Describe(_ context.Context, _, _, _ string) (string, error) { return "", nil }
+func (m *auditMock) Delete(_ context.Context, _, _, _ string) (string, error)   { return "", nil }
+func (m *auditMock) Apply(_ context.Context, _ string) (string, error)          { return "", nil }
+
+const (
+	emptyList = `{"items": []}`
+
+	pvBoundOnly = `{
+	  "items": [{
+	    "metadata": {"name": "pv-bound"},
+	    "spec": {"capacity": {"storage": "10Gi"}, "persistentVolumeReclaimPolicy": "Delete"},
+	    "status": {"phase": "Bound"}
+	  }]
+	}`
+
+	pvAllStates = `{
+	  "items": [
+	    {"metadata": {"name": "pv-released"}, "spec": {"capacity": {"storage": "20Gi"}, "persistentVolumeReclaimPolicy": "Retain"}, "status": {"phase": "Released"}},
+	    {"metadata": {"name": "pv-available"}, "spec": {"capacity": {"storage": "5Gi"}, "persistentVolumeReclaimPolicy": "Delete"}, "status": {"phase": "Available"}},
+	    {"metadata": {"name": "pv-failed"}, "spec": {"capacity": {"storage": "1Gi"}, "persistentVolumeReclaimPolicy": "Delete"}, "status": {"phase": "Failed"}},
+	    {"metadata": {"name": "pv-bound"}, "spec": {"capacity": {"storage": "10Gi"}, "persistentVolumeReclaimPolicy": "Delete"}, "status": {"phase": "Bound"}}
+	  ]
+	}`
+
+	pvcBoundUsed = `{
+	  "items": [{
+	    "metadata": {"name": "data", "namespace": "prod"},
+	    "spec": {"volumeName": "pv-bound", "resources": {"requests": {"storage": "10Gi"}}},
+	    "status": {"phase": "Bound", "capacity": {"storage": "10Gi"}}
+	  }]
+	}`
+
+	pvcMixed = `{
+	  "items": [
+	    {"metadata": {"name": "orphan", "namespace": "prod"}, "spec": {"volumeName": "pv-bound", "resources": {"requests": {"storage": "10Gi"}}}, "status": {"phase": "Bound", "capacity": {"storage": "10Gi"}}},
+	    {"metadata": {"name": "stuck", "namespace": "default"}, "spec": {"resources": {"requests": {"storage": "5Gi"}}}, "status": {"phase": "Pending"}},
+	    {"metadata": {"name": "gone", "namespace": "default"}, "spec": {"resources": {"requests": {"storage": "1Gi"}}}, "status": {"phase": "Lost"}}
+	  ]
+	}`
+
+	podMountingOrphan = `{
+	  "items": [{
+	    "metadata": {"namespace": "prod"},
+	    "spec": {"volumes": [{"persistentVolumeClaim": {"claimName": "data"}}]}
+	  }]
+	}`
+
+	podsNoPVC = `{
+	  "items": [{
+	    "metadata": {"namespace": "kube-system"},
+	    "spec": {"volumes": [{"emptyDir": {}}]}
+	  }]
+	}`
+)
+
+func TestAudit_HappyPath(t *testing.T) {
+	a := NewAuditor(&auditMock{
+		pvList:   pvBoundOnly,
+		pvcList:  pvcBoundUsed,
+		podsList: podMountingOrphan,
+	}, false)
+
+	report, err := a.Audit(context.Background())
+	if err != nil {
+		t.Fatalf("Audit: %v", err)
+	}
+	if report.PVsScanned != 1 || report.PVCsScanned != 1 || report.PodsScanned != 1 {
+		t.Errorf("scan counts wrong: PVs=%d PVCs=%d Pods=%d", report.PVsScanned, report.PVCsScanned, report.PodsScanned)
+	}
+	if len(report.Findings) != 0 {
+		t.Errorf("expected 0 findings, got %+v", report.Findings)
+	}
+}
+
+func TestAudit_FlagsOrphanedPendingLost(t *testing.T) {
+	a := NewAuditor(&auditMock{
+		pvList:   pvBoundOnly,
+		pvcList:  pvcMixed,
+		podsList: podsNoPVC,
+	}, false)
+
+	report, err := a.Audit(context.Background())
+	if err != nil {
+		t.Fatalf("Audit: %v", err)
+	}
+
+	issues := map[string]string{} // name -> issue
+	for _, f := range report.Findings {
+		if f.Kind == "pvc" {
+			issues[f.Name] = f.Issue
+		}
+	}
+
+	if !strings.Contains(issues["orphan"], "not referenced") {
+		t.Errorf("expected orphan PVC flagged, got %+v", report.Findings)
+	}
+	if !strings.Contains(issues["stuck"], "Pending") {
+		t.Errorf("expected stuck PVC flagged Pending, got %+v", report.Findings)
+	}
+	if !strings.Contains(issues["gone"], "Lost") {
+		t.Errorf("expected gone PVC flagged Lost, got %+v", report.Findings)
+	}
+
+	if report.OrphanedPVCs != 1 {
+		t.Errorf("OrphanedPVCs = %d, want 1", report.OrphanedPVCs)
+	}
+	if report.PendingPVCs != 1 {
+		t.Errorf("PendingPVCs = %d, want 1", report.PendingPVCs)
+	}
+}
+
+func TestAudit_FlagsAllPVStates(t *testing.T) {
+	a := NewAuditor(&auditMock{
+		pvList:   pvAllStates,
+		pvcList:  emptyList,
+		podsList: emptyList,
+	}, false)
+
+	report, err := a.Audit(context.Background())
+	if err != nil {
+		t.Fatalf("Audit: %v", err)
+	}
+
+	issues := map[string]string{}
+	for _, f := range report.Findings {
+		if f.Kind == "pv" {
+			issues[f.Name] = f.Issue
+		}
+	}
+
+	if !strings.Contains(issues["pv-released"], "Released") {
+		t.Errorf("expected Released PV flagged, got %+v", report.Findings)
+	}
+	if !strings.Contains(issues["pv-available"], "Available") {
+		t.Errorf("expected Available PV flagged, got %+v", report.Findings)
+	}
+	if !strings.Contains(issues["pv-failed"], "Failed") {
+		t.Errorf("expected Failed PV flagged, got %+v", report.Findings)
+	}
+	if _, ok := issues["pv-bound"]; ok {
+		t.Errorf("Bound PV should not be flagged, got %+v", report.Findings)
+	}
+
+	if report.OrphanedPVs != 3 {
+		t.Errorf("OrphanedPVs = %d, want 3", report.OrphanedPVs)
+	}
+}
+
+func TestAudit_PodScanFailureToleratesOrphans(t *testing.T) {
+	// Pod listing fails — orphaned-PVC detection should be disabled but
+	// the rest of the audit (pending/lost/PVs) must still run.
+	a := NewAuditor(&auditMock{
+		pvList:  pvBoundOnly,
+		pvcList: pvcMixed,
+		podsErr: errors.New("forbidden"),
+	}, false)
+
+	report, err := a.Audit(context.Background())
+	if err != nil {
+		t.Fatalf("Audit should not fail when pod scan errors: %v", err)
+	}
+
+	for _, f := range report.Findings {
+		if f.Kind == "pvc" && f.Name == "orphan" && strings.Contains(f.Issue, "not referenced") {
+			t.Errorf("orphaned-PVC detection should be skipped when pod scan fails, got %+v", f)
+		}
+	}
+
+	// Pending + Lost should still surface.
+	pending := false
+	lost := false
+	for _, f := range report.Findings {
+		if f.Kind == "pvc" && strings.Contains(f.Issue, "Pending") {
+			pending = true
+		}
+		if f.Kind == "pvc" && strings.Contains(f.Issue, "Lost") {
+			lost = true
+		}
+	}
+	if !pending || !lost {
+		t.Errorf("expected Pending+Lost findings even with pod scan failure, got %+v", report.Findings)
+	}
+}
+
+func TestAudit_PVListFailureReturnsError(t *testing.T) {
+	a := NewAuditor(&auditMock{
+		pvErr:    errors.New("kubectl boom"),
+		pvcList:  emptyList,
+		podsList: emptyList,
+	}, false)
+
+	if _, err := a.Audit(context.Background()); err == nil {
+		t.Error("expected error when PV list fails")
+	}
+}
+
+func TestAudit_FindingsSortedDeterministic(t *testing.T) {
+	a := NewAuditor(&auditMock{
+		pvList: pvAllStates,
+		pvcList: `{
+		  "items": [
+		    {"metadata": {"name": "z", "namespace": "alpha"}, "spec": {"resources": {"requests": {"storage": "1Gi"}}}, "status": {"phase": "Pending"}},
+		    {"metadata": {"name": "a", "namespace": "beta"}, "spec": {"resources": {"requests": {"storage": "1Gi"}}}, "status": {"phase": "Pending"}}
+		  ]
+		}`,
+		podsList: emptyList,
+	}, false)
+
+	r1, _ := a.Audit(context.Background())
+	r2, _ := a.Audit(context.Background())
+
+	if len(r1.Findings) != len(r2.Findings) {
+		t.Fatalf("finding counts differ across runs: %d vs %d", len(r1.Findings), len(r2.Findings))
+	}
+	for i := range r1.Findings {
+		if r1.Findings[i].Name != r2.Findings[i].Name || r1.Findings[i].Kind != r2.Findings[i].Kind {
+			t.Errorf("findings[%d] differ across runs: %+v vs %+v", i, r1.Findings[i], r2.Findings[i])
+		}
+	}
+
+	// Verify "pv" sorts before "pvc" alphabetically.
+	if r1.Findings[0].Kind != "pv" {
+		t.Errorf("first finding kind = %q, want pv (sort order broken)", r1.Findings[0].Kind)
+	}
+}

--- a/internal/k8s/storage/auditor_test.go
+++ b/internal/k8s/storage/auditor_test.go
@@ -179,8 +179,8 @@ func TestAudit_FlagsAllPVStates(t *testing.T) {
 		t.Errorf("Bound PV should not be flagged, got %+v", report.Findings)
 	}
 
-	if report.OrphanedPVs != 3 {
-		t.Errorf("OrphanedPVs = %d, want 3", report.OrphanedPVs)
+	if report.UnusedPVs != 3 {
+		t.Errorf("UnusedPVs = %d, want 3", report.UnusedPVs)
 	}
 }
 


### PR DESCRIPTION
## Summary

Phase 3 work for the CLI: two new K8s read-only audit subcommands plus a fresh-eyes review pass over Phase 2 surfaces.

## Commits

- **fix(k8s):** post-merge review pass on Phase 2 surfaces — defensive nil-guard on \`AnalyzeScalingWaste\`, propagates detection error into \`Notes\` instead of swallowing; \`printAutoscalerReport\` now renders \`HotPodReasons\`; karpenter debug printf moved off stdout (would corrupt JSON output); test timestamps refactored from constants to a function returning \`time.Now()\`-relative timestamps so they don't silently break in 2027.
- **feat(k8s):** \`clanker k8s autoscaler validate\` — HPA + KEDA config linter (Phase 3 K5). Detects \`minReplicas > maxReplicas\`, missing metrics, empty \`scaleTargetRef\`, KEDA polling intervals, idle/min/max ordering. Probes for KEDA via \`kubectl api-resources --api-group=keda.sh\` and only scans \`ScaledObjects\` when present.
- **feat(k8s):** \`clanker k8s storage audit\` — PV/PVC waste detection (Phase 3 K7). Surfaces orphaned PVCs (Bound but no pod mounts them), Pending/Lost PVCs, Released/Available/Failed PVs. Pod-listing failure degrades gracefully — orphaned-PVC detection skipped, rest of audit still runs.

## Test plan

- [x] \`make ci\` (fmt → vet → test-short → build) passes locally
- [x] New \`internal/k8s/sre/hpa_validator_test.go\` — 8 cases (happy, misconfig, KEDA detected/not-detected, polling thresholds)
- [x] New \`internal/k8s/storage/auditor_test.go\` — 6 cases (happy, orphan/pending/lost detection, all PV states, pod-scan failure tolerance, deterministic sort)
- [x] New \`cmd/k8s_hpa_validate_print_test.go\` and \`cmd/k8s_storage_audit_print_test.go\`
- [ ] Smoke run against a real cluster: \`clanker k8s autoscaler validate\` and \`clanker k8s storage audit\`