### PR TITLE
[codex] add self update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,34 @@ brew install clanker
 make install
 ```
 
+### Self-update
+
+```bash
+clanker update
+```
+
+By default, `clanker update` replaces the current binary with the latest GitHub
+release from `bgdnvk/clanker`. To track the latest commit on the repository's
+default branch instead, set the update channel during setup:
+
+```bash
+clanker config init --update-channel main
+```
+
+or edit `~/.clanker.yaml`:
+
+```yaml
+update:
+  channel: main # release or main
+```
+
+You can also override it for one run:
+
+```bash
+clanker update --channel release
+clanker update --channel main
+```
+
 ### Requirements
 
 - Go

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bgdnvk/clanker/internal/updater"
 	"github.com/spf13/cobra"
 )
 
@@ -28,6 +29,12 @@ var configInitCmd = &cobra.Command{
 	Short: "Initialize configuration file",
 	Long:  `Create a default configuration file in your home directory.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		updateChannel, _ := cmd.Flags().GetString("update-channel")
+		normalizedUpdateChannel, err := updater.NormalizeChannel(updateChannel)
+		if err != nil {
+			return err
+		}
+
 		home, err := os.UserHomeDir()
 		if err != nil {
 			return fmt.Errorf("error finding home directory: %w", err)
@@ -209,7 +216,13 @@ codebase:
 
 # General settings
 timeout: 30  # Timeout for AI requests in seconds
+
+# Self-update settings for 'clanker update'.
+# Use "release" for the latest GitHub release, or "main" for the latest commit on the default branch.
+update:
+  channel: __UPDATE_CHANNEL__
 `
+		defaultConfig = strings.ReplaceAll(defaultConfig, "__UPDATE_CHANNEL__", normalizedUpdateChannel)
 
 		err = os.WriteFile(configPath, []byte(defaultConfig), 0644)
 		if err != nil {
@@ -935,6 +948,7 @@ func init() {
 	configCmd.AddCommand(configShowCmd)
 	configCmd.AddCommand(configScanCmd)
 
+	configInitCmd.Flags().String("update-channel", updater.ChannelRelease, "default self-update channel for clanker update: release or main")
 	configScanCmd.Flags().StringP("output", "o", "", "Output format (json for JSON output)")
 	configScanCmd.Flags().StringSlice("aws-paths", []string{}, "Custom AWS credential file paths to scan (comma-separated)")
 	configScanCmd.Flags().StringSlice("gcp-paths", []string{}, "Custom GCP credential file paths to scan (comma-separated)")

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/bgdnvk/clanker/internal/updater"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update clanker",
+	Long: `Update the clanker binary from GitHub.
+
+By default, clanker updates from the latest GitHub release. Set update.channel
+to "main" in ~/.clanker.yaml, or pass --channel main, to build and install the
+latest commit from the main branch instead.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		channel, _ := cmd.Flags().GetString("channel")
+		if strings.TrimSpace(channel) == "" {
+			channel = viper.GetString("update.channel")
+		}
+
+		repo, _ := cmd.Flags().GetString("repo")
+		installPath, _ := cmd.Flags().GetString("install-path")
+		force, _ := cmd.Flags().GetBool("force")
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+		token := strings.TrimSpace(viper.GetString("github.token"))
+		if token == "" {
+			token = os.Getenv("GITHUB_TOKEN")
+		}
+
+		result, err := updater.Update(cmd.Context(), updater.Options{
+			Channel:        channel,
+			Repo:           repo,
+			InstallPath:    installPath,
+			CurrentVersion: Version,
+			Token:          token,
+			Force:          force,
+			DryRun:         dryRun,
+			Stdout:         cmd.OutOrStdout(),
+			Stderr:         cmd.ErrOrStderr(),
+		})
+		if err != nil {
+			return err
+		}
+
+		if dryRun {
+			if result.Channel == updater.ChannelMain {
+				fmt.Fprintf(cmd.OutOrStdout(), "Would update clanker from %s commit %s into %s\n", result.SourceURL, result.TargetSHA, result.InstallPath)
+				return nil
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Would update clanker to %s from %s into %s\n", result.TargetVersion, result.SourceURL, result.InstallPath)
+			return nil
+		}
+
+		if !result.Updated {
+			fmt.Fprintf(cmd.OutOrStdout(), "clanker is already up to date (%s)\n", result.TargetVersion)
+			return nil
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Updated clanker to %s via %s at %s\n", result.TargetVersion, result.Channel, result.InstallPath)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(updateCmd)
+
+	updateCmd.Flags().String("channel", "", "update channel: release or main (default: update.channel config or release)")
+	updateCmd.Flags().String("repo", updater.DefaultRepo, "GitHub repository to update from, in owner/repo form")
+	updateCmd.Flags().String("install-path", "", "path to replace (default: current clanker executable)")
+	updateCmd.Flags().Bool("force", false, "update even if the current version appears current")
+	updateCmd.Flags().Bool("dry-run", false, "show what would be updated without changing files")
+}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -1,0 +1,409 @@
+package updater
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultRepo = "bgdnvk/clanker"
+
+	ChannelRelease = "release"
+	ChannelMain    = "main"
+)
+
+type Options struct {
+	Channel        string
+	Repo           string
+	InstallPath    string
+	CurrentVersion string
+	Token          string
+	Force          bool
+	DryRun         bool
+	HTTPClient     *http.Client
+	Stdout         io.Writer
+	Stderr         io.Writer
+}
+
+type Result struct {
+	Channel       string
+	TargetVersion string
+	TargetSHA     string
+	SourceURL     string
+	InstallPath   string
+	Updated       bool
+}
+
+type githubRelease struct {
+	TagName string        `json:"tag_name"`
+	Assets  []githubAsset `json:"assets"`
+}
+
+type githubAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+type githubBranch struct {
+	Commit struct {
+		SHA string `json:"sha"`
+	} `json:"commit"`
+}
+
+type githubRepo struct {
+	DefaultBranch string `json:"default_branch"`
+}
+
+func Update(ctx context.Context, opts Options) (Result, error) {
+	channel, err := NormalizeChannel(opts.Channel)
+	if err != nil {
+		return Result{}, err
+	}
+
+	repo := strings.TrimSpace(opts.Repo)
+	if repo == "" {
+		repo = DefaultRepo
+	}
+	if err := validateRepo(repo); err != nil {
+		return Result{}, err
+	}
+
+	installPath := strings.TrimSpace(opts.InstallPath)
+	if installPath == "" {
+		installPath, err = os.Executable()
+		if err != nil {
+			return Result{}, fmt.Errorf("determine current executable path: %w", err)
+		}
+	}
+
+	client := opts.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Minute}
+	}
+
+	out := opts.Stdout
+	if out == nil {
+		out = io.Discard
+	}
+	errOut := opts.Stderr
+	if errOut == nil {
+		errOut = io.Discard
+	}
+
+	switch channel {
+	case ChannelRelease:
+		return updateFromLatestRelease(ctx, client, out, repo, installPath, opts)
+	case ChannelMain:
+		return updateFromMain(ctx, client, out, errOut, repo, installPath, opts)
+	default:
+		return Result{}, fmt.Errorf("unsupported update channel %q", channel)
+	}
+}
+
+func updateFromLatestRelease(ctx context.Context, client *http.Client, out io.Writer, repo, installPath string, opts Options) (Result, error) {
+	release, err := latestRelease(ctx, client, repo, opts.Token)
+	if err != nil {
+		return Result{}, err
+	}
+	if strings.TrimSpace(release.TagName) == "" {
+		return Result{}, errors.New("latest GitHub release did not include a tag")
+	}
+
+	result := Result{
+		Channel:       ChannelRelease,
+		TargetVersion: release.TagName,
+		InstallPath:   installPath,
+	}
+	if strings.TrimSpace(opts.CurrentVersion) == release.TagName && !opts.Force {
+		return result, nil
+	}
+
+	asset, err := SelectAsset(release.Assets, runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		return Result{}, err
+	}
+	result.SourceURL = asset.BrowserDownloadURL
+
+	if opts.DryRun {
+		return result, nil
+	}
+
+	fmt.Fprintf(out, "Downloading %s...\n", asset.Name)
+	binary, err := downloadReleaseBinary(ctx, client, asset.BrowserDownloadURL, opts.Token)
+	if err != nil {
+		return Result{}, err
+	}
+
+	if err := installBinary(binary, installPath); err != nil {
+		return Result{}, err
+	}
+	result.Updated = true
+	return result, nil
+}
+
+func updateFromMain(ctx context.Context, client *http.Client, out, errOut io.Writer, repo, installPath string, opts Options) (Result, error) {
+	branch, sha, err := latestMainCommit(ctx, client, repo, opts.Token)
+	if err != nil {
+		return Result{}, err
+	}
+	if strings.TrimSpace(sha) == "" {
+		return Result{}, errors.New("GitHub main branch response did not include a commit SHA")
+	}
+
+	result := Result{
+		Channel:       ChannelMain,
+		TargetVersion: "main-" + shortSHA(sha),
+		TargetSHA:     sha,
+		SourceURL:     fmt.Sprintf("https://github.com/%s/tree/%s", repo, branch),
+		InstallPath:   installPath,
+	}
+	if strings.TrimSpace(opts.CurrentVersion) == result.TargetVersion && !opts.Force {
+		return result, nil
+	}
+	if opts.DryRun {
+		return result, nil
+	}
+
+	fmt.Fprintf(out, "Building clanker from %s@%s...\n", repo, shortSHA(sha))
+	binary, err := buildMainBinary(ctx, out, errOut, repo, sha)
+	if err != nil {
+		return Result{}, err
+	}
+	if err := installBinary(binary, installPath); err != nil {
+		return Result{}, err
+	}
+	result.Updated = true
+	return result, nil
+}
+
+func NormalizeChannel(channel string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(channel)) {
+	case "", ChannelRelease, "latest", "github-release", "github-releases", "releases":
+		return ChannelRelease, nil
+	case ChannelMain, "master", "source", "commit", "tip":
+		return ChannelMain, nil
+	default:
+		return "", fmt.Errorf("invalid update channel %q (expected %q or %q)", channel, ChannelRelease, ChannelMain)
+	}
+}
+
+func AssetName(tag, goos, goarch string) string {
+	return fmt.Sprintf("clanker_%s_%s_%s.tar.gz", tag, goos, goarch)
+}
+
+func SelectAsset(assets []githubAsset, goos, goarch string) (githubAsset, error) {
+	want := AssetName("*", goos, goarch)
+	for _, asset := range assets {
+		name := strings.TrimSpace(asset.Name)
+		if name == "" || strings.TrimSpace(asset.BrowserDownloadURL) == "" {
+			continue
+		}
+		if strings.Contains(name, "_"+goos+"_"+goarch+".tar.gz") {
+			return asset, nil
+		}
+	}
+	return githubAsset{}, fmt.Errorf("latest release does not include a %s asset", want)
+}
+
+func latestRelease(ctx context.Context, client *http.Client, repo, token string) (githubRelease, error) {
+	var release githubRelease
+	if err := githubJSON(ctx, client, repo, token, "releases/latest", &release); err != nil {
+		return githubRelease{}, fmt.Errorf("fetch latest release: %w", err)
+	}
+	return release, nil
+}
+
+func latestMainCommit(ctx context.Context, client *http.Client, repo, token string) (string, string, error) {
+	branchName := "main"
+	var repoInfo githubRepo
+	if err := githubJSON(ctx, client, repo, token, "", &repoInfo); err != nil {
+		return "", "", fmt.Errorf("fetch repository metadata: %w", err)
+	}
+	if strings.TrimSpace(repoInfo.DefaultBranch) != "" {
+		branchName = repoInfo.DefaultBranch
+	}
+
+	var branch githubBranch
+	if err := githubJSON(ctx, client, repo, token, "branches/"+branchName, &branch); err != nil {
+		return "", "", fmt.Errorf("fetch %s branch: %w", branchName, err)
+	}
+	return branchName, branch.Commit.SHA, nil
+}
+
+func githubJSON(ctx context.Context, client *http.Client, repo, token, path string, target any) error {
+	url := fmt.Sprintf("https://api.github.com/repos/%s", repo)
+	if strings.TrimSpace(path) != "" {
+		url += "/" + strings.TrimLeft(path, "/")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "clanker-updater")
+	if token = strings.TrimSpace(token); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return fmt.Errorf("GitHub API returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+	return json.NewDecoder(resp.Body).Decode(target)
+}
+
+func downloadReleaseBinary(ctx context.Context, client *http.Client, url, token string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "clanker-updater")
+	if token = strings.TrimSpace(token); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("download returned %s: %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+	return extractBinaryFromTarGz(resp.Body)
+}
+
+func extractBinaryFromTarGz(r io.Reader) ([]byte, error) {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return nil, fmt.Errorf("open tarball: %w", err)
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		header, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read tarball: %w", err)
+		}
+		if header == nil || header.Typeflag != tar.TypeReg || filepath.Base(header.Name) != "clanker" {
+			continue
+		}
+		binary, err := io.ReadAll(tr)
+		if err != nil {
+			return nil, fmt.Errorf("read clanker binary from tarball: %w", err)
+		}
+		if len(binary) == 0 {
+			return nil, errors.New("release tarball contained an empty clanker binary")
+		}
+		return binary, nil
+	}
+	return nil, errors.New("release tarball did not contain a clanker binary")
+}
+
+func buildMainBinary(ctx context.Context, out, errOut io.Writer, repo, sha string) ([]byte, error) {
+	if _, err := exec.LookPath("go"); err != nil {
+		return nil, fmt.Errorf("go is required to update from main: %w", err)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "clanker-update-main")
+	if err != nil {
+		return nil, fmt.Errorf("create temp build dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	version := "main-" + shortSHA(sha)
+	module := "github.com/" + repo + "@" + sha
+	cmd := exec.CommandContext(ctx, "go", "install", "-ldflags", "-X github.com/bgdnvk/clanker/cmd.Version="+version, module)
+	cmd.Env = append(os.Environ(), "GOBIN="+tmpDir)
+	cmd.Stdout = out
+	cmd.Stderr = errOut
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("go install %s: %w", module, err)
+	}
+
+	binaryPath := filepath.Join(tmpDir, "clanker")
+	if runtime.GOOS == "windows" {
+		binaryPath += ".exe"
+	}
+	binary, err := os.ReadFile(binaryPath)
+	if err != nil {
+		return nil, fmt.Errorf("read built binary: %w", err)
+	}
+	if len(binary) == 0 {
+		return nil, errors.New("built clanker binary was empty")
+	}
+	return binary, nil
+}
+
+func installBinary(binary []byte, installPath string) error {
+	targetInfo, err := os.Stat(installPath)
+	mode := os.FileMode(0755)
+	if err == nil {
+		mode = targetInfo.Mode().Perm()
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("stat install path %s: %w", installPath, err)
+	}
+
+	dir := filepath.Dir(installPath)
+	tmp, err := os.CreateTemp(dir, ".clanker-update-*")
+	if err != nil {
+		return fmt.Errorf("create temp file in %s: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := tmp.Write(binary); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write updated binary: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close updated binary: %w", err)
+	}
+	if err := os.Chmod(tmpPath, mode); err != nil {
+		return fmt.Errorf("chmod updated binary: %w", err)
+	}
+	if err := os.Rename(tmpPath, installPath); err != nil {
+		return fmt.Errorf("replace %s: %w", installPath, err)
+	}
+	return nil
+}
+
+func validateRepo(repo string) error {
+	parts := strings.Split(repo, "/")
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return fmt.Errorf("invalid GitHub repository %q (expected owner/repo)", repo)
+	}
+	return nil
+}
+
+func shortSHA(sha string) string {
+	sha = strings.TrimSpace(sha)
+	if len(sha) <= 12 {
+		return sha
+	}
+	return sha[:12]
+}

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -1,0 +1,152 @@
+package updater
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeChannel(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "empty defaults to release", input: "", want: ChannelRelease},
+		{name: "release", input: "release", want: ChannelRelease},
+		{name: "latest alias", input: "latest", want: ChannelRelease},
+		{name: "main", input: "main", want: ChannelMain},
+		{name: "master alias", input: "master", want: ChannelMain},
+		{name: "invalid", input: "nightly", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeChannel(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NormalizeChannel returned error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("NormalizeChannel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSelectAssetChoosesPlatformTarball(t *testing.T) {
+	assets := []githubAsset{
+		{Name: "clanker_v1.2.3_darwin_amd64.tar.gz", BrowserDownloadURL: "https://example.com/amd64"},
+		{Name: "clanker_v1.2.3_darwin_arm64.tar.gz", BrowserDownloadURL: "https://example.com/arm64"},
+	}
+
+	got, err := SelectAsset(assets, "darwin", "arm64")
+	if err != nil {
+		t.Fatalf("SelectAsset returned error: %v", err)
+	}
+	if got.BrowserDownloadURL != "https://example.com/arm64" {
+		t.Fatalf("selected %q, want arm64 asset", got.BrowserDownloadURL)
+	}
+}
+
+func TestSelectAssetRejectsMissingPlatformTarball(t *testing.T) {
+	_, err := SelectAsset([]githubAsset{
+		{Name: "clanker_v1.2.3_darwin_arm64.tar.gz", BrowserDownloadURL: "https://example.com/arm64"},
+	}, "linux", "arm64")
+	if err == nil {
+		t.Fatal("expected missing asset error")
+	}
+}
+
+func TestExtractBinaryFromTarGz(t *testing.T) {
+	const want = "fake binary"
+	tarball := makeTarGz(t, "clanker", want)
+
+	got, err := extractBinaryFromTarGz(bytes.NewReader(tarball))
+	if err != nil {
+		t.Fatalf("extractBinaryFromTarGz returned error: %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("extracted %q, want %q", string(got), want)
+	}
+}
+
+func TestUpdateMainUsesRepositoryDefaultBranch(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		body := `{}`
+		switch req.URL.Path {
+		case "/repos/bgdnvk/clanker":
+			body = `{"default_branch":"master"}`
+		case "/repos/bgdnvk/clanker/branches/master":
+			body = `{"commit":{"sha":"1234567890abcdef"}}`
+		default:
+			t.Fatalf("unexpected request path: %s", req.URL.Path)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})}
+
+	result, err := Update(context.Background(), Options{
+		Channel:     ChannelMain,
+		HTTPClient:  client,
+		DryRun:      true,
+		InstallPath: "/tmp/clanker",
+	})
+	if err != nil {
+		t.Fatalf("Update returned error: %v", err)
+	}
+	if result.TargetSHA != "1234567890abcdef" {
+		t.Fatalf("TargetSHA = %q, want repository default branch SHA", result.TargetSHA)
+	}
+	if !strings.HasSuffix(result.SourceURL, "/tree/master") {
+		t.Fatalf("SourceURL = %q, want master branch URL", result.SourceURL)
+	}
+}
+
+func makeTarGz(t *testing.T, name string, content string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	if err := tw.WriteHeader(&tar.Header{
+		Name: name,
+		Mode: 0755,
+		Size: int64(len(content)),
+	}); err != nil {
+		t.Fatalf("WriteHeader: %v", err)
+	}
+	if _, err := io.WriteString(tw, content); err != nil {
+		t.Fatalf("WriteString: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar close: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}


### PR DESCRIPTION
## Summary

- add `clanker update` with release and source-update channels
- default release updates download the matching GitHub release tarball and replace the current executable
- `main` channel builds the latest commit from the repository default branch and installs it in place
- add `clanker config init --update-channel` plus README setup docs

## Validation

- `go test ./internal/updater ./cmd`
- `go build ./...`
- `go run . update --dry-run --channel main`
- `go run . update --dry-run --channel release`
- `go test ./...`
