### PR TITLE
fix(cost): pass full AWS service names to GetReservationPurchaseRecommendation

### DIFF
--- a/internal/cost/aws_savings.go
+++ b/internal/cost/aws_savings.go
@@ -52,10 +52,26 @@ func (p *AWSProvider) GetSavingsRecommendations(ctx context.Context, lookback, t
 
 	// 2) Reserved Instances — services that have RI offerings on
 	// Cost Explorer. Each call hits one service.
-	for _, svc := range []string{"AmazonEC2", "AmazonRDS", "AmazonElastiCache", "AmazonOpenSearchService", "AmazonRedshift"} {
+	//
+	// AWS Cost Explorer's GetReservationPurchaseRecommendation expects
+	// the *full* service name as it appears in the AWS billing console,
+	// not the short SDK identifier ("AmazonEC2"). Passing the short
+	// form returns ValidationException with a helpful list of the
+	// 8 supported full names — those are exactly what's enumerated
+	// here. Adding MemoryDB + DynamoDB to surface RI recs that were
+	// previously silently dropped.
+	for _, svc := range []string{
+		"Amazon Elastic Compute Cloud - Compute",
+		"Amazon Relational Database Service",
+		"Amazon ElastiCache",
+		"Amazon OpenSearch Service",
+		"Amazon Redshift",
+		"Amazon MemoryDB Service",
+		"Amazon DynamoDB Service",
+	} {
 		recs, err := p.fetchRIRecs(ctx, svc, lookback, term)
 		if err != nil {
-			appendCostNote(&report.Notes, fmt.Sprintf("%s RI recommendations skipped: %v", svc, err))
+			appendCostNote(&report.Notes, fmt.Sprintf("%s RI recommendations skipped: %v", riServiceLabel(svc), err))
 			continue
 		}
 		report.Recommendations = append(report.Recommendations, recs...)
@@ -231,18 +247,27 @@ func savingsPlanDetail(d types.SavingsPlansPurchaseRecommendationDetail) string 
 	return strings.Join(parts, ", ")
 }
 
+// riServiceLabel maps the full AWS service name (which Cost Explorer's
+// GetReservationPurchaseRecommendation API requires) to the short
+// human-readable label rendered in the CLI table and the JSON output's
+// `service` field. The legacy short codes ("AmazonEC2") are kept as
+// fall-throughs so callers carrying older identifiers still work.
 func riServiceLabel(svc string) string {
 	switch svc {
-	case "AmazonEC2":
+	case "Amazon Elastic Compute Cloud - Compute", "AmazonEC2":
 		return "EC2"
-	case "AmazonRDS":
+	case "Amazon Relational Database Service", "AmazonRDS":
 		return "RDS"
-	case "AmazonElastiCache":
+	case "Amazon ElastiCache", "AmazonElastiCache":
 		return "ElastiCache"
-	case "AmazonOpenSearchService":
+	case "Amazon OpenSearch Service", "AmazonOpenSearchService":
 		return "OpenSearch"
-	case "AmazonRedshift":
+	case "Amazon Redshift", "AmazonRedshift":
 		return "Redshift"
+	case "Amazon MemoryDB Service":
+		return "MemoryDB"
+	case "Amazon DynamoDB Service":
+		return "DynamoDB"
 	}
 	return svc
 }

--- a/internal/cost/aws_savings_test.go
+++ b/internal/cost/aws_savings_test.go
@@ -128,6 +128,17 @@ func TestSavingsPlanFamilyLabel(t *testing.T) {
 
 func TestRIServiceLabel(t *testing.T) {
 	cases := map[string]string{
+		// Full AWS Cost Explorer service names (the canonical inputs
+		// the live API accepts and that fetchRIRecs now passes).
+		"Amazon Elastic Compute Cloud - Compute": "EC2",
+		"Amazon Relational Database Service":     "RDS",
+		"Amazon ElastiCache":                     "ElastiCache",
+		"Amazon OpenSearch Service":              "OpenSearch",
+		"Amazon Redshift":                        "Redshift",
+		"Amazon MemoryDB Service":                "MemoryDB",
+		"Amazon DynamoDB Service":                "DynamoDB",
+		// Legacy short codes preserved for backward-compat with any
+		// caller still passing the SDK-style identifier.
 		"AmazonEC2":               "EC2",
 		"AmazonRDS":               "RDS",
 		"AmazonElastiCache":       "ElastiCache",


### PR DESCRIPTION
## Summary

\`clanker cost savings\` was passing short SDK-style identifiers (\`AmazonEC2\`, \`AmazonRDS\`, …) to AWS Cost Explorer's \`GetReservationPurchaseRecommendation\` API, which rejects them with \`ValidationException: Invalid Service\` and lists the eight canonical full names it accepts.

Five RI calls were silently failing on every \`clanker cost savings\` run. The error noise landed in the report's \`notes\` field but the RI recommendations never reached the user.

## Fix

- Pass the full AWS-canonical service names (\`Amazon Elastic Compute Cloud - Compute\`, \`Amazon Relational Database Service\`, etc.).
- Add coverage for two services we were silently missing: \`Amazon MemoryDB Service\` and \`Amazon DynamoDB Service\`.
- \`riServiceLabel\` keeps the legacy short codes mapped alongside the new full names so any caller still passing \`AmazonEC2\` continues to render \`EC2\` correctly.

## Test plan

- [x] \`go test ./internal/cost/...\` — all green; \`TestRIServiceLabel\` extended to cover both full-name and legacy-short-code inputs.
- [x] \`gofmt\`, \`go vet\` clean.
- [x] **Live verification** against the working AWS account — \`/api/cost/savings\` (clanker-cloud → \`clanker cost savings\`) returned:
  - **Before:** 5 recs, \$150.24/mo, validation errors in \`notes\` for EC2/RDS/ElastiCache/OpenSearch/Redshift.
  - **After:** 7 recs, \$201.97/mo, \`notes\` empty. Two real recs surfaced that were previously silently dropped:
    - \`Amazon EC2\` RI: \$44.30/mo
    - \`Amazon RDS\` RI: \$7.44/mo

## Backward compatibility

The \`riServiceLabel\` switch keeps the old short codes (\`AmazonEC2\` etc.) as fall-throughs alongside the canonical names, so anything in the codebase still carrying the legacy identifiers stays unaffected.