### PR TITLE
feat(cost): Phase 6 — Savings Plans + RI recommendations

### DIFF
--- a/cmd/cost_savings.go
+++ b/cmd/cost_savings.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/bgdnvk/clanker/internal/cost"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	costSavingsLookback string
+	costSavingsTerm     string
+)
+
+var costSavingsCmd = &cobra.Command{
+	Use:   "savings",
+	Short: "AWS Savings Plan + Reserved Instance purchase recommendations",
+	Long: `Pull commitment-purchase recommendations from AWS Cost Explorer:
+
+  • Savings Plans (Compute / EC2 Instance / SageMaker)
+  • Reserved Instances (EC2 / RDS / ElastiCache / OpenSearch / Redshift)
+
+Both shapes are merged into one ranked list so the highest-savings
+commitment wins regardless of type. Read-only — no purchases are made.
+
+Recommendations require usage history; brand-new accounts produce an
+empty list with a note rather than an error.
+
+Examples:
+  clanker cost savings                            # 1y term, 60d lookback
+  clanker cost savings --term 3                   # 3y term
+  clanker cost savings --lookback 30 -o json
+  clanker cost savings --profile prod`,
+	RunE: runCostSavings,
+}
+
+func init() {
+	costCmd.AddCommand(costSavingsCmd)
+	costSavingsCmd.Flags().StringVar(&costSavingsLookback, "lookback", "60", "Lookback window in days (7, 30, 60)")
+	costSavingsCmd.Flags().StringVar(&costSavingsTerm, "term", "1", "Commitment term in years (1 or 3)")
+}
+
+func runCostSavings(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	debug := viper.GetBool("debug")
+
+	awsProfile := costProfile
+	if awsProfile == "" {
+		awsProfile = os.Getenv("AWS_PROFILE")
+	}
+
+	provider, err := cost.NewAWSProvider(ctx, awsProfile, debug)
+	if err != nil {
+		return fmt.Errorf("AWS provider unavailable: %w", err)
+	}
+
+	report, err := provider.GetSavingsRecommendations(ctx, costSavingsLookback, costSavingsTerm)
+	if err != nil {
+		return fmt.Errorf("savings recommendations failed: %w", err)
+	}
+
+	switch strings.ToLower(costFormat) {
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	default:
+		printSavingsReport(os.Stdout, report, costTop)
+		return nil
+	}
+}
+
+func printSavingsReport(out io.Writer, report *cost.SavingsReport, topN int) {
+	if report == nil {
+		fmt.Fprintln(out, "No savings report.")
+		return
+	}
+
+	fmt.Fprintf(out, "AWS savings recommendations — term=%s, lookback=%s\n",
+		report.Term, report.Lookback)
+	fmt.Fprintf(out, "Estimated total monthly savings: $%.2f\n", report.TotalEstimatedSavings)
+	if report.Notes != "" {
+		fmt.Fprintf(out, "Notes: %s\n", report.Notes)
+	}
+	fmt.Fprintln(out)
+
+	if len(report.Recommendations) == 0 {
+		fmt.Fprintln(out, "No commitment recommendations available.")
+		return
+	}
+
+	limit := len(report.Recommendations)
+	if topN > 0 && topN < limit {
+		limit = topN
+	}
+
+	fmt.Fprintf(out, "%d recommendation(s):\n", len(report.Recommendations))
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "KIND\tSERVICE/FAMILY\tHOURLY\tUPFRONT\tSAVINGS/MO\tSAVINGS %\tBREAKEVEN")
+	fmt.Fprintln(w, "----\t--------------\t------\t-------\t----------\t---------\t---------")
+	for _, r := range report.Recommendations[:limit] {
+		label := r.Service
+		if label == "" {
+			label = r.Family
+		} else if r.Family != "" {
+			label = label + " (" + r.Family + ")"
+		}
+		breakeven := ""
+		if r.BreakevenMonths > 0 {
+			breakeven = fmt.Sprintf("%.1f mo", r.BreakevenMonths)
+		} else {
+			breakeven = "—"
+		}
+		fmt.Fprintf(w, "%s\t%s\t$%.4f\t$%.2f\t$%.2f\t%.1f%%\t%s\n",
+			kindLabel(r.Kind),
+			truncate(label, 30),
+			r.HourlyCommitment,
+			r.UpfrontCost,
+			r.EstimatedSavings,
+			r.EstimatedSavingsPc,
+			breakeven,
+		)
+	}
+	w.Flush()
+
+	if topN > 0 && len(report.Recommendations) > topN {
+		fmt.Fprintf(out, "\n(showing top %d of %d — pass --top 0 for all)\n", topN, len(report.Recommendations))
+	}
+
+	fmt.Fprintln(out, "\nDetails:")
+	for _, r := range report.Recommendations[:limit] {
+		fmt.Fprintf(out, "  • [%s] %s — $%.2f/mo savings (%.1f%%)\n",
+			kindLabel(r.Kind), r.Family, r.EstimatedSavings, r.EstimatedSavingsPc)
+		if r.Detail != "" {
+			fmt.Fprintf(out, "    %s\n", r.Detail)
+		}
+	}
+}
+
+func kindLabel(k cost.SavingsKind) string {
+	switch k {
+	case cost.SavingsKindSavingsPlan:
+		return "SP"
+	case cost.SavingsKindReservedInstance:
+		return "RI"
+	}
+	return string(k)
+}

--- a/cmd/cost_savings_print_test.go
+++ b/cmd/cost_savings_print_test.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/bgdnvk/clanker/internal/cost"
+)
+
+func TestPrintSavingsReport_Nil(t *testing.T) {
+	var buf bytes.Buffer
+	printSavingsReport(&buf, nil, 10)
+	if !strings.Contains(buf.String(), "No savings report") {
+		t.Errorf("expected nil-report message, got %q", buf.String())
+	}
+}
+
+func TestPrintSavingsReport_EmptyWithNote(t *testing.T) {
+	var buf bytes.Buffer
+	printSavingsReport(&buf, &cost.SavingsReport{
+		Term:     "ONE_YEAR",
+		Lookback: "SIXTY_DAYS",
+		Notes:    "no commitment recommendations — account may not have enough usage history",
+	}, 10)
+	out := buf.String()
+	if !strings.Contains(out, "term=ONE_YEAR") {
+		t.Errorf("expected term in header, got %q", out)
+	}
+	if !strings.Contains(out, "Notes:") {
+		t.Errorf("expected note line, got %q", out)
+	}
+	if !strings.Contains(out, "No commitment recommendations available") {
+		t.Errorf("expected empty-state message, got %q", out)
+	}
+}
+
+func TestPrintSavingsReport_RendersRows(t *testing.T) {
+	var buf bytes.Buffer
+	printSavingsReport(&buf, &cost.SavingsReport{
+		Term: "ONE_YEAR", Lookback: "SIXTY_DAYS",
+		TotalEstimatedSavings: 750.50,
+		Recommendations: []cost.SavingsRecommendation{
+			{Provider: "aws", Kind: cost.SavingsKindSavingsPlan, Family: "Compute", Term: "ONE_YEAR", HourlyCommitment: 0.05, EstimatedSavings: 500, EstimatedSavingsPc: 25, Detail: "family=m5, region=us-east-1"},
+			{Provider: "aws", Kind: cost.SavingsKindReservedInstance, Service: "RDS", Family: "db.r6g", Term: "ONE_YEAR", UpfrontCost: 1200, EstimatedSavings: 250, EstimatedSavingsPc: 18, BreakevenMonths: 4.8, Detail: "qty=2"},
+		},
+	}, 10)
+	out := buf.String()
+
+	for _, want := range []string{
+		"$750.50",
+		"SP",
+		"RI",
+		"Compute",
+		"RDS",
+		"db.r6g",
+		"$500.00",
+		"$250.00",
+		"4.8 mo",
+		"Details:",
+		"family=m5",
+		"qty=2",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintSavingsReport_TopN(t *testing.T) {
+	recs := []cost.SavingsRecommendation{
+		{Kind: cost.SavingsKindSavingsPlan, Family: "Compute-1", EstimatedSavings: 100},
+		{Kind: cost.SavingsKindSavingsPlan, Family: "Compute-2", EstimatedSavings: 50},
+		{Kind: cost.SavingsKindSavingsPlan, Family: "Compute-3", EstimatedSavings: 25},
+	}
+	var buf bytes.Buffer
+	printSavingsReport(&buf, &cost.SavingsReport{Recommendations: recs}, 2)
+	out := buf.String()
+
+	if !strings.Contains(out, "Compute-1") || !strings.Contains(out, "Compute-2") {
+		t.Errorf("expected first two rows, got:\n%s", out)
+	}
+	if strings.Contains(out, "Compute-3") {
+		t.Errorf("Compute-3 should be cut off by --top 2, got:\n%s", out)
+	}
+	if !strings.Contains(out, "showing top 2 of 3") {
+		t.Errorf("expected truncation note, got:\n%s", out)
+	}
+}
+
+func TestKindLabel(t *testing.T) {
+	if got := kindLabel(cost.SavingsKindSavingsPlan); got != "SP" {
+		t.Errorf("SavingsPlan label = %q, want SP", got)
+	}
+	if got := kindLabel(cost.SavingsKindReservedInstance); got != "RI" {
+		t.Errorf("RI label = %q, want RI", got)
+	}
+	if got := kindLabel("custom"); got != "custom" {
+		t.Errorf("unknown kind passthrough = %q, want custom", got)
+	}
+}

--- a/cmd/k8s_cost.go
+++ b/cmd/k8s_cost.go
@@ -1,0 +1,285 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/bgdnvk/clanker/internal/k8s"
+	"github.com/bgdnvk/clanker/internal/k8s/cost"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	k8sCostOutput     string
+	k8sCostKubeconfig string
+	k8sCostContext    string
+	k8sCostBy         string // pod | workload | namespace | node
+	k8sCostPricesFile string
+	k8sCostTopN       int
+)
+
+var k8sCostCmd = &cobra.Command{
+	Use:   "cost",
+	Short: "Attribute node cost to pods / workloads / namespaces",
+	Long: `Estimate per-workload Kubernetes cost by walking pods + nodes
+and attributing each pod's share of its host node's hourly price.
+
+Pod share = max(cpu_request / node_alloc_cpu, mem_request / node_alloc_mem).
+Pod cost  = node_hourly_price × pod_share. (Standard Kubecost-style model.)
+
+Node prices come from a built-in static AWS on-demand fallback. Operators
+with real billing data should pass --prices <file> with a JSON map of
+instance-type → hourly USD; entries override the fallback.
+
+Read-only — only kubectl get is invoked.
+
+Examples:
+  clanker k8s cost                              # per-pod (top 25)
+  clanker k8s cost --by workload                # roll up to deployments/STS/DS
+  clanker k8s cost --by namespace -o json
+  clanker k8s cost --prices ./node-prices.json
+  clanker k8s cost --top 100`,
+	RunE: runK8sCost,
+}
+
+func init() {
+	k8sCmd.AddCommand(k8sCostCmd)
+	k8sCostCmd.Flags().StringVarP(&k8sCostOutput, "output", "o", "table", "Output format (table, json)")
+	k8sCostCmd.Flags().StringVar(&k8sCostKubeconfig, "kubeconfig", "", "Path to kubeconfig (default: ~/.kube/config)")
+	k8sCostCmd.Flags().StringVar(&k8sCostContext, "context", "", "kubectl context to use")
+	k8sCostCmd.Flags().StringVar(&k8sCostBy, "by", "pod", "Aggregation level (pod, workload, namespace, node)")
+	k8sCostCmd.Flags().StringVar(&k8sCostPricesFile, "prices", "", "Path to JSON file mapping instance-type → hourly USD (overrides built-in)")
+	k8sCostCmd.Flags().IntVar(&k8sCostTopN, "top", 25, "Show only the top N rows (table mode); 0 = all")
+}
+
+func runK8sCost(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	debug := viper.GetBool("debug")
+
+	priceLookup, err := loadPriceLookup(k8sCostPricesFile)
+	if err != nil {
+		return err
+	}
+
+	client := k8s.NewClient(k8sCostKubeconfig, k8sCostContext, debug)
+	attributor := cost.NewWorkloadCostAttributor(k8s.NewK8sCostAdapter(client), priceLookup, debug)
+
+	report, err := attributor.Attribute(ctx)
+	if err != nil {
+		return fmt.Errorf("workload cost attribution failed: %w", err)
+	}
+
+	switch strings.ToLower(k8sCostOutput) {
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	default:
+		printK8sCostReport(os.Stdout, report, strings.ToLower(k8sCostBy), k8sCostTopN)
+		return nil
+	}
+}
+
+// loadPriceLookup builds the price lookup chain. With a custom file, the
+// user table wins on a hit and falls through to the built-in static AWS
+// on-demand table for misses.
+func loadPriceLookup(path string) (cost.NodePriceLookup, error) {
+	if path == "" {
+		return cost.DefaultAWSOnDemandPrices(), nil
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read prices file %q: %w", path, err)
+	}
+	var prices map[string]float64
+	if err := json.Unmarshal(raw, &prices); err != nil {
+		return nil, fmt.Errorf("parse prices file %q: %w", path, err)
+	}
+	return cost.CompositePriceLookup(cost.MapPriceLookup(prices), cost.DefaultAWSOnDemandPrices()), nil
+}
+
+func printK8sCostReport(out io.Writer, report *cost.WorkloadCostReport, by string, topN int) {
+	if report == nil {
+		fmt.Fprintln(out, "No cost report.")
+		return
+	}
+
+	fmt.Fprintf(out, "Scanned %d node(s), %d pod(s)\n", report.NodesScanned, report.PodsScanned)
+	if report.PodsWithoutNode > 0 {
+		fmt.Fprintf(out, "  • %d pod(s) skipped (no node assignment — Pending/etc.)\n", report.PodsWithoutNode)
+	}
+	if report.PodsWithoutRequests > 0 {
+		fmt.Fprintf(out, "  • %d pod(s) had no resource requests (0%% share)\n", report.PodsWithoutRequests)
+	}
+	if report.NodesWithoutPrice > 0 {
+		fmt.Fprintf(out, "  • %d node(s) without a price match — pass --prices to fix\n", report.NodesWithoutPrice)
+	}
+	fmt.Fprintf(out, "Estimated total: $%.2f/hr  ($%.2f/mo)\n",
+		report.TotalHourlyUSD, report.TotalMonthlyUSD)
+	if report.Notes != "" {
+		fmt.Fprintf(out, "Notes: %s\n", report.Notes)
+	}
+	fmt.Fprintln(out)
+
+	if len(report.Pods) == 0 {
+		fmt.Fprintln(out, "No pods attributed.")
+		return
+	}
+
+	switch by {
+	case "workload":
+		printWorkloadRollup(out, cost.AggregateByWorkload(report.Pods), topN)
+	case "namespace":
+		printNamespaceRollup(out, cost.AggregateByNamespace(report.Pods), topN)
+	case "node":
+		printNodeRollup(out, report)
+	default:
+		printPodRollup(out, report.Pods, topN)
+	}
+}
+
+func printPodRollup(out io.Writer, pods []cost.PodAttribution, topN int) {
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAMESPACE\tWORKLOAD\tPOD\tNODE\tCPU(c)\tMEM(MiB)\tSHARE\tHOURLY\tMONTHLY")
+	fmt.Fprintln(w, "---------\t--------\t---\t----\t------\t--------\t-----\t------\t-------")
+	limit := len(pods)
+	if topN > 0 && topN < limit {
+		limit = topN
+	}
+	for _, p := range pods[:limit] {
+		fmt.Fprintf(w, "%s\t%s/%s\t%s\t%s\t%.2f\t%.0f\t%.1f%%\t%s\t%s\n",
+			p.Namespace,
+			p.WorkloadKind, p.Workload,
+			truncate(p.Pod, 40),
+			truncate(p.Node, 30),
+			p.CPURequestC, p.MemRequestMB,
+			p.DominantShare*100,
+			formatUSD(p.HourlyUSD, p.PriceKnown),
+			formatUSD(p.MonthlyUSD, p.PriceKnown),
+		)
+	}
+	w.Flush()
+	if topN > 0 && len(pods) > topN {
+		fmt.Fprintf(out, "\n(showing top %d of %d pods — pass --top 0 for all)\n", topN, len(pods))
+	}
+}
+
+func printWorkloadRollup(out io.Writer, rollups []cost.WorkloadRollup, topN int) {
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAMESPACE\tKIND\tWORKLOAD\tREPLICAS\tCPU(c)\tMEM(MiB)\tHOURLY\tMONTHLY")
+	fmt.Fprintln(w, "---------\t----\t--------\t--------\t------\t--------\t------\t-------")
+	limit := len(rollups)
+	if topN > 0 && topN < limit {
+		limit = topN
+	}
+	for _, r := range rollups[:limit] {
+		marker := ""
+		if r.AnyUnpriced {
+			marker = " *"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s%s\t%d\t%.2f\t%.0f\t$%.4f\t$%.2f\n",
+			r.Namespace, r.WorkloadKind, r.Workload, marker,
+			r.Pods, r.CPURequestC, r.MemRequestMB,
+			r.HourlyUSD, r.MonthlyUSD,
+		)
+	}
+	w.Flush()
+	if topN > 0 && len(rollups) > topN {
+		fmt.Fprintf(out, "\n(showing top %d of %d workloads)\n", topN, len(rollups))
+	}
+	for _, r := range rollups[:limit] {
+		if r.AnyUnpriced {
+			fmt.Fprintln(out, "* = at least one replica on an unpriced node — totals are partial")
+			break
+		}
+	}
+}
+
+func printNamespaceRollup(out io.Writer, rollups []cost.NamespaceRollup, topN int) {
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAMESPACE\tPODS\tCPU(c)\tMEM(MiB)\tHOURLY\tMONTHLY")
+	fmt.Fprintln(w, "---------\t----\t------\t--------\t------\t-------")
+	limit := len(rollups)
+	if topN > 0 && topN < limit {
+		limit = topN
+	}
+	for _, r := range rollups[:limit] {
+		marker := ""
+		if r.AnyUnpriced {
+			marker = " *"
+		}
+		fmt.Fprintf(w, "%s%s\t%d\t%.2f\t%.0f\t$%.4f\t$%.2f\n",
+			r.Namespace, marker,
+			r.Pods, r.CPURequestC, r.MemRequestMB,
+			r.HourlyUSD, r.MonthlyUSD,
+		)
+	}
+	w.Flush()
+}
+
+func printNodeRollup(out io.Writer, report *cost.WorkloadCostReport) {
+	// Roll pods up by node so operators can see allocated-share-of-node.
+	type nodeAgg struct {
+		hourly        float64
+		cpuRequestC   float64
+		memRequestMB  float64
+		dominantShare float64
+		pods          int
+	}
+	byNode := map[string]*nodeAgg{}
+	for _, p := range report.Pods {
+		n, ok := byNode[p.Node]
+		if !ok {
+			n = &nodeAgg{}
+			byNode[p.Node] = n
+		}
+		n.hourly += p.HourlyUSD
+		n.cpuRequestC += p.CPURequestC
+		n.memRequestMB += p.MemRequestMB
+		n.dominantShare += p.DominantShare
+		n.pods++
+	}
+
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NODE\tINSTANCE\tPRICED\tPODS\tALLOC CPU\tALLOC MEM\tREQUESTED CPU\tREQUESTED MEM\tBOOKED %\tNODE $/HR\tATTRIBUTED $/HR")
+	fmt.Fprintln(w, "----\t--------\t------\t----\t---------\t---------\t-------------\t-------------\t--------\t---------\t---------------")
+	for _, n := range report.Nodes {
+		agg := byNode[n.Name]
+		if agg == nil {
+			agg = &nodeAgg{}
+		}
+		priced := "no"
+		if n.PriceKnown {
+			priced = "yes"
+		}
+		bookedShare := 0.0
+		if n.AllocCPU > 0 || n.AllocMemMB > 0 {
+			bookedShare = agg.dominantShare
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%.2f\t%.0fMi\t%.2f\t%.0fMi\t%.1f%%\t$%.4f\t$%.4f\n",
+			truncate(n.Name, 40),
+			n.InstanceType,
+			priced,
+			agg.pods,
+			n.AllocCPU, n.AllocMemMB,
+			agg.cpuRequestC, agg.memRequestMB,
+			bookedShare*100,
+			n.HourlyUSD,
+			agg.hourly,
+		)
+	}
+	w.Flush()
+}
+
+func formatUSD(v float64, known bool) string {
+	if !known {
+		return "—"
+	}
+	return fmt.Sprintf("$%.4f", v)
+}

--- a/cmd/k8s_cost_print_test.go
+++ b/cmd/k8s_cost_print_test.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/bgdnvk/clanker/internal/k8s/cost"
+)
+
+func TestPrintK8sCostReport_Nil(t *testing.T) {
+	var buf bytes.Buffer
+	printK8sCostReport(&buf, nil, "pod", 25)
+	if !strings.Contains(buf.String(), "No cost report") {
+		t.Errorf("expected nil-report message, got %q", buf.String())
+	}
+}
+
+func TestPrintK8sCostReport_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	printK8sCostReport(&buf, &cost.WorkloadCostReport{
+		NodesScanned: 3, PodsScanned: 0,
+	}, "pod", 25)
+	out := buf.String()
+	if !strings.Contains(out, "Scanned 3 node(s), 0 pod(s)") {
+		t.Errorf("expected header, got %q", out)
+	}
+	if !strings.Contains(out, "No pods attributed") {
+		t.Errorf("expected empty-state message, got %q", out)
+	}
+}
+
+func TestPrintK8sCostReport_PodTopN(t *testing.T) {
+	pods := []cost.PodAttribution{
+		{Namespace: "prod", Workload: "api", WorkloadKind: "Deployment", Pod: "api-1", Node: "node-a", DominantShare: 0.5, HourlyUSD: 0.1, MonthlyUSD: 73, PriceKnown: true},
+		{Namespace: "prod", Workload: "api", WorkloadKind: "Deployment", Pod: "api-2", Node: "node-a", DominantShare: 0.4, HourlyUSD: 0.08, MonthlyUSD: 58.4, PriceKnown: true},
+		{Namespace: "default", Workload: "queue", WorkloadKind: "Deployment", Pod: "queue-1", Node: "node-b", DominantShare: 0.2, HourlyUSD: 0, MonthlyUSD: 0, PriceKnown: false},
+	}
+	var buf bytes.Buffer
+	printK8sCostReport(&buf, &cost.WorkloadCostReport{
+		NodesScanned: 2, PodsScanned: 3, Pods: pods, TotalHourlyUSD: 0.18, TotalMonthlyUSD: 131.4,
+	}, "pod", 2)
+	out := buf.String()
+
+	// Should show first 2 pods + a (showing top 2 of 3) message.
+	if !strings.Contains(out, "api-1") || !strings.Contains(out, "api-2") {
+		t.Errorf("expected api-1 and api-2 in output, got:\n%s", out)
+	}
+	if strings.Contains(out, "queue-1") {
+		t.Errorf("queue-1 should be cut off by --top 2, got:\n%s", out)
+	}
+	if !strings.Contains(out, "showing top 2 of 3") {
+		t.Errorf("expected truncation note, got:\n%s", out)
+	}
+	// Unpriced pod renders as "—" — verify formatUSD path even though
+	// queue isn't shown here, by placing it first.
+}
+
+func TestPrintK8sCostReport_WorkloadAggregation(t *testing.T) {
+	pods := []cost.PodAttribution{
+		{Namespace: "prod", Workload: "api", WorkloadKind: "Deployment", HourlyUSD: 0.1, MonthlyUSD: 73, PriceKnown: true},
+		{Namespace: "prod", Workload: "api", WorkloadKind: "Deployment", HourlyUSD: 0, MonthlyUSD: 0, PriceKnown: false},
+	}
+	var buf bytes.Buffer
+	printK8sCostReport(&buf, &cost.WorkloadCostReport{
+		PodsScanned: 2, Pods: pods,
+	}, "workload", 25)
+	out := buf.String()
+
+	if !strings.Contains(out, "Deployment") || !strings.Contains(out, "api") {
+		t.Errorf("expected Deployment/api row, got:\n%s", out)
+	}
+	if !strings.Contains(out, "*") {
+		t.Errorf("expected unpriced marker, got:\n%s", out)
+	}
+}
+
+func TestPrintK8sCostReport_NamespaceAggregation(t *testing.T) {
+	pods := []cost.PodAttribution{
+		{Namespace: "prod", HourlyUSD: 0.1, MonthlyUSD: 73, PriceKnown: true},
+		{Namespace: "default", HourlyUSD: 0.02, MonthlyUSD: 14.6, PriceKnown: true},
+	}
+	var buf bytes.Buffer
+	printK8sCostReport(&buf, &cost.WorkloadCostReport{
+		PodsScanned: 2, Pods: pods,
+	}, "namespace", 25)
+	out := buf.String()
+
+	if !strings.Contains(out, "prod") || !strings.Contains(out, "default") {
+		t.Errorf("expected both namespaces, got:\n%s", out)
+	}
+	// prod has higher cost — should appear first.
+	if strings.Index(out, "prod") > strings.Index(out, "default") {
+		t.Errorf("expected prod (higher cost) before default, got:\n%s", out)
+	}
+}
+
+func TestPrintK8sCostReport_NodeAggregation(t *testing.T) {
+	report := &cost.WorkloadCostReport{
+		NodesScanned: 1,
+		PodsScanned:  2,
+		Nodes: []cost.NodeInfo{
+			{Name: "node-a", InstanceType: "m5.xlarge", AllocCPU: 4, AllocMemMB: 16384, HourlyUSD: 0.192, PriceKnown: true},
+		},
+		Pods: []cost.PodAttribution{
+			{Namespace: "prod", Pod: "p1", Node: "node-a", CPURequestC: 1, MemRequestMB: 2048, DominantShare: 0.25, HourlyUSD: 0.048, PriceKnown: true},
+			{Namespace: "prod", Pod: "p2", Node: "node-a", CPURequestC: 0.5, MemRequestMB: 1024, DominantShare: 0.125, HourlyUSD: 0.024, PriceKnown: true},
+		},
+	}
+	var buf bytes.Buffer
+	printK8sCostReport(&buf, report, "node", 25)
+	out := buf.String()
+
+	for _, want := range []string{"node-a", "m5.xlarge", "yes", "$0.1920", "$0.0720"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output, got:\n%s", want, out)
+		}
+	}
+}

--- a/cmd/k8s_karpenter_recommendations.go
+++ b/cmd/k8s_karpenter_recommendations.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/bgdnvk/clanker/internal/k8s"
+	"github.com/bgdnvk/clanker/internal/k8s/sre"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var k8sAutoscalerRecsCmd = &cobra.Command{
+	Use:   "recommendations",
+	Short: "Karpenter NodePool / NodeClaim recommendations",
+	Long: `Analyse Karpenter NodePools and NodeClaims for cost / reliability issues:
+
+  • NodePool with no consolidation policy (idle nodes never deprovisioned)
+  • NodePool with no spec.limits (unbounded growth → runaway cost)
+  • Stale NodePools (>7d old, never provisioned)
+  • NodeClaims stuck not-Ready (provisioner / quota issue)
+  • Multiple unweighted NodePools (Karpenter picks arbitrarily)
+
+Read-only — only kubectl get is invoked.
+
+Examples:
+  clanker k8s autoscaler recommendations
+  clanker k8s autoscaler recommendations -o json`,
+	RunE: runKarpenterRecs,
+}
+
+func init() {
+	k8sAutoscalerCmd.AddCommand(k8sAutoscalerRecsCmd)
+	// --output / --kubeconfig / --context come from k8sAutoscalerCmd's
+	// PersistentFlags, defined alongside `validate`.
+}
+
+func runKarpenterRecs(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	debug := viper.GetBool("debug")
+
+	client := k8s.NewClient(autoscalerKubeconfig, autoscalerContext, debug)
+	advisor := sre.NewKarpenterAdvisor(k8s.NewSREAdapter(client), debug)
+
+	report, err := advisor.Advise(ctx)
+	if err != nil {
+		return fmt.Errorf("karpenter advisor failed: %w", err)
+	}
+
+	switch strings.ToLower(autoscalerOutput) {
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	default:
+		printKarpenterRecsReport(os.Stdout, report)
+		return nil
+	}
+}
+
+func printKarpenterRecsReport(out io.Writer, report *sre.KarpenterAdvisorReport) {
+	if report == nil {
+		fmt.Fprintln(out, "No advisor report.")
+		return
+	}
+	if !report.Installed {
+		fmt.Fprintln(out, "Karpenter not installed in this cluster.")
+		if report.Notes != "" {
+			fmt.Fprintf(out, "Notes: %s\n", report.Notes)
+		}
+		return
+	}
+
+	fmt.Fprintf(out, "Karpenter detected — %d NodePool(s), %d NodeClaim(s)\n",
+		report.NodePools, report.NodeClaims)
+	if report.Notes != "" {
+		fmt.Fprintf(out, "Notes: %s\n", report.Notes)
+	}
+	if len(report.Recommendations) == 0 {
+		fmt.Fprintln(out, "\nNo recommendations — Karpenter looks healthy. ✓")
+		return
+	}
+
+	fmt.Fprintf(out, "\n%d recommendation(s):\n", len(report.Recommendations))
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "SEVERITY\tRESOURCE\tNAME\tISSUE")
+	fmt.Fprintln(w, "--------\t--------\t----\t-----")
+	for _, r := range report.Recommendations {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+			strings.ToUpper(string(r.Severity)),
+			r.Resource,
+			truncate(r.Name, 40),
+			truncate(r.Issue, 60),
+		)
+	}
+	w.Flush()
+
+	fmt.Fprintln(out, "\nDetails:")
+	for _, r := range report.Recommendations {
+		fmt.Fprintf(out, "  • [%s] %s/%s — %s\n", r.Severity, r.Resource, r.Name, r.Issue)
+		if r.Detail != "" {
+			fmt.Fprintf(out, "    %s\n", r.Detail)
+		}
+		if r.Suggestion != "" {
+			fmt.Fprintf(out, "    → %s\n", r.Suggestion)
+		}
+	}
+}

--- a/cmd/k8s_karpenter_recommendations_print_test.go
+++ b/cmd/k8s_karpenter_recommendations_print_test.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/bgdnvk/clanker/internal/k8s/sre"
+)
+
+func TestPrintKarpenterRecsReport_Nil(t *testing.T) {
+	var buf bytes.Buffer
+	printKarpenterRecsReport(&buf, nil)
+	if !strings.Contains(buf.String(), "No advisor report") {
+		t.Errorf("expected nil-report message, got %q", buf.String())
+	}
+}
+
+func TestPrintKarpenterRecsReport_NotInstalled(t *testing.T) {
+	var buf bytes.Buffer
+	printKarpenterRecsReport(&buf, &sre.KarpenterAdvisorReport{Installed: false})
+	if !strings.Contains(buf.String(), "Karpenter not installed") {
+		t.Errorf("expected not-installed message, got %q", buf.String())
+	}
+}
+
+func TestPrintKarpenterRecsReport_HealthyInstall(t *testing.T) {
+	var buf bytes.Buffer
+	printKarpenterRecsReport(&buf, &sre.KarpenterAdvisorReport{
+		Installed: true, NodePools: 2, NodeClaims: 3,
+	})
+	out := buf.String()
+	if !strings.Contains(out, "2 NodePool(s)") {
+		t.Errorf("expected NodePool count in output, got %q", out)
+	}
+	if !strings.Contains(out, "looks healthy") {
+		t.Errorf("expected healthy message, got %q", out)
+	}
+}
+
+func TestPrintKarpenterRecsReport_RendersDetails(t *testing.T) {
+	var buf bytes.Buffer
+	printKarpenterRecsReport(&buf, &sre.KarpenterAdvisorReport{
+		Installed: true, NodePools: 1, NodeClaims: 0,
+		Recommendations: []sre.KarpenterRecommendation{
+			{Severity: sre.SeverityWarning, Resource: "nodepool", Name: "default", Issue: "no consolidation policy set", Detail: "policy is empty", Suggestion: "set spec.disruption..."},
+		},
+	})
+	out := buf.String()
+
+	for _, want := range []string{
+		"WARNING",
+		"nodepool",
+		"default",
+		"no consolidation policy",
+		"Details:",
+		"set spec.disruption",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output, got:\n%s", want, out)
+		}
+	}
+}

--- a/cmd/k8s_workloads_audit.go
+++ b/cmd/k8s_workloads_audit.go
@@ -1,0 +1,147 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/bgdnvk/clanker/internal/k8s"
+	"github.com/bgdnvk/clanker/internal/k8s/sre"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	workloadsAuditOutput     string
+	workloadsAuditKubeconfig string
+	workloadsAuditContext    string
+	workloadsAuditSeverity   string
+)
+
+var k8sWorkloadsCmd = &cobra.Command{
+	Use:   "workloads",
+	Short: "Inspect Kubernetes workload posture",
+	Long:  `Inspect or audit pod / deployment / node health signals cluster-wide.`,
+}
+
+var k8sWorkloadsAuditCmd = &cobra.Command{
+	Use:   "audit",
+	Short: "Roll cluster-wide workload health issues into a categorised report",
+	Long: `Surface what's broken in the cluster in one shot:
+
+  • CrashLoopBackOff containers
+  • OOMKilled containers
+  • ImagePullBackOff / ErrImagePull
+  • Pods with restart spikes (≥5 restarts)
+  • Pods stuck NotReady
+  • Nodes under pressure (Memory/Disk/PID/NetworkUnavailable)
+
+Read-only — only kubectl get is invoked.
+
+Examples:
+  clanker k8s workloads audit
+  clanker k8s workloads audit -o json
+  clanker k8s workloads audit --severity warning`,
+	RunE: runWorkloadsAudit,
+}
+
+func init() {
+	k8sCmd.AddCommand(k8sWorkloadsCmd)
+	k8sWorkloadsCmd.AddCommand(k8sWorkloadsAuditCmd)
+	k8sWorkloadsCmd.PersistentFlags().StringVarP(&workloadsAuditOutput, "output", "o", "table", "Output format (table, json)")
+	k8sWorkloadsCmd.PersistentFlags().StringVar(&workloadsAuditKubeconfig, "kubeconfig", "", "Path to kubeconfig (default: ~/.kube/config)")
+	k8sWorkloadsCmd.PersistentFlags().StringVar(&workloadsAuditContext, "context", "", "kubectl context to use")
+	k8sWorkloadsAuditCmd.Flags().StringVar(&workloadsAuditSeverity, "severity", "", "Minimum severity to surface in Issues (info, warning, critical) — default shows all")
+}
+
+func runWorkloadsAudit(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+	debug := viper.GetBool("debug")
+
+	client := k8s.NewClient(workloadsAuditKubeconfig, workloadsAuditContext, debug)
+	auditor := sre.NewWorkloadHealthAuditor(k8s.NewSREAdapter(client), debug)
+
+	report, err := auditor.Audit(ctx)
+	if err != nil {
+		return fmt.Errorf("workload audit failed: %w", err)
+	}
+
+	report.Issues = filterIssuesBySeverity(report.Issues, workloadsAuditSeverity)
+
+	switch strings.ToLower(workloadsAuditOutput) {
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	default:
+		printWorkloadsAuditReport(os.Stdout, report)
+		return nil
+	}
+}
+
+// filterIssuesBySeverity is reused from cmd/k8s_health.go.
+
+func printWorkloadsAuditReport(out io.Writer, report *sre.WorkloadHealthReport) {
+	if report == nil {
+		fmt.Fprintln(out, "No workload health report.")
+		return
+	}
+
+	fmt.Fprintf(out, "Total issues: %d   (critical %d, warning %d, info %d)\n",
+		report.TotalIssues, report.Critical, report.Warning, report.Info)
+	if report.TotalIssues == 0 {
+		fmt.Fprintln(out, "Cluster is healthy. ✓")
+		return
+	}
+
+	fmt.Fprintln(out, "\nBy category:")
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "CATEGORY\tCOUNT")
+	fmt.Fprintln(w, "--------\t-----")
+	for _, c := range report.ByCategory {
+		fmt.Fprintf(w, "%s\t%d\n", c.Category, c.Count)
+	}
+	w.Flush()
+
+	if len(report.HotPods) > 0 {
+		fmt.Fprintln(out, "\nHot pods (most issues):")
+		hw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(hw, "NAMESPACE/POD\tISSUES\tCATEGORIES")
+		fmt.Fprintln(hw, "-------------\t------\t----------")
+		for _, p := range report.HotPods {
+			cats := make([]string, len(p.Categories))
+			for i, c := range p.Categories {
+				cats[i] = string(c)
+			}
+			fmt.Fprintf(hw, "%s/%s\t%d\t%s\n",
+				p.Namespace, p.Pod, p.Issues, strings.Join(cats, ", "))
+		}
+		hw.Flush()
+	}
+
+	if len(report.Issues) > 0 && len(report.Issues) <= 50 {
+		fmt.Fprintf(out, "\n%d issue(s):\n", len(report.Issues))
+		iw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(iw, "SEVERITY\tKIND\tNAMESPACE/NAME\tMESSAGE")
+		fmt.Fprintln(iw, "--------\t----\t--------------\t-------")
+		for _, i := range report.Issues {
+			ns := i.Namespace
+			if ns == "" {
+				ns = "-"
+			}
+			fmt.Fprintf(iw, "%s\t%s\t%s/%s\t%s\n",
+				strings.ToUpper(string(i.Severity)),
+				i.ResourceType,
+				ns, i.ResourceName,
+				truncate(i.Message, 80),
+			)
+		}
+		iw.Flush()
+	} else if len(report.Issues) > 50 {
+		fmt.Fprintf(out, "\n%d issue(s) — pass -o json for full list.\n", len(report.Issues))
+	}
+}

--- a/cmd/k8s_workloads_audit_print_test.go
+++ b/cmd/k8s_workloads_audit_print_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/bgdnvk/clanker/internal/k8s/sre"
+)
+
+func TestPrintWorkloadsAuditReport_Nil(t *testing.T) {
+	var buf bytes.Buffer
+	printWorkloadsAuditReport(&buf, nil)
+	if !strings.Contains(buf.String(), "No workload health report") {
+		t.Errorf("expected nil-report message, got %q", buf.String())
+	}
+}
+
+func TestPrintWorkloadsAuditReport_Healthy(t *testing.T) {
+	var buf bytes.Buffer
+	printWorkloadsAuditReport(&buf, &sre.WorkloadHealthReport{TotalIssues: 0})
+	out := buf.String()
+	if !strings.Contains(out, "Total issues: 0") {
+		t.Errorf("expected zero-issues header, got %q", out)
+	}
+	if !strings.Contains(out, "Cluster is healthy") {
+		t.Errorf("expected healthy message, got %q", out)
+	}
+}
+
+func TestPrintWorkloadsAuditReport_RendersSections(t *testing.T) {
+	report := &sre.WorkloadHealthReport{
+		TotalIssues: 3, Critical: 2, Warning: 1,
+		ByCategory: []sre.CategoryCount{
+			{Category: sre.HealthCategoryCrashLoop, Count: 2},
+			{Category: sre.HealthCategoryOOMKilled, Count: 1},
+		},
+		HotPods: []sre.HotPod{
+			{Namespace: "prod", Pod: "api-1", Issues: 2, Categories: []sre.HealthCategory{sre.HealthCategoryCrashLoop, sre.HealthCategoryRestartSpike}},
+		},
+		Issues: []sre.Issue{
+			{Severity: sre.SeverityCritical, ResourceType: sre.ResourcePod, ResourceName: "api-1", Namespace: "prod", Message: "Container app is in CrashLoopBackOff"},
+		},
+	}
+	var buf bytes.Buffer
+	printWorkloadsAuditReport(&buf, report)
+	out := buf.String()
+
+	for _, want := range []string{
+		"Total issues: 3",
+		"critical 2",
+		"By category",
+		"CrashLoopBackOff",
+		"Hot pods",
+		"prod/api-1",
+		"CRITICAL",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output, got:\n%s", want, out)
+		}
+	}
+}
+
+// TestFilterIssuesBySeverity already lives in cmd/k8s_health_test.go —
+// the function is shared so we don't duplicate the test here.

--- a/internal/cost/aws_savings.go
+++ b/internal/cost/aws_savings.go
@@ -1,0 +1,295 @@
+package cost
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/costexplorer"
+	"github.com/aws/aws-sdk-go-v2/service/costexplorer/types"
+)
+
+// GetSavingsRecommendations fetches AWS Savings Plan + Reserved Instance
+// purchase recommendations from Cost Explorer. Both are pulled in one
+// call (different SDK methods) and merged into a single report so the
+// CLI can show "here is the highest-savings commitment, regardless of
+// shape" instead of forcing the operator to switch tabs.
+//
+// Cost Explorer returns recommendations only for accounts with usage
+// history; brand-new accounts produce an empty list and a Note rather
+// than an error.
+func (p *AWSProvider) GetSavingsRecommendations(ctx context.Context, lookback, term string) (*SavingsReport, error) {
+	lookback = normaliseLookback(lookback)
+	term = normaliseTerm(term)
+
+	report := &SavingsReport{
+		GeneratedAt: time.Now().UTC(),
+		Provider:    "aws",
+		Lookback:    lookback,
+		Term:        term,
+	}
+
+	// 1) Savings Plans — three families: Compute, EC2 Instance, SageMaker.
+	for _, family := range []types.SupportedSavingsPlansType{
+		types.SupportedSavingsPlansTypeComputeSp,
+		types.SupportedSavingsPlansTypeEc2InstanceSp,
+		types.SupportedSavingsPlansTypeSagemakerSp,
+	} {
+		recs, err := p.fetchSavingsPlanRecs(ctx, family, lookback, term)
+		if err != nil {
+			// Don't fail the whole report on one family — Cost Explorer
+			// occasionally returns AccessDeniedException for SageMaker
+			// when the account never used it. Surface the issue in
+			// Notes instead so the operator knows what was skipped.
+			appendCostNote(&report.Notes, fmt.Sprintf("%s recommendations skipped: %v", family, err))
+			continue
+		}
+		report.Recommendations = append(report.Recommendations, recs...)
+	}
+
+	// 2) Reserved Instances — services that have RI offerings on
+	// Cost Explorer. Each call hits one service.
+	for _, svc := range []string{"AmazonEC2", "AmazonRDS", "AmazonElastiCache", "AmazonOpenSearchService", "AmazonRedshift"} {
+		recs, err := p.fetchRIRecs(ctx, svc, lookback, term)
+		if err != nil {
+			appendCostNote(&report.Notes, fmt.Sprintf("%s RI recommendations skipped: %v", svc, err))
+			continue
+		}
+		report.Recommendations = append(report.Recommendations, recs...)
+	}
+
+	// Aggregate + sort.
+	for _, r := range report.Recommendations {
+		report.TotalEstimatedSavings += r.EstimatedSavings
+	}
+	sortSavingsRecsByEstimatedSavings(report.Recommendations)
+
+	if len(report.Recommendations) == 0 && report.Notes == "" {
+		report.Notes = "no commitment recommendations — account may not have enough usage history"
+	}
+	return report, nil
+}
+
+func (p *AWSProvider) fetchSavingsPlanRecs(ctx context.Context, family types.SupportedSavingsPlansType, lookback, term string) ([]SavingsRecommendation, error) {
+	out, err := p.client.GetSavingsPlansPurchaseRecommendation(ctx, &costexplorer.GetSavingsPlansPurchaseRecommendationInput{
+		SavingsPlansType:     family,
+		TermInYears:          types.TermInYears(term),
+		PaymentOption:        types.PaymentOptionNoUpfront,
+		LookbackPeriodInDays: types.LookbackPeriodInDays(lookback),
+		PageSize:             50,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if out.SavingsPlansPurchaseRecommendation == nil {
+		return nil, nil
+	}
+
+	familyLabel := savingsPlanFamilyLabel(family)
+	recs := make([]SavingsRecommendation, 0, len(out.SavingsPlansPurchaseRecommendation.SavingsPlansPurchaseRecommendationDetails))
+	for _, d := range out.SavingsPlansPurchaseRecommendation.SavingsPlansPurchaseRecommendationDetails {
+		monthlySavings := parseFloatString(d.EstimatedMonthlySavingsAmount)
+		percent := parseFloatString(d.EstimatedSavingsPercentage)
+		hourlyCommit := parseFloatString(d.HourlyCommitmentToPurchase)
+		upfront := parseFloatString(d.UpfrontCost)
+
+		recs = append(recs, SavingsRecommendation{
+			Provider:           "aws",
+			Kind:               SavingsKindSavingsPlan,
+			Family:             familyLabel,
+			Term:               term,
+			PaymentOption:      string(types.PaymentOptionNoUpfront),
+			UpfrontCost:        upfront,
+			HourlyCommitment:   hourlyCommit,
+			EstimatedSavings:   monthlySavings,
+			EstimatedSavingsPc: percent,
+			BreakevenMonths:    breakevenMonths(upfront, monthlySavings),
+			Detail:             savingsPlanDetail(d),
+		})
+	}
+	return recs, nil
+}
+
+func (p *AWSProvider) fetchRIRecs(ctx context.Context, service, lookback, term string) ([]SavingsRecommendation, error) {
+	out, err := p.client.GetReservationPurchaseRecommendation(ctx, &costexplorer.GetReservationPurchaseRecommendationInput{
+		Service:              aws.String(service),
+		TermInYears:          types.TermInYears(term),
+		PaymentOption:        types.PaymentOptionNoUpfront,
+		LookbackPeriodInDays: types.LookbackPeriodInDays(lookback),
+		PageSize:             50,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(out.Recommendations) == 0 {
+		return nil, nil
+	}
+
+	var recs []SavingsRecommendation
+	for _, rec := range out.Recommendations {
+		for _, d := range rec.RecommendationDetails {
+			monthlySavings := parseFloatString(d.EstimatedMonthlySavingsAmount)
+			percent := parseFloatString(d.EstimatedMonthlySavingsPercentage)
+			upfront := parseFloatString(d.UpfrontCost)
+
+			recs = append(recs, SavingsRecommendation{
+				Provider:           "aws",
+				Kind:               SavingsKindReservedInstance,
+				Service:            riServiceLabel(service),
+				Family:             instanceFamilyFromDetails(d.InstanceDetails),
+				Term:               term,
+				PaymentOption:      string(types.PaymentOptionNoUpfront),
+				UpfrontCost:        upfront,
+				EstimatedSavings:   monthlySavings,
+				EstimatedSavingsPc: percent,
+				BreakevenMonths:    breakevenMonths(upfront, monthlySavings),
+				Detail:             riDetail(d),
+			})
+		}
+	}
+	return recs, nil
+}
+
+func parseFloatString(s *string) float64 {
+	if s == nil {
+		return 0
+	}
+	v, err := strconv.ParseFloat(strings.TrimSpace(*s), 64)
+	if err != nil {
+		return 0
+	}
+	return v
+}
+
+func breakevenMonths(upfront, monthlySavings float64) float64 {
+	if monthlySavings <= 0 {
+		return 0
+	}
+	return upfront / monthlySavings
+}
+
+func sortSavingsRecsByEstimatedSavings(recs []SavingsRecommendation) {
+	// Insertion sort — fine for the small list sizes (<100) Cost Explorer
+	// returns. Avoids an import cycle with sort+ pulled into types.go.
+	for i := 1; i < len(recs); i++ {
+		for j := i; j > 0 && recs[j-1].EstimatedSavings < recs[j].EstimatedSavings; j-- {
+			recs[j-1], recs[j] = recs[j], recs[j-1]
+		}
+	}
+}
+
+func normaliseLookback(s string) string {
+	switch strings.ToUpper(strings.TrimSpace(s)) {
+	case "SEVEN_DAYS", "7":
+		return "SEVEN_DAYS"
+	case "THIRTY_DAYS", "30":
+		return "THIRTY_DAYS"
+	case "SIXTY_DAYS", "60", "":
+		return "SIXTY_DAYS"
+	}
+	return "SIXTY_DAYS"
+}
+
+func normaliseTerm(s string) string {
+	switch strings.ToUpper(strings.TrimSpace(s)) {
+	case "THREE_YEARS", "3":
+		return "THREE_YEARS"
+	case "ONE_YEAR", "1", "":
+		return "ONE_YEAR"
+	}
+	return "ONE_YEAR"
+}
+
+func savingsPlanFamilyLabel(t types.SupportedSavingsPlansType) string {
+	switch t {
+	case types.SupportedSavingsPlansTypeComputeSp:
+		return "Compute"
+	case types.SupportedSavingsPlansTypeEc2InstanceSp:
+		return "EC2 Instance"
+	case types.SupportedSavingsPlansTypeSagemakerSp:
+		return "SageMaker"
+	}
+	return string(t)
+}
+
+func savingsPlanDetail(d types.SavingsPlansPurchaseRecommendationDetail) string {
+	parts := []string{}
+	if d.SavingsPlansDetails != nil {
+		if v := d.SavingsPlansDetails.InstanceFamily; v != nil && *v != "" {
+			parts = append(parts, "family="+*v)
+		}
+		if v := d.SavingsPlansDetails.Region; v != nil && *v != "" {
+			parts = append(parts, "region="+*v)
+		}
+	}
+	if v := d.CurrentAverageHourlyOnDemandSpend; v != nil && *v != "" {
+		parts = append(parts, "current $/hr="+*v)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func riServiceLabel(svc string) string {
+	switch svc {
+	case "AmazonEC2":
+		return "EC2"
+	case "AmazonRDS":
+		return "RDS"
+	case "AmazonElastiCache":
+		return "ElastiCache"
+	case "AmazonOpenSearchService":
+		return "OpenSearch"
+	case "AmazonRedshift":
+		return "Redshift"
+	}
+	return svc
+}
+
+func instanceFamilyFromDetails(d *types.InstanceDetails) string {
+	if d == nil {
+		return ""
+	}
+	switch {
+	case d.EC2InstanceDetails != nil && d.EC2InstanceDetails.Family != nil:
+		return *d.EC2InstanceDetails.Family
+	case d.RDSInstanceDetails != nil && d.RDSInstanceDetails.Family != nil:
+		return *d.RDSInstanceDetails.Family
+	case d.ElastiCacheInstanceDetails != nil && d.ElastiCacheInstanceDetails.Family != nil:
+		return *d.ElastiCacheInstanceDetails.Family
+	case d.RedshiftInstanceDetails != nil && d.RedshiftInstanceDetails.Family != nil:
+		return *d.RedshiftInstanceDetails.Family
+	}
+	return ""
+}
+
+func riDetail(d types.ReservationPurchaseRecommendationDetail) string {
+	parts := []string{}
+	if v := d.RecommendedNumberOfInstancesToPurchase; v != nil && *v != "" {
+		parts = append(parts, "qty="+*v)
+	}
+	if d.InstanceDetails != nil && d.InstanceDetails.EC2InstanceDetails != nil {
+		ec2 := d.InstanceDetails.EC2InstanceDetails
+		if ec2.InstanceType != nil && *ec2.InstanceType != "" {
+			parts = append(parts, "instance="+*ec2.InstanceType)
+		}
+		if ec2.Region != nil && *ec2.Region != "" {
+			parts = append(parts, "region="+*ec2.Region)
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+// appendCostNote concatenates a non-empty note onto an accumulator. Local
+// to this package so we don't depend on the sre helper.
+func appendCostNote(dst *string, note string) {
+	if note == "" {
+		return
+	}
+	if *dst == "" {
+		*dst = note
+		return
+	}
+	*dst += "; " + note
+}

--- a/internal/cost/aws_savings_test.go
+++ b/internal/cost/aws_savings_test.go
@@ -1,0 +1,216 @@
+package cost
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/costexplorer/types"
+)
+
+func strPtr(s string) *string { return &s }
+
+func TestNormaliseLookback(t *testing.T) {
+	cases := map[string]string{
+		"":              "SIXTY_DAYS",
+		"7":             "SEVEN_DAYS",
+		"seven_days":    "SEVEN_DAYS",
+		"30":            "THIRTY_DAYS",
+		"60":            "SIXTY_DAYS",
+		"sixty_days":    "SIXTY_DAYS",
+		"  THIRTY_DAYS": "THIRTY_DAYS",
+		"garbage":       "SIXTY_DAYS", // fallback
+	}
+	for in, want := range cases {
+		if got := normaliseLookback(in); got != want {
+			t.Errorf("normaliseLookback(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestNormaliseTerm(t *testing.T) {
+	cases := map[string]string{
+		"":            "ONE_YEAR",
+		"1":           "ONE_YEAR",
+		"one_year":    "ONE_YEAR",
+		"3":           "THREE_YEARS",
+		"three_years": "THREE_YEARS",
+		"  3":         "THREE_YEARS",
+		"garbage":     "ONE_YEAR",
+	}
+	for in, want := range cases {
+		if got := normaliseTerm(in); got != want {
+			t.Errorf("normaliseTerm(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestParseFloatString(t *testing.T) {
+	if v := parseFloatString(nil); v != 0 {
+		t.Errorf("nil → %v, want 0", v)
+	}
+	cases := map[string]float64{
+		"":        0,
+		"   ":     0,
+		"123.45":  123.45,
+		" 0.001 ": 0.001,
+		"not-a-#": 0,
+	}
+	for in, want := range cases {
+		s := in
+		if got := parseFloatString(&s); got != want {
+			t.Errorf("parseFloatString(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestBreakevenMonths(t *testing.T) {
+	cases := []struct {
+		upfront float64
+		monthly float64
+		want    float64
+	}{
+		{0, 100, 0},     // no upfront → instant
+		{1200, 100, 12}, // 1y to break even
+		{600, 0, 0},     // no savings → guard against div-by-zero
+		{600, -10, 0},   // negative savings clamped to zero
+		{0, 0, 0},
+	}
+	for _, c := range cases {
+		if got := breakevenMonths(c.upfront, c.monthly); got != c.want {
+			t.Errorf("breakevenMonths(%v, %v) = %v, want %v", c.upfront, c.monthly, got, c.want)
+		}
+	}
+}
+
+func TestSortSavingsRecsByEstimatedSavings(t *testing.T) {
+	recs := []SavingsRecommendation{
+		{Service: "low", EstimatedSavings: 10},
+		{Service: "high", EstimatedSavings: 500},
+		{Service: "mid", EstimatedSavings: 100},
+		{Service: "zero", EstimatedSavings: 0},
+	}
+	sortSavingsRecsByEstimatedSavings(recs)
+	wantOrder := []string{"high", "mid", "low", "zero"}
+	for i, w := range wantOrder {
+		if recs[i].Service != w {
+			t.Errorf("position %d = %q, want %q (full: %+v)", i, recs[i].Service, w, recs)
+		}
+	}
+}
+
+func TestAppendCostNote(t *testing.T) {
+	var s string
+	appendCostNote(&s, "")
+	if s != "" {
+		t.Errorf("empty append should be noop, got %q", s)
+	}
+	appendCostNote(&s, "first")
+	if s != "first" {
+		t.Errorf("first append = %q, want %q", s, "first")
+	}
+	appendCostNote(&s, "second")
+	if s != "first; second" {
+		t.Errorf("second append = %q, want %q", s, "first; second")
+	}
+}
+
+func TestSavingsPlanFamilyLabel(t *testing.T) {
+	cases := map[types.SupportedSavingsPlansType]string{
+		types.SupportedSavingsPlansTypeComputeSp:     "Compute",
+		types.SupportedSavingsPlansTypeEc2InstanceSp: "EC2 Instance",
+		types.SupportedSavingsPlansTypeSagemakerSp:   "SageMaker",
+	}
+	for in, want := range cases {
+		if got := savingsPlanFamilyLabel(in); got != want {
+			t.Errorf("savingsPlanFamilyLabel(%v) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestRIServiceLabel(t *testing.T) {
+	cases := map[string]string{
+		"AmazonEC2":               "EC2",
+		"AmazonRDS":               "RDS",
+		"AmazonElastiCache":       "ElastiCache",
+		"AmazonOpenSearchService": "OpenSearch",
+		"AmazonRedshift":          "Redshift",
+		"SomethingElse":           "SomethingElse", // fallback
+	}
+	for in, want := range cases {
+		if got := riServiceLabel(in); got != want {
+			t.Errorf("riServiceLabel(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestInstanceFamilyFromDetails(t *testing.T) {
+	if v := instanceFamilyFromDetails(nil); v != "" {
+		t.Errorf("nil details → %q, want empty", v)
+	}
+
+	ec2 := &types.InstanceDetails{
+		EC2InstanceDetails: &types.EC2InstanceDetails{Family: strPtr("m5")},
+	}
+	if v := instanceFamilyFromDetails(ec2); v != "m5" {
+		t.Errorf("ec2 → %q, want m5", v)
+	}
+
+	rds := &types.InstanceDetails{
+		RDSInstanceDetails: &types.RDSInstanceDetails{Family: strPtr("db.r6g")},
+	}
+	if v := instanceFamilyFromDetails(rds); v != "db.r6g" {
+		t.Errorf("rds → %q, want db.r6g", v)
+	}
+
+	// Empty details → empty.
+	if v := instanceFamilyFromDetails(&types.InstanceDetails{}); v != "" {
+		t.Errorf("empty details → %q, want empty", v)
+	}
+}
+
+func TestSavingsPlanDetail(t *testing.T) {
+	d := types.SavingsPlansPurchaseRecommendationDetail{
+		SavingsPlansDetails: &types.SavingsPlansDetails{
+			InstanceFamily: strPtr("m5"),
+			Region:         strPtr("us-east-1"),
+		},
+		CurrentAverageHourlyOnDemandSpend: strPtr("0.50"),
+	}
+	got := savingsPlanDetail(d)
+	for _, want := range []string{"family=m5", "region=us-east-1", "current $/hr=0.50"} {
+		if !contains(got, want) {
+			t.Errorf("savingsPlanDetail missing %q, got %q", want, got)
+		}
+	}
+	// Empty input — should not panic, returns empty.
+	if v := savingsPlanDetail(types.SavingsPlansPurchaseRecommendationDetail{}); v != "" {
+		t.Errorf("empty detail → %q, want empty", v)
+	}
+}
+
+func TestRIDetail(t *testing.T) {
+	d := types.ReservationPurchaseRecommendationDetail{
+		RecommendedNumberOfInstancesToPurchase: strPtr("3"),
+		InstanceDetails: &types.InstanceDetails{
+			EC2InstanceDetails: &types.EC2InstanceDetails{
+				InstanceType: strPtr("m5.xlarge"),
+				Region:       strPtr("us-east-1"),
+			},
+		},
+	}
+	got := riDetail(d)
+	for _, want := range []string{"qty=3", "instance=m5.xlarge", "region=us-east-1"} {
+		if !contains(got, want) {
+			t.Errorf("riDetail missing %q, got %q", want, got)
+		}
+	}
+}
+
+// contains is a tiny helper to avoid importing strings just for the check.
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cost/provider.go
+++ b/internal/cost/provider.go
@@ -40,3 +40,17 @@ type TagProvider interface {
 	Provider
 	GetCostsByTag(ctx context.Context, tagKey string, start, end time.Time) ([]TagCost, error)
 }
+
+// SavingsProvider is implemented by providers that surface commitment-based
+// purchase recommendations (AWS Savings Plans + Reserved Instances). The
+// shape is intentionally vendor-neutral so a future GCP CUD or Azure
+// Reservation provider can plug in.
+type SavingsProvider interface {
+	Provider
+	// GetSavingsRecommendations returns Savings Plan / Reserved Instance
+	// purchase recommendations. lookback selects the AWS Cost Explorer
+	// LookbackPeriodInDays — empty defaults to "SIXTY_DAYS". term selects
+	// the commitment term — "ONE_YEAR" or "THREE_YEARS"; empty defaults
+	// to "ONE_YEAR".
+	GetSavingsRecommendations(ctx context.Context, lookback, term string) (*SavingsReport, error)
+}

--- a/internal/cost/types.go
+++ b/internal/cost/types.go
@@ -145,3 +145,40 @@ type TagAuditReport struct {
 	Entries []TagAuditEntry `json:"entries"`
 	Period  CostPeriod      `json:"period"`
 }
+
+// SavingsKind names the recommendation type — "savings_plan" (AWS
+// Savings Plan, also covers Compute / EC2 Instance / SageMaker SP) or
+// "reserved_instance" (RDS / ElastiCache / Redshift / OpenSearch RI).
+type SavingsKind string
+
+const (
+	SavingsKindSavingsPlan      SavingsKind = "savings_plan"
+	SavingsKindReservedInstance SavingsKind = "reserved_instance"
+)
+
+// SavingsRecommendation is one purchase recommendation row.
+type SavingsRecommendation struct {
+	Provider           string      `json:"provider"`
+	Kind               SavingsKind `json:"kind"`
+	Service            string      `json:"service,omitempty"`       // e.g. "EC2", "RDS"
+	Family             string      `json:"family,omitempty"`        // e.g. "Compute", "EC2 Instance"
+	Term               string      `json:"term"`                    // "ONE_YEAR" or "THREE_YEARS"
+	PaymentOption      string      `json:"paymentOption,omitempty"` // "ALL_UPFRONT" / "PARTIAL_UPFRONT" / "NO_UPFRONT"
+	UpfrontCost        float64     `json:"upfrontCost"`             // USD
+	HourlyCommitment   float64     `json:"hourlyCommitment,omitempty"`
+	EstimatedSavings   float64     `json:"estimatedSavingsUsd"`       // monthly USD
+	EstimatedSavingsPc float64     `json:"estimatedSavingsPct"`       // 0..100
+	BreakevenMonths    float64     `json:"breakevenMonths,omitempty"` // upfront / monthly savings; 0 if NO_UPFRONT
+	Detail             string      `json:"detail,omitempty"`
+}
+
+// SavingsReport rolls up commitment-purchase recommendations.
+type SavingsReport struct {
+	GeneratedAt           time.Time               `json:"generatedAt"`
+	Provider              string                  `json:"provider"`
+	Lookback              string                  `json:"lookback"`
+	Term                  string                  `json:"term"`
+	Recommendations       []SavingsRecommendation `json:"recommendations,omitempty"`
+	TotalEstimatedSavings float64                 `json:"totalEstimatedSavingsUsd"`
+	Notes                 string                  `json:"notes,omitempty"`
+}

--- a/internal/k8s/agent_adapters.go
+++ b/internal/k8s/agent_adapters.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 
+	"github.com/bgdnvk/clanker/internal/k8s/cost"
 	"github.com/bgdnvk/clanker/internal/k8s/networking"
 	"github.com/bgdnvk/clanker/internal/k8s/sre"
 	"github.com/bgdnvk/clanker/internal/k8s/storage"
@@ -182,4 +183,20 @@ func (a *telemetryClientAdapter) RunJSON(ctx context.Context, args ...string) ([
 
 func (a *telemetryClientAdapter) GetJSON(ctx context.Context, resourceType, name, namespace string) ([]byte, error) {
 	return a.client.GetJSON(ctx, resourceType, name, namespace)
+}
+
+// NewK8sCostAdapter returns a cost.K8sClient backed by the given kubectl
+// Client. Exposed so callers outside this package can build the workload
+// cost attributor without poking at the unexported adapter type.
+func NewK8sCostAdapter(client *Client) cost.K8sClient {
+	return &k8sCostClientAdapter{client: client}
+}
+
+// k8sCostClientAdapter wraps Client to implement cost.K8sClient.
+type k8sCostClientAdapter struct {
+	client *Client
+}
+
+func (a *k8sCostClientAdapter) RunJSON(ctx context.Context, args ...string) ([]byte, error) {
+	return a.client.RunJSON(ctx, args...)
 }

--- a/internal/k8s/cost/attributor.go
+++ b/internal/k8s/cost/attributor.go
@@ -1,0 +1,467 @@
+package cost
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// HoursPerMonth is the standard cloud-billing month (730 hours = 8760/12).
+// Matches the convention used by AWS, GCP, and Kubecost.
+const HoursPerMonth = 730.0
+
+// K8sClient is the minimal kubectl surface this attributor needs. Mirrors
+// the pattern used by sre / storage so the package can be built with
+// k8s.NewClient via an adapter and stays mock-friendly in tests.
+type K8sClient interface {
+	RunJSON(ctx context.Context, args ...string) ([]byte, error)
+}
+
+// NodeInfo captures the subset of a node spec needed for attribution.
+type NodeInfo struct {
+	Name         string  `json:"name"`
+	InstanceType string  `json:"instanceType,omitempty"`
+	Region       string  `json:"region,omitempty"`
+	Zone         string  `json:"zone,omitempty"`
+	Provider     string  `json:"provider,omitempty"` // "aws", "gcp", "azure"
+	AllocCPU     float64 `json:"allocCpuCores"`
+	AllocMemMB   float64 `json:"allocMemMb"`
+	HourlyUSD    float64 `json:"hourlyUsd,omitempty"`
+	PriceKnown   bool    `json:"priceKnown"`
+}
+
+// PodAttribution is the cost attribution for a single pod. Shares are
+// fractions in [0, 1]; DominantShare is max(CPUShare, MemShare) and is
+// the share used to multiply the node's hourly price.
+type PodAttribution struct {
+	Namespace     string  `json:"namespace"`
+	Pod           string  `json:"pod"`
+	Workload      string  `json:"workload"`     // owner Deployment/STS/DS/Job name
+	WorkloadKind  string  `json:"workloadKind"` // Deployment, StatefulSet, DaemonSet, ...
+	Node          string  `json:"node,omitempty"`
+	CPURequestC   float64 `json:"cpuRequestCores"`
+	MemRequestMB  float64 `json:"memRequestMb"`
+	CPUShare      float64 `json:"cpuShare"`
+	MemShare      float64 `json:"memShare"`
+	DominantShare float64 `json:"dominantShare"`
+	HourlyUSD     float64 `json:"hourlyUsd,omitempty"`
+	MonthlyUSD    float64 `json:"monthlyUsd,omitempty"`
+	PriceKnown    bool    `json:"priceKnown"`
+}
+
+// WorkloadCostReport rolls up the pod-level attributions.
+type WorkloadCostReport struct {
+	GeneratedAt         time.Time        `json:"generatedAt"`
+	NodesScanned        int              `json:"nodesScanned"`
+	PodsScanned         int              `json:"podsScanned"`
+	PodsWithoutNode     int              `json:"podsWithoutNode"`
+	PodsWithoutRequests int              `json:"podsWithoutRequests"`
+	NodesWithoutPrice   int              `json:"nodesWithoutPrice"`
+	TotalHourlyUSD      float64          `json:"totalHourlyUsd"`
+	TotalMonthlyUSD     float64          `json:"totalMonthlyUsd"`
+	Nodes               []NodeInfo       `json:"nodes,omitempty"`
+	Pods                []PodAttribution `json:"pods,omitempty"`
+	Notes               string           `json:"notes,omitempty"`
+}
+
+// WorkloadCostAttributor walks pods + nodes and attributes node cost to
+// each pod by max(cpu_share, mem_share) of the pod's host node. Rolls up
+// to per-workload / per-namespace / per-node totals at the cmd layer.
+//
+// Read-only — only kubectl get is invoked.
+type WorkloadCostAttributor struct {
+	client K8sClient
+	prices NodePriceLookup
+	debug  bool
+}
+
+// NewWorkloadCostAttributor returns an attributor with the supplied price
+// lookup. Pass nil to fall back to DefaultAWSOnDemandPrices(); pass
+// CompositePriceLookup(custom, DefaultAWSOnDemandPrices()) to layer.
+func NewWorkloadCostAttributor(client K8sClient, prices NodePriceLookup, debug bool) *WorkloadCostAttributor {
+	if prices == nil {
+		prices = DefaultAWSOnDemandPrices()
+	}
+	return &WorkloadCostAttributor{client: client, prices: prices, debug: debug}
+}
+
+// Attribute lists nodes + pods cluster-wide and produces a per-pod cost
+// attribution. Pods missing a nodeName (Pending, Failed, etc.) are
+// counted but not attributed — they show up in PodsWithoutNode.
+func (a *WorkloadCostAttributor) Attribute(ctx context.Context) (*WorkloadCostReport, error) {
+	report := &WorkloadCostReport{GeneratedAt: time.Now().UTC()}
+
+	nodes, err := a.listNodes(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list nodes: %w", err)
+	}
+	report.NodesScanned = len(nodes)
+
+	// Apply price lookup once per node so the cmd layer can render node
+	// totals without a second lookup.
+	byNode := make(map[string]*NodeInfo, len(nodes))
+	for i := range nodes {
+		if p, ok := a.prices(nodes[i]); ok {
+			nodes[i].HourlyUSD = p
+			nodes[i].PriceKnown = true
+		} else {
+			report.NodesWithoutPrice++
+		}
+		byNode[nodes[i].Name] = &nodes[i]
+	}
+	report.Nodes = nodes
+
+	pods, err := a.listPods(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list pods: %w", err)
+	}
+	report.PodsScanned = len(pods)
+
+	for _, p := range pods {
+		if p.Node == "" {
+			report.PodsWithoutNode++
+			continue
+		}
+		if p.CPURequestC == 0 && p.MemRequestMB == 0 {
+			report.PodsWithoutRequests++
+			// Still record the pod so the operator can see un-requested
+			// workloads — they'll show 0% share but are visible.
+		}
+		node, ok := byNode[p.Node]
+		if !ok {
+			// Pod references a node we didn't see (race: node deleted
+			// between list calls). Skip rather than divide by zero.
+			report.PodsWithoutNode++
+			continue
+		}
+
+		if node.AllocCPU > 0 {
+			p.CPUShare = p.CPURequestC / node.AllocCPU
+		}
+		if node.AllocMemMB > 0 {
+			p.MemShare = p.MemRequestMB / node.AllocMemMB
+		}
+		p.DominantShare = p.CPUShare
+		if p.MemShare > p.DominantShare {
+			p.DominantShare = p.MemShare
+		}
+
+		if node.PriceKnown {
+			p.HourlyUSD = node.HourlyUSD * p.DominantShare
+			p.MonthlyUSD = p.HourlyUSD * HoursPerMonth
+			p.PriceKnown = true
+		}
+
+		report.Pods = append(report.Pods, p)
+		report.TotalHourlyUSD += p.HourlyUSD
+	}
+	report.TotalMonthlyUSD = report.TotalHourlyUSD * HoursPerMonth
+
+	// Sort pods by monthly cost desc, then dominant-share desc as a
+	// tiebreaker (so pods on un-priced nodes still get a stable order).
+	sort.SliceStable(report.Pods, func(i, j int) bool {
+		if report.Pods[i].MonthlyUSD != report.Pods[j].MonthlyUSD {
+			return report.Pods[i].MonthlyUSD > report.Pods[j].MonthlyUSD
+		}
+		if report.Pods[i].DominantShare != report.Pods[j].DominantShare {
+			return report.Pods[i].DominantShare > report.Pods[j].DominantShare
+		}
+		if report.Pods[i].Namespace != report.Pods[j].Namespace {
+			return report.Pods[i].Namespace < report.Pods[j].Namespace
+		}
+		return report.Pods[i].Pod < report.Pods[j].Pod
+	})
+
+	if report.NodesWithoutPrice > 0 {
+		report.Notes = fmt.Sprintf("%d/%d node(s) had no price match — install a custom NodePriceLookup or update the static table to fix",
+			report.NodesWithoutPrice, report.NodesScanned)
+	}
+	return report, nil
+}
+
+// AggregateByWorkload rolls per-pod attributions up to per-workload
+// totals (sum of replicas). Sorted by monthly cost desc.
+func AggregateByWorkload(pods []PodAttribution) []WorkloadRollup {
+	byKey := map[string]*WorkloadRollup{}
+	for _, p := range pods {
+		key := p.Namespace + "/" + p.WorkloadKind + "/" + p.Workload
+		w, ok := byKey[key]
+		if !ok {
+			w = &WorkloadRollup{
+				Namespace:    p.Namespace,
+				Workload:     p.Workload,
+				WorkloadKind: p.WorkloadKind,
+			}
+			byKey[key] = w
+		}
+		w.Pods++
+		w.CPURequestC += p.CPURequestC
+		w.MemRequestMB += p.MemRequestMB
+		w.HourlyUSD += p.HourlyUSD
+		w.MonthlyUSD += p.MonthlyUSD
+		if !p.PriceKnown {
+			w.AnyUnpriced = true
+		}
+	}
+	out := make([]WorkloadRollup, 0, len(byKey))
+	for _, w := range byKey {
+		out = append(out, *w)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].MonthlyUSD != out[j].MonthlyUSD {
+			return out[i].MonthlyUSD > out[j].MonthlyUSD
+		}
+		if out[i].Namespace != out[j].Namespace {
+			return out[i].Namespace < out[j].Namespace
+		}
+		return out[i].Workload < out[j].Workload
+	})
+	return out
+}
+
+// AggregateByNamespace rolls per-pod attributions up to per-namespace
+// totals. Sorted by monthly cost desc.
+func AggregateByNamespace(pods []PodAttribution) []NamespaceRollup {
+	byNS := map[string]*NamespaceRollup{}
+	for _, p := range pods {
+		ns, ok := byNS[p.Namespace]
+		if !ok {
+			ns = &NamespaceRollup{Namespace: p.Namespace}
+			byNS[p.Namespace] = ns
+		}
+		ns.Pods++
+		ns.CPURequestC += p.CPURequestC
+		ns.MemRequestMB += p.MemRequestMB
+		ns.HourlyUSD += p.HourlyUSD
+		ns.MonthlyUSD += p.MonthlyUSD
+		if !p.PriceKnown {
+			ns.AnyUnpriced = true
+		}
+	}
+	out := make([]NamespaceRollup, 0, len(byNS))
+	for _, ns := range byNS {
+		out = append(out, *ns)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].MonthlyUSD != out[j].MonthlyUSD {
+			return out[i].MonthlyUSD > out[j].MonthlyUSD
+		}
+		return out[i].Namespace < out[j].Namespace
+	})
+	return out
+}
+
+// WorkloadRollup is a workload-level aggregation of PodAttribution.
+type WorkloadRollup struct {
+	Namespace    string  `json:"namespace"`
+	Workload     string  `json:"workload"`
+	WorkloadKind string  `json:"workloadKind"`
+	Pods         int     `json:"pods"`
+	CPURequestC  float64 `json:"cpuRequestCores"`
+	MemRequestMB float64 `json:"memRequestMb"`
+	HourlyUSD    float64 `json:"hourlyUsd"`
+	MonthlyUSD   float64 `json:"monthlyUsd"`
+	AnyUnpriced  bool    `json:"anyUnpriced,omitempty"`
+}
+
+// NamespaceRollup is a namespace-level aggregation of PodAttribution.
+type NamespaceRollup struct {
+	Namespace    string  `json:"namespace"`
+	Pods         int     `json:"pods"`
+	CPURequestC  float64 `json:"cpuRequestCores"`
+	MemRequestMB float64 `json:"memRequestMb"`
+	HourlyUSD    float64 `json:"hourlyUsd"`
+	MonthlyUSD   float64 `json:"monthlyUsd"`
+	AnyUnpriced  bool    `json:"anyUnpriced,omitempty"`
+}
+
+// listNodes parses `kubectl get nodes -o json` into NodeInfo.
+func (a *WorkloadCostAttributor) listNodes(ctx context.Context) ([]NodeInfo, error) {
+	raw, err := a.client.RunJSON(ctx, "get", "nodes", "-o", "json")
+	if err != nil {
+		return nil, err
+	}
+	var list struct {
+		Items []struct {
+			Metadata struct {
+				Name   string            `json:"name"`
+				Labels map[string]string `json:"labels"`
+			} `json:"metadata"`
+			Spec struct {
+				ProviderID string `json:"providerID"`
+			} `json:"spec"`
+			Status struct {
+				Allocatable struct {
+					CPU    string `json:"cpu"`
+					Memory string `json:"memory"`
+				} `json:"allocatable"`
+			} `json:"status"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, fmt.Errorf("parse nodes: %w", err)
+	}
+
+	out := make([]NodeInfo, 0, len(list.Items))
+	for _, item := range list.Items {
+		ni := NodeInfo{Name: item.Metadata.Name}
+		// instance type — newer label preferred, fall back to legacy.
+		if v, ok := item.Metadata.Labels["node.kubernetes.io/instance-type"]; ok {
+			ni.InstanceType = v
+		} else if v, ok := item.Metadata.Labels["beta.kubernetes.io/instance-type"]; ok {
+			ni.InstanceType = v
+		}
+		if v, ok := item.Metadata.Labels["topology.kubernetes.io/region"]; ok {
+			ni.Region = v
+		}
+		if v, ok := item.Metadata.Labels["topology.kubernetes.io/zone"]; ok {
+			ni.Zone = v
+		}
+		ni.Provider = providerFromID(item.Spec.ProviderID)
+
+		if c, err := parseCPUQuantity(item.Status.Allocatable.CPU); err == nil {
+			ni.AllocCPU = c
+		}
+		if m, err := parseMemoryQuantity(item.Status.Allocatable.Memory); err == nil {
+			ni.AllocMemMB = m
+		}
+		out = append(out, ni)
+	}
+	return out, nil
+}
+
+// listPods parses `kubectl get pods -A -o json` into PodAttribution
+// stubs (without share / cost — Attribute fills those in).
+func (a *WorkloadCostAttributor) listPods(ctx context.Context) ([]PodAttribution, error) {
+	raw, err := a.client.RunJSON(ctx, "get", "pods", "-A", "-o", "json")
+	if err != nil {
+		return nil, err
+	}
+	var list struct {
+		Items []struct {
+			Metadata struct {
+				Name            string `json:"name"`
+				Namespace       string `json:"namespace"`
+				OwnerReferences []struct {
+					Kind string `json:"kind"`
+					Name string `json:"name"`
+				} `json:"ownerReferences"`
+			} `json:"metadata"`
+			Spec struct {
+				NodeName   string `json:"nodeName"`
+				Containers []struct {
+					Resources struct {
+						Requests struct {
+							CPU    string `json:"cpu"`
+							Memory string `json:"memory"`
+						} `json:"requests"`
+					} `json:"resources"`
+				} `json:"containers"`
+			} `json:"spec"`
+			Status struct {
+				Phase string `json:"phase"`
+			} `json:"status"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(raw, &list); err != nil {
+		return nil, fmt.Errorf("parse pods: %w", err)
+	}
+
+	out := make([]PodAttribution, 0, len(list.Items))
+	for _, item := range list.Items {
+		// Skip terminal pods — they don't consume node resources.
+		if strings.EqualFold(item.Status.Phase, "Succeeded") || strings.EqualFold(item.Status.Phase, "Failed") {
+			continue
+		}
+		p := PodAttribution{
+			Namespace: item.Metadata.Namespace,
+			Pod:       item.Metadata.Name,
+			Node:      item.Spec.NodeName,
+		}
+		p.Workload, p.WorkloadKind = workloadFromOwner(item.Metadata.OwnerReferences, item.Metadata.Name)
+
+		var cpu, mem float64
+		for _, c := range item.Spec.Containers {
+			if v, err := parseCPUQuantity(c.Resources.Requests.CPU); err == nil {
+				cpu += v
+			}
+			if v, err := parseMemoryQuantity(c.Resources.Requests.Memory); err == nil {
+				mem += v
+			}
+		}
+		p.CPURequestC = cpu
+		p.MemRequestMB = mem
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+// workloadFromOwner derives the (workload-name, workload-kind) pair from
+// a pod's ownerReferences. ReplicaSets are unwrapped to their parent
+// Deployment by stripping the "-<hash>" suffix kubectl appends to RS
+// names; Job-by-CronJob gets the same treatment. Standalone pods (no
+// owner) are reported as kind="Pod".
+func workloadFromOwner(refs []struct {
+	Kind string `json:"kind"`
+	Name string `json:"name"`
+}, podName string) (string, string) {
+	if len(refs) == 0 {
+		return podName, "Pod"
+	}
+	o := refs[0]
+	switch o.Kind {
+	case "ReplicaSet":
+		// "<deployment>-<podtemplate-hash>" → "<deployment>"
+		if idx := strings.LastIndex(o.Name, "-"); idx > 0 {
+			return o.Name[:idx], "Deployment"
+		}
+		return o.Name, "ReplicaSet"
+	case "Job":
+		// CronJob-owned Job names are "<cronjob>-<unix-ts>". Strip the
+		// trailing numeric segment if present.
+		if idx := strings.LastIndex(o.Name, "-"); idx > 0 {
+			suffix := o.Name[idx+1:]
+			allDigits := suffix != ""
+			for _, c := range suffix {
+				if c < '0' || c > '9' {
+					allDigits = false
+					break
+				}
+			}
+			if allDigits {
+				return o.Name[:idx], "CronJob"
+			}
+		}
+		return o.Name, "Job"
+	default:
+		return o.Name, o.Kind
+	}
+}
+
+// providerFromID extracts the cloud provider from a node's spec.providerID.
+// Examples: "aws:///us-east-1a/i-abc" → "aws", "gce://proj/zone/name" →
+// "gcp", "azure:///subscriptions/..." → "azure".
+func providerFromID(id string) string {
+	if id == "" {
+		return ""
+	}
+	switch {
+	case strings.HasPrefix(id, "aws://"):
+		return "aws"
+	case strings.HasPrefix(id, "gce://"):
+		return "gcp"
+	case strings.HasPrefix(id, "azure://"):
+		return "azure"
+	case strings.HasPrefix(id, "kind://"):
+		return "kind"
+	case strings.HasPrefix(id, "k3s://"):
+		return "k3s"
+	}
+	if i := strings.Index(id, ":"); i > 0 {
+		return id[:i]
+	}
+	return ""
+}

--- a/internal/k8s/cost/attributor_test.go
+++ b/internal/k8s/cost/attributor_test.go
@@ -1,0 +1,281 @@
+package cost
+
+import (
+	"context"
+	"errors"
+	"math"
+	"strings"
+	"testing"
+)
+
+type attributorMock struct {
+	nodes    string
+	nodesErr error
+	pods     string
+	podsErr  error
+}
+
+func (m *attributorMock) RunJSON(_ context.Context, args ...string) ([]byte, error) {
+	full := strings.Join(args, " ")
+	switch {
+	case strings.Contains(full, "get nodes"):
+		return []byte(m.nodes), m.nodesErr
+	case strings.Contains(full, "get pods"):
+		return []byte(m.pods), m.podsErr
+	}
+	return []byte(`{"items": []}`), nil
+}
+
+const (
+	twoNodes = `{
+	  "items": [
+	    {
+	      "metadata": {"name": "node-a", "labels": {"node.kubernetes.io/instance-type": "m5.xlarge", "topology.kubernetes.io/region": "us-east-1"}},
+	      "spec": {"providerID": "aws:///us-east-1a/i-aaaa"},
+	      "status": {"allocatable": {"cpu": "4", "memory": "16384Mi"}}
+	    },
+	    {
+	      "metadata": {"name": "node-b", "labels": {"node.kubernetes.io/instance-type": "unknown.huge"}},
+	      "spec": {"providerID": "aws:///us-east-1a/i-bbbb"},
+	      "status": {"allocatable": {"cpu": "8", "memory": "32768Mi"}}
+	    }
+	  ]
+	}`
+
+	mixedPods = `{
+	  "items": [
+	    {
+	      "metadata": {"name": "api-7d9-xyz", "namespace": "prod", "ownerReferences": [{"kind": "ReplicaSet", "name": "api-7d9"}]},
+	      "spec": {"nodeName": "node-a", "containers": [{"resources": {"requests": {"cpu": "1", "memory": "2Gi"}}}]},
+	      "status": {"phase": "Running"}
+	    },
+	    {
+	      "metadata": {"name": "worker-0", "namespace": "prod", "ownerReferences": [{"kind": "StatefulSet", "name": "worker"}]},
+	      "spec": {"nodeName": "node-b", "containers": [{"resources": {"requests": {"cpu": "500m", "memory": "1Gi"}}}, {"resources": {"requests": {"cpu": "500m", "memory": "1Gi"}}}]},
+	      "status": {"phase": "Running"}
+	    },
+	    {
+	      "metadata": {"name": "stateless", "namespace": "default"},
+	      "spec": {"nodeName": "node-a", "containers": [{"resources": {"requests": {"cpu": "100m", "memory": "128Mi"}}}]},
+	      "status": {"phase": "Running"}
+	    },
+	    {
+	      "metadata": {"name": "pending", "namespace": "default", "ownerReferences": [{"kind": "ReplicaSet", "name": "queue-1"}]},
+	      "spec": {"containers": [{"resources": {"requests": {"cpu": "1", "memory": "1Gi"}}}]},
+	      "status": {"phase": "Pending"}
+	    },
+	    {
+	      "metadata": {"name": "succeeded-job", "namespace": "default", "ownerReferences": [{"kind": "Job", "name": "backup-1700000000"}]},
+	      "spec": {"nodeName": "node-a", "containers": [{"resources": {"requests": {"cpu": "1"}}}]},
+	      "status": {"phase": "Succeeded"}
+	    }
+	  ]
+	}`
+)
+
+func TestAttribute_HappyPath(t *testing.T) {
+	a := NewWorkloadCostAttributor(&attributorMock{nodes: twoNodes, pods: mixedPods}, nil, false)
+	report, err := a.Attribute(context.Background())
+	if err != nil {
+		t.Fatalf("Attribute: %v", err)
+	}
+
+	if report.NodesScanned != 2 {
+		t.Errorf("NodesScanned = %d, want 2", report.NodesScanned)
+	}
+	// 5 input pods, 1 Succeeded skipped → 4 listed.
+	// 1 of those (pending) has no node → counted in PodsWithoutNode.
+	if report.PodsScanned != 4 {
+		t.Errorf("PodsScanned = %d, want 4", report.PodsScanned)
+	}
+	if report.PodsWithoutNode != 1 {
+		t.Errorf("PodsWithoutNode = %d, want 1", report.PodsWithoutNode)
+	}
+	if report.NodesWithoutPrice != 1 {
+		t.Errorf("NodesWithoutPrice = %d, want 1 (unknown.huge)", report.NodesWithoutPrice)
+	}
+
+	// 3 attributed pods.
+	if len(report.Pods) != 3 {
+		t.Fatalf("attributed pods = %d, want 3: %+v", len(report.Pods), report.Pods)
+	}
+
+	// api-7d9-xyz on node-a (m5.xlarge, $0.192/hr): cpu 1/4 = 0.25, mem 2048/16384 = 0.125 → dominant 0.25.
+	// hourly = 0.192 * 0.25 = 0.048. monthly = 0.048 * 730 = 35.04.
+	api := findPod(report.Pods, "api-7d9-xyz")
+	if api == nil {
+		t.Fatal("api-7d9-xyz missing from attribution")
+	}
+	if !approxEqual(api.DominantShare, 0.25, 1e-9) {
+		t.Errorf("api dominant share = %v, want 0.25", api.DominantShare)
+	}
+	if !approxEqual(api.HourlyUSD, 0.048, 1e-9) {
+		t.Errorf("api hourly = %v, want 0.048", api.HourlyUSD)
+	}
+	if api.WorkloadKind != "Deployment" || api.Workload != "api" {
+		t.Errorf("api workload = %s/%s, want Deployment/api", api.WorkloadKind, api.Workload)
+	}
+
+	// worker-0 on node-b (no price): cpu 1/8 = 0.125, mem 2048/32768 = 0.0625 → dominant 0.125.
+	worker := findPod(report.Pods, "worker-0")
+	if worker == nil {
+		t.Fatal("worker-0 missing from attribution")
+	}
+	if !approxEqual(worker.DominantShare, 0.125, 1e-9) {
+		t.Errorf("worker dominant share = %v, want 0.125", worker.DominantShare)
+	}
+	if worker.PriceKnown {
+		t.Errorf("worker should be unpriced (node-b is unknown.huge)")
+	}
+	if worker.WorkloadKind != "StatefulSet" || worker.Workload != "worker" {
+		t.Errorf("worker workload = %s/%s, want StatefulSet/worker", worker.WorkloadKind, worker.Workload)
+	}
+
+	// First pod in the sorted list should be the highest-cost one (api).
+	if report.Pods[0].Pod != "api-7d9-xyz" {
+		t.Errorf("expected api-7d9-xyz first by monthly cost, got %s", report.Pods[0].Pod)
+	}
+
+	if report.Notes == "" {
+		t.Error("expected note about unpriced nodes")
+	}
+}
+
+func TestAttribute_NodeListErrorPropagates(t *testing.T) {
+	a := NewWorkloadCostAttributor(&attributorMock{nodesErr: errors.New("forbidden")}, nil, false)
+	if _, err := a.Attribute(context.Background()); err == nil {
+		t.Error("expected error when node list fails")
+	}
+}
+
+func TestAttribute_DivideByZeroNodeAllocSafe(t *testing.T) {
+	// Node with empty allocatable (broken state). Pods on it should not
+	// crash with NaN/Inf; share stays 0.
+	a := NewWorkloadCostAttributor(&attributorMock{
+		nodes: `{"items": [{"metadata": {"name": "n", "labels": {}}, "status": {"allocatable": {"cpu": "0", "memory": "0"}}}]}`,
+		pods:  `{"items": [{"metadata": {"name": "p", "namespace": "x"}, "spec": {"nodeName": "n", "containers": [{"resources": {"requests": {"cpu": "1"}}}]}, "status": {"phase": "Running"}}]}`,
+	}, nil, false)
+	report, err := a.Attribute(context.Background())
+	if err != nil {
+		t.Fatalf("Attribute: %v", err)
+	}
+	if len(report.Pods) != 1 {
+		t.Fatalf("attributed pods = %d, want 1", len(report.Pods))
+	}
+	if math.IsNaN(report.Pods[0].DominantShare) || math.IsInf(report.Pods[0].DominantShare, 0) {
+		t.Errorf("dominant share should be 0 for zero-alloc node, got %v", report.Pods[0].DominantShare)
+	}
+	if report.Pods[0].DominantShare != 0 {
+		t.Errorf("dominant share = %v, want 0", report.Pods[0].DominantShare)
+	}
+}
+
+func TestAggregateByWorkload_SumsReplicas(t *testing.T) {
+	pods := []PodAttribution{
+		{Namespace: "prod", Workload: "api", WorkloadKind: "Deployment", HourlyUSD: 0.05, MonthlyUSD: 36.5, CPURequestC: 1, MemRequestMB: 2048, PriceKnown: true},
+		{Namespace: "prod", Workload: "api", WorkloadKind: "Deployment", HourlyUSD: 0.05, MonthlyUSD: 36.5, CPURequestC: 1, MemRequestMB: 2048, PriceKnown: true},
+		{Namespace: "prod", Workload: "api", WorkloadKind: "Deployment", HourlyUSD: 0, MonthlyUSD: 0, CPURequestC: 1, MemRequestMB: 2048, PriceKnown: false},
+		{Namespace: "default", Workload: "queue", WorkloadKind: "Deployment", HourlyUSD: 0.01, MonthlyUSD: 7.3, PriceKnown: true},
+	}
+	out := AggregateByWorkload(pods)
+	if len(out) != 2 {
+		t.Fatalf("rollups = %d, want 2", len(out))
+	}
+	// First should be prod/api (highest cost).
+	if out[0].Workload != "api" || out[0].Pods != 3 {
+		t.Errorf("first rollup = %+v, want prod/api with 3 pods", out[0])
+	}
+	if !approxEqual(out[0].MonthlyUSD, 73.0, 1e-9) {
+		t.Errorf("api monthly = %v, want 73.0", out[0].MonthlyUSD)
+	}
+	if !out[0].AnyUnpriced {
+		t.Error("api should be flagged AnyUnpriced (one replica had no price)")
+	}
+	if out[1].Workload != "queue" || out[1].AnyUnpriced {
+		t.Errorf("second rollup = %+v, want default/queue priced", out[1])
+	}
+}
+
+func TestAggregateByNamespace_RollsUpAndSorts(t *testing.T) {
+	pods := []PodAttribution{
+		{Namespace: "prod", MonthlyUSD: 100, PriceKnown: true},
+		{Namespace: "default", MonthlyUSD: 30, PriceKnown: true},
+		{Namespace: "prod", MonthlyUSD: 50, PriceKnown: true},
+	}
+	out := AggregateByNamespace(pods)
+	if len(out) != 2 {
+		t.Fatalf("namespaces = %d, want 2", len(out))
+	}
+	if out[0].Namespace != "prod" || out[0].MonthlyUSD != 150 {
+		t.Errorf("first namespace = %+v, want prod $150", out[0])
+	}
+}
+
+func TestWorkloadFromOwner(t *testing.T) {
+	type ref struct {
+		Kind string `json:"kind"`
+		Name string `json:"name"`
+	}
+	cases := []struct {
+		refs     []ref
+		podName  string
+		wantName string
+		wantKind string
+	}{
+		{nil, "standalone", "standalone", "Pod"},
+		{[]ref{{Kind: "ReplicaSet", Name: "api-7d9"}}, "api-7d9-xyz", "api", "Deployment"},
+		{[]ref{{Kind: "StatefulSet", Name: "worker"}}, "worker-0", "worker", "StatefulSet"},
+		{[]ref{{Kind: "DaemonSet", Name: "fluentd"}}, "fluentd-abc", "fluentd", "DaemonSet"},
+		{[]ref{{Kind: "Job", Name: "backup-1700000000"}}, "backup-1700000000-xy", "backup", "CronJob"},
+		{[]ref{{Kind: "Job", Name: "ad-hoc"}}, "ad-hoc-pod", "ad-hoc", "Job"},
+	}
+	for _, c := range cases {
+		// Re-shape into the inline anonymous struct the function expects.
+		shaped := make([]struct {
+			Kind string `json:"kind"`
+			Name string `json:"name"`
+		}, len(c.refs))
+		for i, r := range c.refs {
+			shaped[i].Kind = r.Kind
+			shaped[i].Name = r.Name
+		}
+		gotName, gotKind := workloadFromOwner(shaped, c.podName)
+		if gotName != c.wantName || gotKind != c.wantKind {
+			t.Errorf("workloadFromOwner(%+v, %q) = (%q, %q), want (%q, %q)",
+				c.refs, c.podName, gotName, gotKind, c.wantName, c.wantKind)
+		}
+	}
+}
+
+func TestProviderFromID(t *testing.T) {
+	cases := map[string]string{
+		"":                                  "",
+		"aws:///us-east-1a/i-abc":           "aws",
+		"gce://proj/us-central1-a/instance": "gcp",
+		"azure:///subscriptions/sub/resourceGroups/rg":  "azure",
+		"kind://docker/clanker-cluster/clanker-control": "kind",
+		"foo://bar": "foo",
+	}
+	for in, want := range cases {
+		if got := providerFromID(in); got != want {
+			t.Errorf("providerFromID(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func findPod(pods []PodAttribution, name string) *PodAttribution {
+	for i := range pods {
+		if pods[i].Pod == name {
+			return &pods[i]
+		}
+	}
+	return nil
+}
+
+func approxEqual(a, b, tol float64) bool {
+	d := a - b
+	if d < 0 {
+		d = -d
+	}
+	return d < tol
+}

--- a/internal/k8s/cost/prices.go
+++ b/internal/k8s/cost/prices.go
@@ -1,0 +1,93 @@
+package cost
+
+import (
+	"strings"
+)
+
+// NodePriceLookup returns the on-demand hourly USD price of a node, or
+// (0, false) if no price is known. Callers can plug in their own lookup
+// (e.g. backed by a real billing API or a per-cluster overrides file);
+// the built-in DefaultAWSOnDemandPrices is a static estimate covering
+// the most common AWS instance types and is documented as approximate.
+type NodePriceLookup func(node NodeInfo) (hourlyUSD float64, ok bool)
+
+// DefaultAWSOnDemandPrices is a small static fallback covering common
+// AWS instance families. Prices are us-east-1 on-demand list, snapshot
+// circa 2024 — operators with a real billing API or up-to-date prices
+// should override this via a custom NodePriceLookup. The intent is to
+// give operators a sensible default rather than refuse to attribute
+// cost when no price source is configured.
+//
+// Missing entries return (0, false) and the attributor records the pod
+// as PriceKnown=false; the dominant-share signal is still useful in
+// that case (it surfaces over-requesting workloads regardless of $).
+func DefaultAWSOnDemandPrices() NodePriceLookup {
+	table := map[string]float64{
+		// General purpose
+		"t3.micro":   0.0104,
+		"t3.small":   0.0208,
+		"t3.medium":  0.0416,
+		"t3.large":   0.0832,
+		"t3.xlarge":  0.1664,
+		"t3.2xlarge": 0.3328,
+		"m5.large":   0.096,
+		"m5.xlarge":  0.192,
+		"m5.2xlarge": 0.384,
+		"m5.4xlarge": 0.768,
+		"m6i.large":  0.096,
+		"m6i.xlarge": 0.192,
+		// Compute optimised
+		"c5.large":   0.085,
+		"c5.xlarge":  0.17,
+		"c5.2xlarge": 0.34,
+		"c6i.large":  0.085,
+		"c6i.xlarge": 0.17,
+		// Memory optimised
+		"r5.large":   0.126,
+		"r5.xlarge":  0.252,
+		"r5.2xlarge": 0.504,
+		"r6i.large":  0.126,
+		"r6i.xlarge": 0.252,
+	}
+	return func(n NodeInfo) (float64, bool) {
+		// Only AWS — match on instance type label. Other providers fall
+		// through to (0, false) and the operator can plug in their own.
+		if !strings.EqualFold(n.Provider, "aws") && n.Provider != "" {
+			return 0, false
+		}
+		if n.InstanceType == "" {
+			return 0, false
+		}
+		p, ok := table[n.InstanceType]
+		return p, ok
+	}
+}
+
+// MapPriceLookup builds a NodePriceLookup from a static instance-type →
+// hourlyUSD map. Useful when an operator supplies prices via a config
+// file or flag and wants to override the defaults.
+func MapPriceLookup(prices map[string]float64) NodePriceLookup {
+	return func(n NodeInfo) (float64, bool) {
+		if n.InstanceType == "" {
+			return 0, false
+		}
+		p, ok := prices[n.InstanceType]
+		return p, ok
+	}
+}
+
+// CompositePriceLookup tries each lookup in order and returns the first
+// hit. Use to chain a user-supplied table over the built-in fallback.
+func CompositePriceLookup(lookups ...NodePriceLookup) NodePriceLookup {
+	return func(n NodeInfo) (float64, bool) {
+		for _, l := range lookups {
+			if l == nil {
+				continue
+			}
+			if p, ok := l(n); ok {
+				return p, true
+			}
+		}
+		return 0, false
+	}
+}

--- a/internal/k8s/cost/quantity.go
+++ b/internal/k8s/cost/quantity.go
@@ -1,0 +1,89 @@
+package cost
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// parseCPUQuantity converts a Kubernetes CPU quantity string to cores.
+// Accepts plain integers/floats ("1", "0.5", "2.5") and milli-CPU
+// suffixes ("100m" → 0.1, "1500m" → 1.5).
+func parseCPUQuantity(s string) (float64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, nil
+	}
+	if strings.HasSuffix(s, "m") {
+		n, err := strconv.ParseFloat(strings.TrimSuffix(s, "m"), 64)
+		if err != nil {
+			return 0, fmt.Errorf("parse CPU milli %q: %w", s, err)
+		}
+		return n / 1000.0, nil
+	}
+	n, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse CPU %q: %w", s, err)
+	}
+	return n, nil
+}
+
+// parseMemoryQuantity converts a Kubernetes memory quantity string to MiB.
+// Supports binary suffixes (Ki, Mi, Gi, Ti, Pi, Ei) and decimal suffixes
+// (k, K, M, G, T, P, E). Plain integers are interpreted as bytes.
+func parseMemoryQuantity(s string) (float64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, nil
+	}
+	// Order matters: check binary (i-suffixed) before decimal so "Mi"
+	// doesn't get matched as "M".
+	binarySuffixes := []struct {
+		suffix string
+		// MiB per unit.
+		mib float64
+	}{
+		{"Ki", 1.0 / 1024.0},
+		{"Mi", 1.0},
+		{"Gi", 1024.0},
+		{"Ti", 1024.0 * 1024.0},
+		{"Pi", 1024.0 * 1024.0 * 1024.0},
+		{"Ei", 1024.0 * 1024.0 * 1024.0 * 1024.0},
+	}
+	for _, sx := range binarySuffixes {
+		if strings.HasSuffix(s, sx.suffix) {
+			n, err := strconv.ParseFloat(strings.TrimSuffix(s, sx.suffix), 64)
+			if err != nil {
+				return 0, fmt.Errorf("parse memory %q: %w", s, err)
+			}
+			return n * sx.mib, nil
+		}
+	}
+	decimalSuffixes := []struct {
+		suffix string
+		mib    float64
+	}{
+		{"k", 1000.0 / (1024.0 * 1024.0)},
+		{"K", 1000.0 / (1024.0 * 1024.0)},
+		{"M", 1000.0 * 1000.0 / (1024.0 * 1024.0)},
+		{"G", 1000.0 * 1000.0 * 1000.0 / (1024.0 * 1024.0)},
+		{"T", 1000.0 * 1000.0 * 1000.0 * 1000.0 / (1024.0 * 1024.0)},
+		{"P", 1000.0 * 1000.0 * 1000.0 * 1000.0 * 1000.0 / (1024.0 * 1024.0)},
+		{"E", 1000.0 * 1000.0 * 1000.0 * 1000.0 * 1000.0 * 1000.0 / (1024.0 * 1024.0)},
+	}
+	for _, sx := range decimalSuffixes {
+		if strings.HasSuffix(s, sx.suffix) {
+			n, err := strconv.ParseFloat(strings.TrimSuffix(s, sx.suffix), 64)
+			if err != nil {
+				return 0, fmt.Errorf("parse memory %q: %w", s, err)
+			}
+			return n * sx.mib, nil
+		}
+	}
+	// No suffix → bytes.
+	n, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse memory %q: %w", s, err)
+	}
+	return n / (1024.0 * 1024.0), nil
+}

--- a/internal/k8s/cost/quantity_test.go
+++ b/internal/k8s/cost/quantity_test.go
@@ -1,0 +1,97 @@
+package cost
+
+import "testing"
+
+func TestParseCPUQuantity(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    float64
+		wantErr bool
+	}{
+		{"", 0, false},
+		{"1", 1, false},
+		{"2.5", 2.5, false},
+		{"100m", 0.1, false},
+		{"1500m", 1.5, false},
+		{"500M", 0, true}, // ambiguous, not valid CPU
+		{"abc", 0, true},
+	}
+	for _, c := range cases {
+		got, err := parseCPUQuantity(c.in)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("parseCPUQuantity(%q) want error, got %v", c.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseCPUQuantity(%q) error = %v", c.in, err)
+		}
+		if !approxEqual(got, c.want, 1e-9) {
+			t.Errorf("parseCPUQuantity(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParseMemoryQuantity(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    float64 // MiB
+		wantErr bool
+	}{
+		{"", 0, false},
+		{"512Mi", 512, false},
+		{"1Gi", 1024, false},
+		{"2Gi", 2048, false},
+		{"1024Ki", 1, false},
+		{"16384Mi", 16384, false},
+		{"1G", 1000.0 * 1000.0 * 1000.0 / (1024.0 * 1024.0), false},
+		{"1k", 1000.0 / (1024.0 * 1024.0), false},
+		// Plain bytes.
+		{"1048576", 1, false},
+		{"abc", 0, true},
+	}
+	for _, c := range cases {
+		got, err := parseMemoryQuantity(c.in)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("parseMemoryQuantity(%q) want error, got %v", c.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseMemoryQuantity(%q) error = %v", c.in, err)
+		}
+		if !approxEqual(got, c.want, 1e-6) {
+			t.Errorf("parseMemoryQuantity(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestPriceLookups(t *testing.T) {
+	def := DefaultAWSOnDemandPrices()
+	if p, ok := def(NodeInfo{InstanceType: "m5.xlarge", Provider: "aws"}); !ok || !approxEqual(p, 0.192, 1e-9) {
+		t.Errorf("default m5.xlarge AWS = (%v, %v), want (0.192, true)", p, ok)
+	}
+	if _, ok := def(NodeInfo{InstanceType: "made-up.huge", Provider: "aws"}); ok {
+		t.Error("default lookup should miss on unknown instance type")
+	}
+	if _, ok := def(NodeInfo{InstanceType: "m5.xlarge", Provider: "gcp"}); ok {
+		t.Error("default lookup should not match non-aws providers")
+	}
+
+	custom := MapPriceLookup(map[string]float64{"my.kind": 1.50})
+	if p, ok := custom(NodeInfo{InstanceType: "my.kind"}); !ok || p != 1.50 {
+		t.Errorf("custom my.kind = (%v, %v), want (1.50, true)", p, ok)
+	}
+
+	// Composite: custom hit beats default fallback.
+	composite := CompositePriceLookup(custom, def)
+	if p, ok := composite(NodeInfo{InstanceType: "my.kind"}); !ok || p != 1.50 {
+		t.Errorf("composite custom hit = (%v, %v), want (1.50, true)", p, ok)
+	}
+	// Composite: custom miss falls through to default.
+	if p, ok := composite(NodeInfo{InstanceType: "m5.xlarge", Provider: "aws"}); !ok || !approxEqual(p, 0.192, 1e-9) {
+		t.Errorf("composite default fallback = (%v, %v), want (0.192, true)", p, ok)
+	}
+}

--- a/internal/k8s/sre/karpenter_advisor.go
+++ b/internal/k8s/sre/karpenter_advisor.go
@@ -1,0 +1,222 @@
+package sre
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// KarpenterAdvisor inspects detected Karpenter NodePools + NodeClaims and
+// surfaces actionable recommendations: missing consolidation, unbounded
+// pools, stale pools, NodeClaims stuck not-Ready, and weighted-but-zero
+// configurations. Read-only.
+//
+// Usage: build a KarpenterDetector, call Advise(ctx). Returns an empty
+// (non-nil) report when Karpenter is not installed so callers can render
+// "no recommendations" without sniffing error strings.
+type KarpenterAdvisor struct {
+	detector *KarpenterDetector
+	debug    bool
+}
+
+func NewKarpenterAdvisor(client K8sClient, debug bool) *KarpenterAdvisor {
+	return &KarpenterAdvisor{
+		detector: NewKarpenterDetector(client, debug),
+		debug:    debug,
+	}
+}
+
+// KarpenterRecommendation is one actionable finding on a NodePool /
+// NodeClaim. Severity follows the rest of the sre package vocabulary.
+type KarpenterRecommendation struct {
+	Severity   IssueSeverity `json:"severity"`
+	Resource   string        `json:"resource"` // "nodepool" or "nodeclaim"
+	Name       string        `json:"name"`
+	Issue      string        `json:"issue"`
+	Detail     string        `json:"detail,omitempty"`
+	Suggestion string        `json:"suggestion,omitempty"`
+}
+
+// KarpenterAdvisorReport aggregates the advisor output.
+type KarpenterAdvisorReport struct {
+	GeneratedAt     time.Time                 `json:"generatedAt"`
+	Installed       bool                      `json:"installed"`
+	NodePools       int                       `json:"nodePools"`
+	NodeClaims      int                       `json:"nodeClaims"`
+	Recommendations []KarpenterRecommendation `json:"recommendations,omitempty"`
+	Notes           string                    `json:"notes,omitempty"`
+}
+
+// StaleNodePoolThreshold is how old (without provisioning any node) a
+// NodePool can get before we flag it as likely abandoned. Exposed so
+// tests can override without touching the package's defaults.
+var StaleNodePoolThreshold = 7 * 24 * time.Hour
+
+// NodeClaimStuckThreshold is how long a NodeClaim can sit not-Ready
+// before we flag the provisioner as unhealthy.
+var NodeClaimStuckThreshold = 30 * time.Minute
+
+// Advise runs detection + listing + analysis and produces a report.
+func (a *KarpenterAdvisor) Advise(ctx context.Context) (*KarpenterAdvisorReport, error) {
+	report := &KarpenterAdvisorReport{GeneratedAt: time.Now().UTC()}
+
+	presence, err := a.detector.Detect(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("detect karpenter: %w", err)
+	}
+	report.Installed = presence.Installed
+	if presence.Notes != "" {
+		report.Notes = presence.Notes
+	}
+	if !presence.Installed {
+		return report, nil
+	}
+
+	pools, err := a.detector.ListNodePools(ctx)
+	if err != nil {
+		appendNote(&report.Notes, fmt.Sprintf("list nodepools failed: %v", err))
+	} else {
+		report.NodePools = len(pools)
+	}
+	claims, err := a.detector.ListNodeClaims(ctx)
+	if err != nil {
+		appendNote(&report.Notes, fmt.Sprintf("list nodeclaims failed: %v", err))
+	} else {
+		report.NodeClaims = len(claims)
+	}
+
+	report.Recommendations = append(report.Recommendations, analysePools(pools)...)
+	report.Recommendations = append(report.Recommendations, analyseClaims(claims)...)
+	report.Recommendations = append(report.Recommendations, analyseGlobal(pools)...)
+
+	sort.SliceStable(report.Recommendations, func(i, j int) bool {
+		ri := karpenterSeverityRank(report.Recommendations[i].Severity)
+		rj := karpenterSeverityRank(report.Recommendations[j].Severity)
+		if ri != rj {
+			return ri > rj
+		}
+		if report.Recommendations[i].Resource != report.Recommendations[j].Resource {
+			return report.Recommendations[i].Resource < report.Recommendations[j].Resource
+		}
+		return report.Recommendations[i].Name < report.Recommendations[j].Name
+	})
+	return report, nil
+}
+
+func analysePools(pools []NodePoolSummary) []KarpenterRecommendation {
+	var out []KarpenterRecommendation
+	now := time.Now().UTC()
+	for _, p := range pools {
+		// Missing consolidation policy → nodes never auto-deprovision.
+		if p.Disruption == "" {
+			out = append(out, KarpenterRecommendation{
+				Severity:   SeverityWarning,
+				Resource:   "nodepool",
+				Name:       p.Name,
+				Issue:      "no consolidation policy set",
+				Detail:     "spec.disruption.consolidationPolicy is empty — nodes will not be consolidated when underutilised",
+				Suggestion: `set spec.disruption.consolidationPolicy: "WhenUnderutilized" to recover idle node spend`,
+			})
+		}
+
+		// Unbounded growth — empty Limits map means the pool can scale
+		// arbitrarily. Often deliberate for system pools; flag as info.
+		if len(p.Limits) == 0 {
+			out = append(out, KarpenterRecommendation{
+				Severity:   SeverityInfo,
+				Resource:   "nodepool",
+				Name:       p.Name,
+				Issue:      "no spec.limits set",
+				Detail:     "NodePool has no CPU/memory limits — runaway scheduling can drain budget",
+				Suggestion: "set spec.limits.cpu and spec.limits.memory to bound the maximum spend",
+			})
+		}
+
+		// Stale NodePool — created long ago but never provisioned a node.
+		// Filter out pools that just look at zero today; we only care
+		// about ones older than the staleness threshold.
+		if !p.CreatedAt.IsZero() && p.NodesProvisioned == 0 && now.Sub(p.CreatedAt) > StaleNodePoolThreshold {
+			out = append(out, KarpenterRecommendation{
+				Severity:   SeverityInfo,
+				Resource:   "nodepool",
+				Name:       p.Name,
+				Issue:      "stale — never provisioned a node",
+				Detail:     fmt.Sprintf("NodePool is %s old with NodesProvisioned=0; selectors may not match any pending pods", p.Age),
+				Suggestion: "review spec.template.spec.requirements / taints, or delete the pool if obsolete",
+			})
+		}
+	}
+	return out
+}
+
+func analyseClaims(claims []NodeClaimSummary) []KarpenterRecommendation {
+	var out []KarpenterRecommendation
+	now := time.Now().UTC()
+	for _, c := range claims {
+		if c.Status == "Ready" {
+			continue
+		}
+		if c.CreatedAt.IsZero() {
+			continue
+		}
+		age := now.Sub(c.CreatedAt)
+		if age <= NodeClaimStuckThreshold {
+			continue
+		}
+		out = append(out, KarpenterRecommendation{
+			Severity: SeverityCritical,
+			Resource: "nodeclaim",
+			Name:     c.Name,
+			Issue:    fmt.Sprintf("stuck %s for %s", c.Status, humanAge(age)),
+			Detail: fmt.Sprintf("NodeClaim has not reached Ready in %s — provisioner or quota is likely unhealthy",
+				humanAge(age)),
+			Suggestion: "check `kubectl describe nodeclaim` for events; verify cloud quotas and provisioner pod logs",
+		})
+	}
+	return out
+}
+
+// karpenterSeverityRank maps an IssueSeverity onto an integer for the
+// sort comparator. Local copy so the sre package doesn't pull in the
+// cmd-side severityRank.
+func karpenterSeverityRank(s IssueSeverity) int {
+	switch s {
+	case SeverityCritical:
+		return 2
+	case SeverityWarning:
+		return 1
+	}
+	return 0
+}
+
+// analyseGlobal looks for issues that only make sense across the whole
+// pool set: weighted scheduling without weights, or duplicate weights.
+func analyseGlobal(pools []NodePoolSummary) []KarpenterRecommendation {
+	if len(pools) < 2 {
+		return nil
+	}
+	allUnweighted := true
+	for _, p := range pools {
+		if p.Weight != 0 {
+			allUnweighted = false
+			break
+		}
+	}
+	if allUnweighted {
+		names := make([]string, 0, len(pools))
+		for _, p := range pools {
+			names = append(names, p.Name)
+		}
+		return []KarpenterRecommendation{{
+			Severity:   SeverityInfo,
+			Resource:   "nodepool",
+			Name:       strings.Join(names, ","),
+			Issue:      fmt.Sprintf("%d NodePools with no weight", len(pools)),
+			Detail:     "multiple unweighted NodePools means Karpenter picks one arbitrarily; you have no preference signal",
+			Suggestion: `set spec.weight on each NodePool (higher number wins) so cheaper / spot pools are preferred over fallback ones`,
+		}}
+	}
+	return nil
+}

--- a/internal/k8s/sre/karpenter_advisor_test.go
+++ b/internal/k8s/sre/karpenter_advisor_test.go
@@ -1,0 +1,231 @@
+package sre
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// nodePoolJSON is a small helper to keep test fixtures concise. The
+// fields mirror the parseNodePool consumer in karpenter.go.
+func nodePoolJSON(name, consolidation string, weight int, age time.Duration, nodesProvisioned int, hasLimits bool) string {
+	limits := ""
+	if hasLimits {
+		limits = `"limits": {"cpu": "100", "memory": "200Gi"},`
+	}
+	created := time.Now().UTC().Add(-age).Format(time.RFC3339)
+	return `{
+	  "metadata": {"name": "` + name + `", "creationTimestamp": "` + created + `"},
+	  "spec": {` + limits + `"weight": ` + itoa(weight) + `, "disruption": {"consolidationPolicy": "` + consolidation + `"}}
+	}`
+}
+
+func nodeClaimJSON(name, status string, age time.Duration) string {
+	created := time.Now().UTC().Add(-age).Format(time.RFC3339)
+	condStatus := "False"
+	if status == "Ready" {
+		condStatus = "True"
+	}
+	return `{
+	  "metadata": {"name": "` + name + `", "creationTimestamp": "` + created + `"},
+	  "status": {"conditions": [{"type": "Ready", "status": "` + condStatus + `"}]}
+	}`
+}
+
+// itoa is a private re-implementation to keep this file self-contained.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	if neg {
+		return "-" + string(b)
+	}
+	return string(b)
+}
+
+func wrapItems(items ...string) []byte {
+	return []byte(`{"items": [` + strings.Join(items, ",") + `]}`)
+}
+
+func TestAdvise_NotInstalled(t *testing.T) {
+	a := NewKarpenterAdvisor(&karpenterMock{
+		apiResourcesErr: errors.New("not found"),
+	}, false)
+	report, err := a.Advise(context.Background())
+	if err != nil {
+		t.Fatalf("Advise: %v", err)
+	}
+	if report.Installed {
+		t.Error("should report not-installed when api-resources errors")
+	}
+	if len(report.Recommendations) != 0 {
+		t.Errorf("uninstalled cluster should have 0 recommendations, got %+v", report.Recommendations)
+	}
+}
+
+func TestAdvise_FlagsMissingConsolidation(t *testing.T) {
+	a := NewKarpenterAdvisor(&karpenterMock{
+		apiResourcesOut: "nodepools.karpenter.sh\n",
+		nodePoolsJSON:   wrapItems(nodePoolJSON("default", "", 1, time.Hour, 1, true)),
+	}, false)
+	report, _ := a.Advise(context.Background())
+	if !report.Installed {
+		t.Fatal("should detect karpenter installed")
+	}
+	found := false
+	for _, r := range report.Recommendations {
+		if r.Resource == "nodepool" && strings.Contains(r.Issue, "consolidation") {
+			found = true
+			if r.Severity != SeverityWarning {
+				t.Errorf("missing-consolidation should be warning, got %s", r.Severity)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected missing-consolidation recommendation, got %+v", report.Recommendations)
+	}
+}
+
+func TestAdvise_FlagsUnboundedLimits(t *testing.T) {
+	a := NewKarpenterAdvisor(&karpenterMock{
+		apiResourcesOut: "nodepools.karpenter.sh\n",
+		nodePoolsJSON:   wrapItems(nodePoolJSON("default", "WhenUnderutilized", 0, time.Hour, 0, false)),
+	}, false)
+	report, _ := a.Advise(context.Background())
+	found := false
+	for _, r := range report.Recommendations {
+		if strings.Contains(r.Issue, "no spec.limits") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected unbounded-limits recommendation, got %+v", report.Recommendations)
+	}
+}
+
+func TestAdvise_FlagsStaleNodePool(t *testing.T) {
+	// Pool created > StaleNodePoolThreshold ago with NodesProvisioned=0.
+	a := NewKarpenterAdvisor(&karpenterMock{
+		apiResourcesOut: "nodepools.karpenter.sh\n",
+		nodePoolsJSON:   wrapItems(nodePoolJSON("ghost", "WhenUnderutilized", 1, StaleNodePoolThreshold+time.Hour, 0, true)),
+	}, false)
+	report, _ := a.Advise(context.Background())
+	found := false
+	for _, r := range report.Recommendations {
+		if strings.Contains(r.Issue, "stale") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected stale-pool recommendation, got %+v", report.Recommendations)
+	}
+}
+
+func TestAdvise_DoesNotFlagFreshUnusedPool(t *testing.T) {
+	a := NewKarpenterAdvisor(&karpenterMock{
+		apiResourcesOut: "nodepools.karpenter.sh\n",
+		nodePoolsJSON:   wrapItems(nodePoolJSON("just-created", "WhenUnderutilized", 1, time.Hour, 0, true)),
+	}, false)
+	report, _ := a.Advise(context.Background())
+	for _, r := range report.Recommendations {
+		if strings.Contains(r.Issue, "stale") {
+			t.Errorf("fresh pool should not be flagged stale, got %+v", r)
+		}
+	}
+}
+
+func TestAdvise_FlagsStuckNodeClaim(t *testing.T) {
+	a := NewKarpenterAdvisor(&karpenterMock{
+		apiResourcesOut: "nodepools.karpenter.sh\nnodeclaims.karpenter.sh\n",
+		nodePoolsJSON:   wrapItems(nodePoolJSON("default", "WhenUnderutilized", 1, time.Hour, 1, true)),
+		nodeClaimsJSON:  wrapItems(nodeClaimJSON("stuck", "Pending", NodeClaimStuckThreshold+time.Hour)),
+	}, false)
+	report, _ := a.Advise(context.Background())
+	found := false
+	for _, r := range report.Recommendations {
+		if r.Resource == "nodeclaim" && strings.Contains(r.Issue, "stuck") {
+			found = true
+			if r.Severity != SeverityCritical {
+				t.Errorf("stuck nodeclaim should be critical, got %s", r.Severity)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected stuck-nodeclaim recommendation, got %+v", report.Recommendations)
+	}
+}
+
+func TestAdvise_DoesNotFlagReadyNodeClaim(t *testing.T) {
+	a := NewKarpenterAdvisor(&karpenterMock{
+		apiResourcesOut: "nodepools.karpenter.sh\nnodeclaims.karpenter.sh\n",
+		nodePoolsJSON:   wrapItems(nodePoolJSON("default", "WhenUnderutilized", 1, time.Hour, 1, true)),
+		nodeClaimsJSON:  wrapItems(nodeClaimJSON("healthy", "Ready", NodeClaimStuckThreshold+time.Hour)),
+	}, false)
+	report, _ := a.Advise(context.Background())
+	for _, r := range report.Recommendations {
+		if r.Resource == "nodeclaim" {
+			t.Errorf("Ready nodeclaim should not be flagged, got %+v", r)
+		}
+	}
+}
+
+func TestAdvise_FlagsMultipleUnweightedPools(t *testing.T) {
+	a := NewKarpenterAdvisor(&karpenterMock{
+		apiResourcesOut: "nodepools.karpenter.sh\n",
+		nodePoolsJSON: wrapItems(
+			nodePoolJSON("a", "WhenUnderutilized", 0, time.Hour, 1, true),
+			nodePoolJSON("b", "WhenUnderutilized", 0, time.Hour, 1, true),
+		),
+	}, false)
+	report, _ := a.Advise(context.Background())
+	found := false
+	for _, r := range report.Recommendations {
+		if strings.Contains(r.Issue, "no weight") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected unweighted-pools recommendation, got %+v", report.Recommendations)
+	}
+}
+
+func TestAdvise_DoesNotFlagSinglePoolForWeights(t *testing.T) {
+	// One pool, no weight — shouldn't flag the global "multiple unweighted"
+	// rule because there's nothing to choose between.
+	a := NewKarpenterAdvisor(&karpenterMock{
+		apiResourcesOut: "nodepools.karpenter.sh\n",
+		nodePoolsJSON:   wrapItems(nodePoolJSON("only", "WhenUnderutilized", 0, time.Hour, 1, true)),
+	}, false)
+	report, _ := a.Advise(context.Background())
+	for _, r := range report.Recommendations {
+		if strings.Contains(r.Issue, "no weight") {
+			t.Errorf("single pool should not trigger the unweighted-pools rule, got %+v", r)
+		}
+	}
+}
+
+func TestAdvise_RecommendationsSortedCriticalFirst(t *testing.T) {
+	a := NewKarpenterAdvisor(&karpenterMock{
+		apiResourcesOut: "nodepools.karpenter.sh\nnodeclaims.karpenter.sh\n",
+		nodePoolsJSON:   wrapItems(nodePoolJSON("p1", "", 0, time.Hour, 1, false)),
+		nodeClaimsJSON:  wrapItems(nodeClaimJSON("nc1", "Pending", NodeClaimStuckThreshold+time.Hour)),
+	}, false)
+	report, _ := a.Advise(context.Background())
+	if len(report.Recommendations) == 0 {
+		t.Fatal("expected at least one recommendation")
+	}
+	if report.Recommendations[0].Severity != SeverityCritical {
+		t.Errorf("first recommendation should be critical (stuck NodeClaim), got %s severity", report.Recommendations[0].Severity)
+	}
+}

--- a/internal/k8s/sre/workload_health.go
+++ b/internal/k8s/sre/workload_health.go
@@ -1,0 +1,175 @@
+package sre
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+)
+
+// WorkloadHealthAuditor wraps the existing DiagnosticsManager and rolls
+// per-resource issues up into a categorised report so operators get a
+// single "what's broken in this cluster" view instead of a flat list.
+//
+// Read-only — only kubectl get is invoked via DiagnosticsManager.
+type WorkloadHealthAuditor struct {
+	client K8sClient
+	debug  bool
+}
+
+func NewWorkloadHealthAuditor(client K8sClient, debug bool) *WorkloadHealthAuditor {
+	return &WorkloadHealthAuditor{client: client, debug: debug}
+}
+
+// HealthCategory groups the kinds of failures we count as headline
+// reliability signals. Anything outside these buckets falls into Other.
+type HealthCategory string
+
+const (
+	HealthCategoryCrashLoop    HealthCategory = "CrashLoopBackOff"
+	HealthCategoryOOMKilled    HealthCategory = "OOMKilled"
+	HealthCategoryImagePull    HealthCategory = "ImagePullBackOff"
+	HealthCategoryRestartSpike HealthCategory = "RestartSpike"
+	HealthCategoryNotReady     HealthCategory = "NotReady"
+	HealthCategoryNodePressure HealthCategory = "NodePressure"
+	HealthCategoryOther        HealthCategory = "Other"
+)
+
+// CategoryCount is one row of the rollup.
+type CategoryCount struct {
+	Category HealthCategory `json:"category"`
+	Count    int            `json:"count"`
+}
+
+// HotPod is a frequently-failing pod surfaced to the top of the report.
+type HotPod struct {
+	Namespace  string           `json:"namespace"`
+	Pod        string           `json:"pod"`
+	Issues     int              `json:"issues"`
+	Categories []HealthCategory `json:"categories"`
+}
+
+// WorkloadHealthReport is the audit output.
+type WorkloadHealthReport struct {
+	GeneratedAt time.Time       `json:"generatedAt"`
+	TotalIssues int             `json:"totalIssues"`
+	Critical    int             `json:"critical"`
+	Warning     int             `json:"warning"`
+	Info        int             `json:"info"`
+	ByCategory  []CategoryCount `json:"byCategory,omitempty"`
+	HotPods     []HotPod        `json:"hotPods,omitempty"`
+	Issues      []Issue         `json:"issues,omitempty"`
+	Notes       string          `json:"notes,omitempty"`
+}
+
+// Audit runs DetectClusterIssues, classifies the resulting issues into
+// reliability categories, and returns a sorted rollup. Empty clusters
+// produce an empty report (not an error).
+func (a *WorkloadHealthAuditor) Audit(ctx context.Context) (*WorkloadHealthReport, error) {
+	dm := NewDiagnosticsManager(a.client, a.debug)
+	issues, err := dm.DetectClusterIssues(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	report := &WorkloadHealthReport{
+		GeneratedAt: time.Now().UTC(),
+		TotalIssues: len(issues),
+		Issues:      issues,
+	}
+
+	categoryCounts := map[HealthCategory]int{}
+	hotPods := map[string]*HotPod{}
+	for _, iss := range issues {
+		switch iss.Severity {
+		case SeverityCritical:
+			report.Critical++
+		case SeverityWarning:
+			report.Warning++
+		case SeverityInfo:
+			report.Info++
+		}
+		cat := classifyIssue(iss)
+		categoryCounts[cat]++
+		if iss.ResourceType == ResourcePod {
+			key := iss.Namespace + "/" + iss.ResourceName
+			hp, ok := hotPods[key]
+			if !ok {
+				hp = &HotPod{Namespace: iss.Namespace, Pod: iss.ResourceName}
+				hotPods[key] = hp
+			}
+			hp.Issues++
+			if !containsCategory(hp.Categories, cat) {
+				hp.Categories = append(hp.Categories, cat)
+			}
+		}
+	}
+
+	for cat, n := range categoryCounts {
+		report.ByCategory = append(report.ByCategory, CategoryCount{Category: cat, Count: n})
+	}
+	sort.Slice(report.ByCategory, func(i, j int) bool {
+		if report.ByCategory[i].Count != report.ByCategory[j].Count {
+			return report.ByCategory[i].Count > report.ByCategory[j].Count
+		}
+		return string(report.ByCategory[i].Category) < string(report.ByCategory[j].Category)
+	})
+
+	for _, hp := range hotPods {
+		report.HotPods = append(report.HotPods, *hp)
+	}
+	sort.Slice(report.HotPods, func(i, j int) bool {
+		if report.HotPods[i].Issues != report.HotPods[j].Issues {
+			return report.HotPods[i].Issues > report.HotPods[j].Issues
+		}
+		if report.HotPods[i].Namespace != report.HotPods[j].Namespace {
+			return report.HotPods[i].Namespace < report.HotPods[j].Namespace
+		}
+		return report.HotPods[i].Pod < report.HotPods[j].Pod
+	})
+	// Trim hot pods to a sensible top-N. Operators wanting more can
+	// inspect Issues directly.
+	if len(report.HotPods) > 25 {
+		report.HotPods = report.HotPods[:25]
+	}
+
+	return report, nil
+}
+
+// classifyIssue maps a diagnostic Issue to a HealthCategory by matching
+// the message prefix that detectPodIssues / detectNodeIssues emit. The
+// match is intentionally loose because the existing code uses Sprintf
+// with embedded names ("Container %s is in CrashLoopBackOff") — we want
+// the substring match to survive name variation.
+func classifyIssue(iss Issue) HealthCategory {
+	msg := iss.Message
+	switch {
+	case strings.Contains(msg, "CrashLoopBackOff"):
+		return HealthCategoryCrashLoop
+	case strings.Contains(msg, "OOMKilled"),
+		strings.Contains(msg, "OOM killed"),
+		strings.Contains(msg, "OOM-killed"):
+		return HealthCategoryOOMKilled
+	case strings.Contains(msg, "ImagePullBackOff"), strings.Contains(msg, "ErrImagePull"):
+		return HealthCategoryImagePull
+	case strings.Contains(msg, "restarted"):
+		return HealthCategoryRestartSpike
+	case strings.Contains(msg, "not ready"), strings.Contains(msg, "NotReady"):
+		return HealthCategoryNotReady
+	case strings.Contains(msg, "MemoryPressure"),
+		strings.Contains(msg, "DiskPressure"),
+		strings.Contains(msg, "PIDPressure"),
+		strings.Contains(msg, "NetworkUnavailable"):
+		return HealthCategoryNodePressure
+	}
+	return HealthCategoryOther
+}
+
+func containsCategory(s []HealthCategory, c HealthCategory) bool {
+	for _, x := range s {
+		if x == c {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/k8s/sre/workload_health_test.go
+++ b/internal/k8s/sre/workload_health_test.go
@@ -1,0 +1,188 @@
+package sre
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// healthAuditMock fans diagnostics-manager kubectl calls (RunJSON) to
+// per-resource fixtures. Other interface methods stay no-op.
+type healthAuditMock struct {
+	nodes string
+	pods  string
+}
+
+func (m *healthAuditMock) Run(_ context.Context, _ ...string) (string, error) {
+	return "", nil
+}
+func (m *healthAuditMock) RunWithNamespace(_ context.Context, _ string, _ ...string) (string, error) {
+	return "", nil
+}
+func (m *healthAuditMock) RunJSON(_ context.Context, args ...string) ([]byte, error) {
+	full := strings.Join(args, " ")
+	switch {
+	case strings.Contains(full, "get nodes"):
+		return []byte(m.nodes), nil
+	case strings.Contains(full, "get pods"):
+		return []byte(m.pods), nil
+	}
+	return []byte(`{"items": []}`), nil
+}
+
+func TestAudit_HealthyClusterEmptyReport(t *testing.T) {
+	a := NewWorkloadHealthAuditor(&healthAuditMock{
+		nodes: `{"items": []}`,
+		pods:  `{"items": []}`,
+	}, false)
+	report, err := a.Audit(context.Background())
+	if err != nil {
+		t.Fatalf("Audit: %v", err)
+	}
+	if report.TotalIssues != 0 {
+		t.Errorf("TotalIssues = %d, want 0", report.TotalIssues)
+	}
+	if len(report.ByCategory) != 0 || len(report.HotPods) != 0 {
+		t.Errorf("expected empty rollup on healthy cluster, got %+v", report)
+	}
+}
+
+func TestAudit_ClassifiesAndRollsUp(t *testing.T) {
+	a := NewWorkloadHealthAuditor(&healthAuditMock{
+		nodes: `{"items": []}`,
+		pods: `{
+		  "items": [
+		    {
+		      "metadata": {"name": "crash-1", "namespace": "prod"},
+		      "spec": {"nodeName": "node-a"},
+		      "status": {
+		        "phase": "Running",
+		        "containerStatuses": [
+		          {"name": "app", "ready": false, "restartCount": 12, "state": {"waiting": {"reason": "CrashLoopBackOff", "message": "back-off restarting failed container"}}}
+		        ]
+		      }
+		    },
+		    {
+		      "metadata": {"name": "oom-1", "namespace": "prod"},
+		      "spec": {"nodeName": "node-a"},
+		      "status": {
+		        "phase": "Running",
+		        "containerStatuses": [
+		          {"name": "app", "ready": false, "restartCount": 3, "state": {"terminated": {"reason": "OOMKilled", "exitCode": 137}}}
+		        ]
+		      }
+		    },
+		    {
+		      "metadata": {"name": "imgpull-1", "namespace": "default"},
+		      "spec": {"nodeName": "node-a"},
+		      "status": {
+		        "phase": "Pending",
+		        "containerStatuses": [
+		          {"name": "app", "ready": false, "restartCount": 0, "state": {"waiting": {"reason": "ImagePullBackOff", "message": "manifest unknown"}}}
+		        ]
+		      }
+		    }
+		  ]
+		}`,
+	}, false)
+
+	report, err := a.Audit(context.Background())
+	if err != nil {
+		t.Fatalf("Audit: %v", err)
+	}
+
+	if report.TotalIssues == 0 {
+		t.Fatalf("expected issues to be detected, got 0")
+	}
+
+	// All categories we expect should be in the rollup.
+	cats := map[HealthCategory]int{}
+	for _, c := range report.ByCategory {
+		cats[c.Category] = c.Count
+	}
+	for _, want := range []HealthCategory{HealthCategoryCrashLoop, HealthCategoryOOMKilled, HealthCategoryImagePull} {
+		if cats[want] == 0 {
+			t.Errorf("expected %s in rollup, got %+v", want, report.ByCategory)
+		}
+	}
+
+	// crash-1 should appear in HotPods with CrashLoop + RestartSpike (it's
+	// also flagged as restarting).
+	var crashHot *HotPod
+	for i := range report.HotPods {
+		if report.HotPods[i].Pod == "crash-1" {
+			crashHot = &report.HotPods[i]
+			break
+		}
+	}
+	if crashHot == nil {
+		t.Fatal("crash-1 missing from HotPods")
+	}
+	if crashHot.Issues == 0 {
+		t.Errorf("crash-1 should have at least one issue, got %+v", crashHot)
+	}
+}
+
+func TestClassifyIssue(t *testing.T) {
+	cases := []struct {
+		message string
+		want    HealthCategory
+	}{
+		{"Container app is in CrashLoopBackOff", HealthCategoryCrashLoop},
+		{"Container app was OOMKilled", HealthCategoryOOMKilled},
+		{"Container app has ImagePullBackOff", HealthCategoryImagePull},
+		{"Container app has ErrImagePull", HealthCategoryImagePull},
+		{"Container app has restarted 12 times", HealthCategoryRestartSpike},
+		{"Pod is not ready", HealthCategoryNotReady},
+		{"Node node-a has MemoryPressure", HealthCategoryNodePressure},
+		{"Node node-a has DiskPressure", HealthCategoryNodePressure},
+		{"Node node-a is NetworkUnavailable", HealthCategoryNodePressure},
+		{"some unrelated message", HealthCategoryOther},
+	}
+	for _, c := range cases {
+		got := classifyIssue(Issue{Message: c.message})
+		if got != c.want {
+			t.Errorf("classifyIssue(%q) = %s, want %s", c.message, got, c.want)
+		}
+	}
+}
+
+func TestHotPods_TopNTrim(t *testing.T) {
+	// Build > 25 distinct pods each with one issue and confirm we trim
+	// HotPods to 25.
+	var items strings.Builder
+	items.WriteString(`{"items": [`)
+	for i := 0; i < 30; i++ {
+		if i > 0 {
+			items.WriteString(",")
+		}
+		items.WriteString(`{
+		  "metadata": {"name": "crash-`)
+		// pad so each name is unique
+		items.WriteString(fmtIndex(i))
+		items.WriteString(`", "namespace": "prod"},
+		  "spec": {"nodeName": "node-a"},
+		  "status": {"phase": "Running", "containerStatuses": [{"name": "app", "ready": false, "restartCount": 1, "state": {"waiting": {"reason": "CrashLoopBackOff"}}}]}
+		}`)
+	}
+	items.WriteString(`]}`)
+
+	a := NewWorkloadHealthAuditor(&healthAuditMock{
+		nodes: `{"items": []}`,
+		pods:  items.String(),
+	}, false)
+	report, err := a.Audit(context.Background())
+	if err != nil {
+		t.Fatalf("Audit: %v", err)
+	}
+	if len(report.HotPods) != 25 {
+		t.Errorf("HotPods length = %d, want 25 (trimmed)", len(report.HotPods))
+	}
+}
+
+func fmtIndex(i int) string {
+	if i < 10 {
+		return string(rune('0'+i)) + ""
+	}
+	return string(rune('0'+i/10)) + string(rune('0'+i%10))
+}


### PR DESCRIPTION
## Summary

Phase 6 closes Tier-2 C2: AWS Savings Plan + Reserved Instance purchase recommendations.

## What changed

\`clanker cost savings\` — pulls commitment-purchase recommendations from AWS Cost Explorer and merges Savings Plans + Reserved Instances into one ranked list:

  • **Savings Plans:** Compute / EC2 Instance / SageMaker (3 calls)
  • **Reserved Instances:** EC2 / RDS / ElastiCache / OpenSearch / Redshift (5 calls)
  • Per-recommendation: monthly \$ savings, % savings, breakeven months, instance family/region

Per-family fetch errors fall back to a Note rather than failing the whole report (e.g. SageMaker AccessDenied on accounts that never used SageMaker — operator should still see EC2/RDS recs). Empty accounts produce a sensible "no usage history" note.

New \`cost.SavingsProvider\` interface — vendor-neutral so a future GCP CUD or Azure Reservation provider can plug in without changing the consumer side.

## Stacked on
- bgdnvk/clanker#153 (Phase 5)

## Companion
- clankercloud/clanker-cloud#? — cost drilldown + per-resource cost breakdown UI

## Test plan
- [x] \`make ci\` passes
- [x] 11 unit tests on the pure helpers (lookback / term normalisation, breakeven math, sort order, family extraction, label maps)
- [x] 4 cmd print tests
- [ ] Smoke against an AWS account with usage history