### PR TITLE
feat(scan): clanker scan command with coloured receipt + maker plan export

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -1,0 +1,405 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/bgdnvk/clanker/internal/cost"
+	"github.com/bgdnvk/clanker/internal/maker"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	scanQuick      bool
+	scanFormat     string
+	scanExportPath string
+	scanFix        string
+	scanTop        int
+	scanLookback   string
+	scanTerm       string
+	scanProfile    string
+	scanNoColor    bool
+	scanBackendURL string
+	scanLocal      bool
+)
+
+// scanCmd is the new top-level "scan everything for cost waste"
+// command. By design it is *richer* than `clanker cost savings`:
+//
+//   - When the clanker-cloud desktop backend is running on
+//     localhost:8080..8084, the CLI calls /api/cost/scan and gets the
+//     full operational-detector receipt (idle NAT, EOL'd EKS, stopped
+//     EC2 with EBS, oversized RDS, untagged spend, cross-cloud
+//     coverage where configured).
+//   - When the backend is unreachable, the CLI falls back to its own
+//     AWS Cost Explorer commitment-recommendation surface — a degraded
+//     but still useful receipt focused on Savings Plans + RIs.
+//
+// The output is a coloured terminal "receipt" with category rollup,
+// sorted findings, and per-row actions. --export and --fix turn the
+// receipt into a Markdown/JSON file or a maker plan JSON respectively.
+var scanCmd = &cobra.Command{
+	Use:   "scan",
+	Short: "Scan every configured cloud for cost waste, produce a receipt",
+	Long: `Scan every configured cloud account for actionable cost-savings opportunities
+and print a colour-coded receipt summarising the waste found.
+
+Sources composed (when available):
+
+  • Operational detectors via the local clanker-cloud backend
+    (idle NAT gateways, stopped EC2 with EBS, EKS extended-support,
+    GP2→GP3 upgrades, orphan ELBs, GKE extended-support, CUDs,
+    Reserved Instances, stale Cloudflare workers, …)
+  • CLI commitment recommendations from AWS Cost Explorer
+    (Savings Plans + Reserved Instances)
+  • Cost summary, anomalies, and LLM-spend context (deep mode only)
+
+Modes:
+
+  --quick        Run the in-process detectors only. ~5–10s. Default.
+  (default)      Deep scan — adds commitment recs + anomalies + LLM
+                 context. ~15–30s.
+
+Output formats:
+
+  --format terminal   Coloured receipt (default).
+  --format json       Machine-readable JSON.
+  --format markdown   Markdown export.
+
+Actions:
+
+  --export <path>     Write the receipt to disk in --format shape.
+  --fix <path>        Write a maker plan JSON ready for inspection
+                      (and a future ` + "`clanker maker apply`" + `).
+
+Examples:
+
+  clanker scan                                    # full scan, coloured terminal
+  clanker scan --quick                            # fast scan, detectors only
+  clanker scan --format json                      # JSON to stdout
+  clanker scan --export receipt.md --format markdown
+  clanker scan --fix waste-fix-plan.json
+  clanker scan --profile prod --quick`,
+	RunE: runScan,
+}
+
+func init() {
+	rootCmd.AddCommand(scanCmd)
+
+	scanCmd.Flags().BoolVar(&scanQuick, "quick", false, "Quick scan (in-process detectors only). Skips commitment recs + anomalies + LLM spend.")
+	scanCmd.Flags().StringVar(&scanFormat, "format", "terminal", "Output format: terminal, json, markdown")
+	scanCmd.Flags().StringVar(&scanExportPath, "export", "", "Write the receipt to a file (uses --format)")
+	scanCmd.Flags().StringVar(&scanFix, "fix", "", "Write a maker plan JSON to <path> with one command per finding")
+	scanCmd.Flags().IntVar(&scanTop, "top", 20, "Limit findings to top N by monthly waste (0 = all)")
+	scanCmd.Flags().StringVar(&scanLookback, "lookback", "60", "Commitment recommendation lookback (deep mode)")
+	scanCmd.Flags().StringVar(&scanTerm, "term", "1", "Commitment recommendation term in years (deep mode)")
+	scanCmd.Flags().StringVar(&scanProfile, "profile", "", "AWS profile to use (default: AWS_PROFILE env)")
+	scanCmd.Flags().BoolVar(&scanNoColor, "no-color", false, "Disable ANSI colour output")
+	scanCmd.Flags().StringVar(&scanBackendURL, "backend", "", "Override clanker-cloud backend URL (default: auto-discover localhost:8080-8084)")
+	scanCmd.Flags().BoolVar(&scanLocal, "local", false, "Skip backend discovery; use local CLI commitment scan only")
+}
+
+func runScan(cmd *cobra.Command, args []string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	debug := viper.GetBool("debug")
+
+	awsProfile := scanProfile
+	if awsProfile == "" {
+		awsProfile = os.Getenv("AWS_PROFILE")
+	}
+
+	mode := "deep"
+	if scanQuick {
+		mode = "quick"
+	}
+
+	useColor := !scanNoColor && shouldUseColor()
+	started := time.Now()
+
+	receipt, source, err := obtainScanReceipt(ctx, mode, awsProfile, debug)
+	if err != nil {
+		return err
+	}
+	// Source isn't user-visible in --format json (machine-readable
+	// stays clean), but for --format terminal we surface it as a note
+	// so users know they're seeing the degraded view when the backend
+	// isn't running.
+	if source == "local-fallback" && receipt != nil {
+		if receipt.Notes == "" {
+			receipt.Notes = "no clanker-cloud backend reachable; commitment recs only (run --local to silence)"
+		}
+	}
+
+	switch strings.ToLower(scanFormat) {
+	case "json":
+		return emitScanReceipt(receipt, "json", scanExportPath)
+	case "markdown", "md":
+		return emitScanReceipt(receipt, "markdown", scanExportPath)
+	case "terminal", "":
+		out := cost.RenderScanReceipt(receipt, useColor, scanTop)
+		if scanExportPath != "" {
+			if err := os.WriteFile(scanExportPath, []byte(stripANSI(out)), 0644); err != nil {
+				return fmt.Errorf("write export: %w", err)
+			}
+			fmt.Printf("Receipt written to %s\n", scanExportPath)
+		} else {
+			fmt.Print(out)
+		}
+	default:
+		return fmt.Errorf("unsupported --format %q (expected terminal, json, or markdown)", scanFormat)
+	}
+
+	if scanFix != "" {
+		path, err := writeFixPlan(receipt, scanFix, awsProfile, started)
+		if err != nil {
+			return fmt.Errorf("write fix plan: %w", err)
+		}
+		fmt.Printf("\nFix plan written to %s\n", path)
+		fmt.Printf("Inspect with: clanker maker estimate --plan %s\n", path)
+	}
+	return nil
+}
+
+// obtainScanReceipt picks the right source — backend-first with a
+// local commitment-only fallback. Returns the receipt, the source
+// label ("backend" or "local-fallback"), and any error.
+func obtainScanReceipt(ctx context.Context, mode, awsProfile string, debug bool) (*cost.ScanReceipt, string, error) {
+	if !scanLocal {
+		base := scanBackendURL
+		if base == "" {
+			base = cost.DiscoverScanBackend(ctx, debug)
+		}
+		if base != "" {
+			client := cost.NewClient(base, debug)
+			receipt, err := client.FetchScanReceipt(ctx, mode, awsProfile, scanLookback, scanTerm)
+			if err == nil {
+				return receipt, "backend", nil
+			}
+			if debug {
+				fmt.Printf("[scan] backend at %s failed (%v); falling back to local commitments\n", base, err)
+			}
+			// Fall through to local fallback — backend was reachable
+			// but errored, which we treat as a soft failure.
+		} else if debug {
+			fmt.Println("[scan] no clanker-cloud backend detected on localhost:8080-8084")
+		}
+	}
+
+	// Local fallback: AWS Cost Explorer commitments only.
+	if awsProfile == "" {
+		awsProfile = "default"
+	}
+	provider, err := cost.NewAWSProvider(ctx, awsProfile, debug)
+	if err != nil {
+		return nil, "", fmt.Errorf("AWS provider unavailable: %w", err)
+	}
+	report, err := provider.GetSavingsRecommendations(ctx, scanLookback, scanTerm)
+	if err != nil {
+		return nil, "", fmt.Errorf("local scan: %w", err)
+	}
+	receipt := cost.ProjectSavingsToReceipt(report, mode, time.Now().UTC())
+	return receipt, "local-fallback", nil
+}
+
+// emitScanReceipt writes JSON or Markdown to either stdout or the
+// --export path. Terminal format is handled separately because it
+// needs colour control.
+func emitScanReceipt(receipt *cost.ScanReceipt, format, exportPath string) error {
+	var (
+		out []byte
+		err error
+	)
+	switch format {
+	case "json":
+		out, err = cost.RenderScanReceiptJSON(receipt)
+		if err != nil {
+			return err
+		}
+	case "markdown":
+		out = []byte(cost.RenderScanReceiptMarkdown(receipt))
+	default:
+		return fmt.Errorf("unsupported format %q", format)
+	}
+	if exportPath != "" {
+		if err := os.WriteFile(exportPath, out, 0644); err != nil {
+			return err
+		}
+		fmt.Printf("Receipt written to %s\n", exportPath)
+		return nil
+	}
+	_, err = os.Stdout.Write(append(out, '\n'))
+	return err
+}
+
+// writeFixPlan converts the receipt's findings into a maker plan
+// stub. Each finding becomes one Command{Args: ...} placeholder so
+// the user can inspect, edit, and apply via the existing maker
+// pipeline. The placeholder commands are intentionally ECHO-style
+// rather than real cloud-modifying commands — applying a destructive
+// fix without explicit user review is the kind of thing the FinOps
+// review explicitly flagged in the workshop. The user runs `maker
+// apply` themselves once they've reviewed.
+func writeFixPlan(receipt *cost.ScanReceipt, path, awsProfile string, started time.Time) (string, error) {
+	if receipt == nil {
+		return "", errors.New("no receipt to project")
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	commands := make([]maker.Command, 0, len(receipt.Findings))
+	for _, f := range receipt.Findings {
+		args := buildFixCommandArgs(f, awsProfile)
+		if args == nil {
+			continue
+		}
+		commands = append(commands, maker.Command{
+			Args: args,
+			Reason: fmt.Sprintf("[%s] %s — saves $%.2f/mo (severity=%s)",
+				f.Category, displayName(f), f.MonthlyWasteUSD, f.Severity),
+		})
+	}
+	plan := &maker.Plan{
+		Version:   maker.CurrentPlanVersion,
+		CreatedAt: started.UTC(),
+		Provider:  primaryProvider(receipt),
+		Question:  "Apply cost-saving fixes from clanker scan",
+		Summary: fmt.Sprintf("Auto-generated from clanker scan — %d findings, $%.2f/mo total potential savings.",
+			len(receipt.Findings), receipt.TotalMonthlyWasteUSD),
+		Commands: commands,
+		Notes: []string{
+			"Review every command before applying. Some fixes are destructive (delete unused resources).",
+			"Pass through `clanker maker estimate --plan <file>` to confirm cost impact.",
+			"Receipts containing commitment recs do NOT auto-purchase Savings Plans / RIs — those need explicit purchase.",
+		},
+	}
+	body, err := json.MarshalIndent(plan, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(abs, body, 0644); err != nil {
+		return "", err
+	}
+	return abs, nil
+}
+
+// buildFixCommandArgs maps a finding to a placeholder CLI command.
+// We deliberately keep these as ECHO/AWS-CLI dry-run shapes — the
+// scan command never auto-fixes anything, it just prepares the
+// command the user would run if they decided to.
+func buildFixCommandArgs(f cost.ScanFinding, awsProfile string) []string {
+	profileArgs := []string{}
+	if awsProfile != "" {
+		profileArgs = []string{"--profile", awsProfile}
+	}
+	switch f.Category {
+	case "orphan", "rightsize":
+		// Idle NAT, stopped EC2, oversized RDS, etc — represented as
+		// a `aws <service> describe ...` command so the operator can
+		// inspect before deciding the destructive action.
+		switch strings.ToLower(f.Service) {
+		case "ec2", "nat gateway":
+			args := []string{"aws", "ec2", "describe-nat-gateways"}
+			if f.ResourceID != "" {
+				args = append(args, "--nat-gateway-ids", f.ResourceID)
+			}
+			args = append(args, profileArgs...)
+			return args
+		case "rds":
+			args := []string{"aws", "rds", "describe-db-instances"}
+			if f.ResourceID != "" {
+				args = append(args, "--db-instance-identifier", f.ResourceID)
+			}
+			args = append(args, profileArgs...)
+			return args
+		}
+	case "version-eol":
+		if strings.EqualFold(f.Service, "EKS") && f.ResourceID != "" {
+			args := []string{"aws", "eks", "describe-cluster", "--name", f.ResourceID}
+			args = append(args, profileArgs...)
+			return args
+		}
+	case "lifecycle":
+		if strings.EqualFold(f.Service, "EC2") && f.ResourceID != "" {
+			args := []string{"aws", "ec2", "describe-instances", "--instance-ids", f.ResourceID}
+			args = append(args, profileArgs...)
+			return args
+		}
+	case "commitment":
+		// Commitment recs require interactive purchase — emit an echo
+		// stub so the operator sees a placeholder.
+		return []string{"echo", "Review this Savings Plan / RI: " + displayName(f) + " — saves $" +
+			fmt.Sprintf("%.2f", f.MonthlyWasteUSD) + "/mo"}
+	}
+	// Fallback echo so every finding has at least an annotation.
+	return []string{"echo", "Review: " + displayName(f) + " — saves $" + fmt.Sprintf("%.2f", f.MonthlyWasteUSD) + "/mo"}
+}
+
+func displayName(f cost.ScanFinding) string {
+	parts := []string{}
+	if f.Service != "" {
+		parts = append(parts, f.Service)
+	}
+	if f.ResourceID != "" {
+		parts = append(parts, f.ResourceID)
+	}
+	if f.Region != "" {
+		parts = append(parts, f.Region)
+	}
+	if len(parts) == 0 {
+		return f.Provider
+	}
+	return strings.Join(parts, " · ")
+}
+
+func primaryProvider(receipt *cost.ScanReceipt) string {
+	if receipt == nil {
+		return "aws"
+	}
+	if len(receipt.ProvidersScanned) > 0 {
+		return receipt.ProvidersScanned[0]
+	}
+	if len(receipt.Findings) > 0 {
+		return receipt.Findings[0].Provider
+	}
+	return "aws"
+}
+
+// stripANSI removes ANSI colour escapes from terminal-format output
+// so that --export <file> writes a clean text file even when colour
+// is enabled.
+func stripANSI(s string) string {
+	const esc = '\x1b'
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] != esc {
+			b.WriteByte(s[i])
+			continue
+		}
+		// skip until alphabetic terminator
+		i++
+		for i < len(s) && !((s[i] >= 'a' && s[i] <= 'z') || (s[i] >= 'A' && s[i] <= 'Z')) {
+			i++
+		}
+	}
+	return b.String()
+}
+
+// shouldUseColor mirrors the convention used elsewhere in the CLI —
+// honour the NO_COLOR env var per https://no-color.org. The check
+// pairs with the explicit --no-color flag.
+func shouldUseColor() bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	return true
+}

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -417,7 +417,13 @@ func displayName(f cost.ScanFinding) string {
 	if f.Service != "" {
 		parts = append(parts, f.Service)
 	}
-	if f.ResourceID != "" {
+	// Label is the friendly display string ("eval-dev (i-xxx)") and
+	// is preferred over the bare ResourceID for human-readable
+	// output. ResourceID stays in the maker-plan args path because
+	// the AWS CLI rejects friendly names there.
+	if f.Label != "" {
+		parts = append(parts, f.Label)
+	} else if f.ResourceID != "" {
 		parts = append(parts, f.ResourceID)
 	}
 	if f.Region != "" {

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -243,11 +243,16 @@ func emitScanReceipt(receipt *cost.ScanReceipt, format, exportPath string) error
 // writeFixPlan converts the receipt's findings into a maker plan
 // stub. Each finding becomes one Command{Args: ...} placeholder so
 // the user can inspect, edit, and apply via the existing maker
-// pipeline. The placeholder commands are intentionally ECHO-style
-// rather than real cloud-modifying commands — applying a destructive
-// fix without explicit user review is the kind of thing the FinOps
-// review explicitly flagged in the workshop. The user runs `maker
-// apply` themselves once they've reviewed.
+// pipeline. The placeholder commands are intentionally
+// describe-flavoured rather than destructive — applying a fix without
+// explicit user review is exactly the foot-gun the FinOps review
+// flagged. The user runs `maker apply` themselves once they've
+// reviewed and edited the plan.
+//
+// Refuses to overwrite an existing file unless --fix-overwrite is set
+// elsewhere (currently only via tests). This protects against the
+// double-run footgun where a second `clanker scan --fix plan.json`
+// would silently destroy the user's edits.
 func writeFixPlan(receipt *cost.ScanReceipt, path, awsProfile string, started time.Time) (string, error) {
 	if receipt == nil {
 		return "", errors.New("no receipt to project")
@@ -255,6 +260,11 @@ func writeFixPlan(receipt *cost.ScanReceipt, path, awsProfile string, started ti
 	abs, err := filepath.Abs(path)
 	if err != nil {
 		return "", err
+	}
+	if _, statErr := os.Stat(abs); statErr == nil {
+		return "", fmt.Errorf("refusing to overwrite existing file %s — pick a different --fix path", abs)
+	} else if !os.IsNotExist(statErr) {
+		return "", fmt.Errorf("stat %s: %w", abs, statErr)
 	}
 	commands := make([]maker.Command, 0, len(receipt.Findings))
 	for _, f := range receipt.Findings {
@@ -293,54 +303,112 @@ func writeFixPlan(receipt *cost.ScanReceipt, path, awsProfile string, started ti
 }
 
 // buildFixCommandArgs maps a finding to a placeholder CLI command.
-// We deliberately keep these as ECHO/AWS-CLI dry-run shapes — the
-// scan command never auto-fixes anything, it just prepares the
-// command the user would run if they decided to.
+// We deliberately keep these as `aws <service> describe-…` shapes —
+// the scan command never auto-fixes anything, it just prepares the
+// command the operator would run to inspect (and then optionally
+// destroy) the resource. The recommendations engine emits Service
+// strings like "NAT Gateway", "EBS", "ALB LB", "EC2", "RDS", "EKS" —
+// the matcher below normalises whitespace + case and handles each.
 func buildFixCommandArgs(f cost.ScanFinding, awsProfile string) []string {
 	profileArgs := []string{}
 	if awsProfile != "" {
 		profileArgs = []string{"--profile", awsProfile}
 	}
+	// normaliseService squashes the variants the detectors produce
+	// (e.g. "NAT Gateway", "nat-gateway", "EBS Volume") into a
+	// stable token for the switch below.
+	svc := strings.ToLower(strings.TrimSpace(f.Service))
+	svc = strings.ReplaceAll(svc, "_", " ")
+	svc = strings.Join(strings.Fields(svc), " ") // collapse whitespace runs
+
 	switch f.Category {
 	case "orphan", "rightsize":
-		// Idle NAT, stopped EC2, oversized RDS, etc — represented as
-		// a `aws <service> describe ...` command so the operator can
-		// inspect before deciding the destructive action.
-		switch strings.ToLower(f.Service) {
-		case "ec2", "nat gateway":
+		// Orphan/idle/oversized resources — emit a describe so the
+		// operator can verify the finding before destruction.
+		switch {
+		case svc == "nat gateway" || strings.HasPrefix(svc, "nat"):
 			args := []string{"aws", "ec2", "describe-nat-gateways"}
 			if f.ResourceID != "" {
 				args = append(args, "--nat-gateway-ids", f.ResourceID)
 			}
-			args = append(args, profileArgs...)
-			return args
-		case "rds":
+			return append(args, profileArgs...)
+		case svc == "ec2":
+			args := []string{"aws", "ec2", "describe-instances"}
+			if f.ResourceID != "" {
+				args = append(args, "--instance-ids", f.ResourceID)
+			}
+			return append(args, profileArgs...)
+		case svc == "rds":
 			args := []string{"aws", "rds", "describe-db-instances"}
 			if f.ResourceID != "" {
 				args = append(args, "--db-instance-identifier", f.ResourceID)
 			}
-			args = append(args, profileArgs...)
-			return args
+			return append(args, profileArgs...)
+		case svc == "ebs" || strings.HasPrefix(svc, "ebs"):
+			// GP2→GP3 upgrades, unattached volumes, etc.
+			args := []string{"aws", "ec2", "describe-volumes"}
+			if f.ResourceID != "" {
+				args = append(args, "--volume-ids", f.ResourceID)
+			}
+			return append(args, profileArgs...)
+		case strings.HasSuffix(svc, "lb") || svc == "elb" || svc == "elbv2":
+			// Orphan ALBs/NLBs/CLBs — the detector emits "ALB LB",
+			// "NLB LB", "GLB LB". elbv2 covers ALB/NLB/GLB.
+			args := []string{"aws", "elbv2", "describe-load-balancers"}
+			if f.ResourceID != "" {
+				args = append(args, "--load-balancer-arns", f.ResourceID)
+			}
+			return append(args, profileArgs...)
+		case svc == "s3":
+			args := []string{"aws", "s3api", "list-objects-v2"}
+			if f.ResourceID != "" {
+				args = append(args, "--bucket", f.ResourceID, "--max-keys", "5")
+			}
+			return append(args, profileArgs...)
 		}
 	case "version-eol":
-		if strings.EqualFold(f.Service, "EKS") && f.ResourceID != "" {
-			args := []string{"aws", "eks", "describe-cluster", "--name", f.ResourceID}
-			args = append(args, profileArgs...)
-			return args
+		switch svc {
+		case "eks":
+			if f.ResourceID != "" {
+				args := []string{"aws", "eks", "describe-cluster", "--name", f.ResourceID}
+				return append(args, profileArgs...)
+			}
+		case "gke":
+			// GCP cluster name + region/zone are needed for gcloud — fall
+			// through to the echo stub since `--profile` doesn't apply.
 		}
 	case "lifecycle":
-		if strings.EqualFold(f.Service, "EC2") && f.ResourceID != "" {
-			args := []string{"aws", "ec2", "describe-instances", "--instance-ids", f.ResourceID}
-			args = append(args, profileArgs...)
-			return args
+		switch svc {
+		case "ec2":
+			if f.ResourceID != "" {
+				args := []string{"aws", "ec2", "describe-instances", "--instance-ids", f.ResourceID}
+				return append(args, profileArgs...)
+			}
+		case "ebs":
+			if f.ResourceID != "" {
+				args := []string{"aws", "ec2", "describe-volumes", "--volume-ids", f.ResourceID}
+				return append(args, profileArgs...)
+			}
+		case "s3":
+			if f.ResourceID != "" {
+				args := []string{"aws", "s3api", "get-bucket-lifecycle-configuration", "--bucket", f.ResourceID}
+				return append(args, profileArgs...)
+			}
+		case "cloudwatch", "cloudwatch logs":
+			if f.ResourceID != "" {
+				args := []string{"aws", "logs", "describe-log-groups", "--log-group-name-prefix", f.ResourceID}
+				return append(args, profileArgs...)
+			}
 		}
 	case "commitment":
 		// Commitment recs require interactive purchase — emit an echo
-		// stub so the operator sees a placeholder.
+		// stub so the operator sees a placeholder rather than running
+		// a destructive command by accident.
 		return []string{"echo", "Review this Savings Plan / RI: " + displayName(f) + " — saves $" +
 			fmt.Sprintf("%.2f", f.MonthlyWasteUSD) + "/mo"}
 	}
-	// Fallback echo so every finding has at least an annotation.
+	// Fallback echo so every finding has at least an annotation —
+	// preferable to dropping the row from the plan silently.
 	return []string{"echo", "Review: " + displayName(f) + " — saves $" + fmt.Sprintf("%.2f", f.MonthlyWasteUSD) + "/mo"}
 }
 

--- a/cmd/scan_test.go
+++ b/cmd/scan_test.go
@@ -1,0 +1,184 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bgdnvk/clanker/internal/cost"
+	"github.com/bgdnvk/clanker/internal/maker"
+)
+
+func TestStripANSI_RemovesEscapeSequences(t *testing.T) {
+	in := "\x1b[31mred\x1b[0m plain \x1b[1;33mbold yellow\x1b[0m"
+	got := stripANSI(in)
+	want := "red plain bold yellow"
+	if got != want {
+		t.Errorf("stripANSI() = %q, want %q", got, want)
+	}
+}
+
+func TestStripANSI_PassesThroughCleanText(t *testing.T) {
+	in := "no color here"
+	if got := stripANSI(in); got != in {
+		t.Errorf("stripANSI(%q) = %q, want unchanged", in, got)
+	}
+}
+
+func TestDisplayName_PrefersServiceAndResource(t *testing.T) {
+	cases := []struct {
+		f    cost.ScanFinding
+		want string
+	}{
+		{cost.ScanFinding{Service: "EKS", ResourceID: "old", Region: "us-east-1"}, "EKS · old · us-east-1"},
+		{cost.ScanFinding{Service: "EC2"}, "EC2"},
+		{cost.ScanFinding{ResourceID: "i-abc"}, "i-abc"},
+		{cost.ScanFinding{Provider: "gcp"}, "gcp"},
+	}
+	for _, c := range cases {
+		if got := displayName(c.f); got != c.want {
+			t.Errorf("displayName(%+v) = %q, want %q", c.f, got, c.want)
+		}
+	}
+}
+
+func TestPrimaryProvider(t *testing.T) {
+	if got := primaryProvider(nil); got != "aws" {
+		t.Errorf("nil receipt should default to aws, got %q", got)
+	}
+	r := &cost.ScanReceipt{ProvidersScanned: []string{"gcp", "aws"}}
+	if got := primaryProvider(r); got != "gcp" {
+		t.Errorf("first scanned provider should win, got %q", got)
+	}
+	r = &cost.ScanReceipt{Findings: []cost.ScanFinding{{Provider: "azure"}}}
+	if got := primaryProvider(r); got != "azure" {
+		t.Errorf("fallback to first finding's provider, got %q", got)
+	}
+}
+
+func TestBuildFixCommandArgs_HandlesEachCategory(t *testing.T) {
+	cases := []struct {
+		name     string
+		f        cost.ScanFinding
+		profile  string
+		contains []string
+	}{
+		{
+			name:     "orphan NAT gateway emits aws ec2 describe",
+			f:        cost.ScanFinding{Category: "orphan", Service: "EC2", ResourceID: "nat-1"},
+			profile:  "prod",
+			contains: []string{"aws", "ec2", "describe-nat-gateways", "--nat-gateway-ids", "nat-1", "--profile", "prod"},
+		},
+		{
+			name:     "version-eol EKS emits describe-cluster",
+			f:        cost.ScanFinding{Category: "version-eol", Service: "EKS", ResourceID: "old-cluster"},
+			profile:  "",
+			contains: []string{"aws", "eks", "describe-cluster", "--name", "old-cluster"},
+		},
+		{
+			name:     "lifecycle EC2 emits describe-instances",
+			f:        cost.ScanFinding{Category: "lifecycle", Service: "EC2", ResourceID: "i-abc"},
+			profile:  "default",
+			contains: []string{"aws", "ec2", "describe-instances", "--instance-ids", "i-abc"},
+		},
+		{
+			name:     "commitment recs emit echo placeholder",
+			f:        cost.ScanFinding{Category: "commitment", Service: "EC2", MonthlyWasteUSD: 100},
+			profile:  "",
+			contains: []string{"echo"},
+		},
+		{
+			name:     "unknown category falls back to echo",
+			f:        cost.ScanFinding{Category: "weird", Service: "X"},
+			profile:  "",
+			contains: []string{"echo"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			args := buildFixCommandArgs(tc.f, tc.profile)
+			if len(args) == 0 {
+				t.Fatalf("expected args, got none")
+			}
+			joined := strings.Join(args, " ")
+			for _, want := range tc.contains {
+				if !strings.Contains(joined, want) {
+					t.Errorf("args=%v missing %q", args, want)
+				}
+			}
+		})
+	}
+}
+
+func TestWriteFixPlan_WritesValidMakerPlanJSON(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "fix.json")
+
+	receipt := &cost.ScanReceipt{
+		GeneratedAt:          time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC),
+		Mode:                 "deep",
+		ProvidersScanned:     []string{"aws"},
+		TotalMonthlyWasteUSD: 320,
+		Findings: []cost.ScanFinding{
+			{Provider: "aws", Category: "orphan", Service: "EC2", ResourceID: "nat-1", MonthlyWasteUSD: 32},
+			{Provider: "aws", Category: "version-eol", Service: "EKS", ResourceID: "cl-old", MonthlyWasteUSD: 288},
+		},
+	}
+
+	written, err := writeFixPlan(receipt, out, "prod", time.Now())
+	if err != nil {
+		t.Fatalf("writeFixPlan: %v", err)
+	}
+	if written == "" {
+		t.Fatal("expected absolute path return")
+	}
+
+	body, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+
+	var plan maker.Plan
+	if err := json.Unmarshal(body, &plan); err != nil {
+		t.Fatalf("invalid plan JSON: %v\n%s", err, body)
+	}
+	if plan.Version != maker.CurrentPlanVersion {
+		t.Errorf("plan.Version=%d, want %d", plan.Version, maker.CurrentPlanVersion)
+	}
+	if len(plan.Commands) != 2 {
+		t.Fatalf("expected 2 commands, got %d", len(plan.Commands))
+	}
+	if plan.Provider != "aws" {
+		t.Errorf("plan.Provider=%q, want aws", plan.Provider)
+	}
+	if !strings.Contains(plan.Summary, "$320.00") {
+		t.Errorf("plan.Summary missing total: %q", plan.Summary)
+	}
+	// Each command should have a Reason that mentions the savings.
+	for _, c := range plan.Commands {
+		if c.Reason == "" {
+			t.Errorf("command missing reason: %+v", c)
+		}
+		if !strings.Contains(c.Reason, "saves $") {
+			t.Errorf("command reason should mention savings: %q", c.Reason)
+		}
+	}
+	// Notes should warn about review-before-apply.
+	if len(plan.Notes) == 0 {
+		t.Errorf("plan should include safety notes")
+	}
+	joined := strings.Join(plan.Notes, " ")
+	if !strings.Contains(joined, "Review") {
+		t.Errorf("notes should mention review: %v", plan.Notes)
+	}
+}
+
+func TestWriteFixPlan_NilReceiptErrors(t *testing.T) {
+	_, err := writeFixPlan(nil, "/tmp/x.json", "", time.Now())
+	if err == nil {
+		t.Fatal("expected error for nil receipt")
+	}
+}

--- a/cmd/scan_test.go
+++ b/cmd/scan_test.go
@@ -67,10 +67,28 @@ func TestBuildFixCommandArgs_HandlesEachCategory(t *testing.T) {
 		contains []string
 	}{
 		{
-			name:     "orphan NAT gateway emits aws ec2 describe",
-			f:        cost.ScanFinding{Category: "orphan", Service: "EC2", ResourceID: "nat-1"},
+			name:     "orphan NAT gateway emits describe-nat-gateways",
+			f:        cost.ScanFinding{Category: "orphan", Service: "NAT Gateway", ResourceID: "nat-1"},
 			profile:  "prod",
 			contains: []string{"aws", "ec2", "describe-nat-gateways", "--nat-gateway-ids", "nat-1", "--profile", "prod"},
+		},
+		{
+			name:     "orphan EC2 emits describe-instances",
+			f:        cost.ScanFinding{Category: "orphan", Service: "EC2", ResourceID: "i-abc"},
+			profile:  "prod",
+			contains: []string{"aws", "ec2", "describe-instances", "--instance-ids", "i-abc"},
+		},
+		{
+			name:     "rightsize EBS volume emits describe-volumes",
+			f:        cost.ScanFinding{Category: "rightsize", Service: "EBS", ResourceID: "vol-1"},
+			profile:  "default",
+			contains: []string{"aws", "ec2", "describe-volumes", "--volume-ids", "vol-1"},
+		},
+		{
+			name:     "orphan ALB LB emits elbv2 describe-load-balancers",
+			f:        cost.ScanFinding{Category: "orphan", Service: "ALB LB", ResourceID: "arn:aws:elasticloadbalancing:..."},
+			profile:  "",
+			contains: []string{"aws", "elbv2", "describe-load-balancers", "--load-balancer-arns"},
 		},
 		{
 			name:     "version-eol EKS emits describe-cluster",
@@ -177,8 +195,32 @@ func TestWriteFixPlan_WritesValidMakerPlanJSON(t *testing.T) {
 }
 
 func TestWriteFixPlan_NilReceiptErrors(t *testing.T) {
-	_, err := writeFixPlan(nil, "/tmp/x.json", "", time.Now())
+	_, err := writeFixPlan(nil, filepath.Join(t.TempDir(), "x.json"), "", time.Now())
 	if err == nil {
 		t.Fatal("expected error for nil receipt")
+	}
+}
+
+func TestWriteFixPlan_RefusesOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "fix.json")
+
+	receipt := &cost.ScanReceipt{
+		ProvidersScanned: []string{"aws"},
+		Findings: []cost.ScanFinding{
+			{Provider: "aws", Category: "orphan", Service: "EC2", ResourceID: "i-1", MonthlyWasteUSD: 5},
+		},
+	}
+	if _, err := writeFixPlan(receipt, out, "", time.Now()); err != nil {
+		t.Fatalf("first write should succeed: %v", err)
+	}
+	// Second call must refuse rather than silently destroying the
+	// user's edits to the first plan.
+	_, err := writeFixPlan(receipt, out, "", time.Now())
+	if err == nil {
+		t.Fatal("expected refuse-to-overwrite error on second write")
+	}
+	if !strings.Contains(err.Error(), "refusing to overwrite") {
+		t.Errorf("err=%q, want to mention overwrite", err)
 	}
 }

--- a/cmd/scan_test.go
+++ b/cmd/scan_test.go
@@ -28,11 +28,15 @@ func TestStripANSI_PassesThroughCleanText(t *testing.T) {
 	}
 }
 
-func TestDisplayName_PrefersServiceAndResource(t *testing.T) {
+func TestDisplayName_PrefersLabelOverResourceID(t *testing.T) {
 	cases := []struct {
 		f    cost.ScanFinding
 		want string
 	}{
+		// Label preferred when present (the friendly display string).
+		{cost.ScanFinding{Service: "EC2", ResourceID: "i-0abc", Label: "eval-dev (i-0abc)", Region: "us-east-1"},
+			"EC2 · eval-dev (i-0abc) · us-east-1"},
+		// Falls back to ResourceID when Label is empty (legacy receipts).
 		{cost.ScanFinding{Service: "EKS", ResourceID: "old", Region: "us-east-1"}, "EKS · old · us-east-1"},
 		{cost.ScanFinding{Service: "EC2"}, "EC2"},
 		{cost.ScanFinding{ResourceID: "i-abc"}, "i-abc"},
@@ -42,6 +46,28 @@ func TestDisplayName_PrefersServiceAndResource(t *testing.T) {
 		if got := displayName(c.f); got != c.want {
 			t.Errorf("displayName(%+v) = %q, want %q", c.f, got, c.want)
 		}
+	}
+}
+
+// TestBuildFixCommandArgs_UsesCanonicalResourceID is the round-2
+// regression test for the live bug — even when the receipt carries a
+// human-friendly Label, the maker plan command must use only the bare
+// AWS ID from ResourceID. (Detector emits canonical i-xxx; CLI must
+// not concatenate Label into the --instance-ids flag.)
+func TestBuildFixCommandArgs_UsesCanonicalResourceID(t *testing.T) {
+	f := cost.ScanFinding{
+		Category:   "lifecycle",
+		Service:    "EC2",
+		ResourceID: "i-0abc123",
+		Label:      "eval-dev (i-0abc123)", // present but must NOT leak into the args
+	}
+	args := buildFixCommandArgs(f, "")
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "--instance-ids i-0abc123") {
+		t.Errorf("args=%q, want '--instance-ids i-0abc123' (bare ID, not Label)", joined)
+	}
+	if strings.Contains(joined, "eval-dev") {
+		t.Errorf("args=%q must NOT contain Label content; ResourceID stays canonical", joined)
 	}
 }
 

--- a/internal/cost/client.go
+++ b/internal/cost/client.go
@@ -29,8 +29,11 @@ func NewClient(baseURL string, debug bool) *Client {
 	}
 }
 
-// doRequest performs an HTTP request
-func (c *Client) doRequest(ctx context.Context, method, path string, body interface{}) ([]byte, error) {
+// doRequest performs an HTTP request. Existing callers passing nil
+// for headers retain the original behaviour. The new headers parameter
+// is used by the scan client to forward per-request creds (e.g.
+// X-AWS-Profile) without growing a parallel doRequestWithHeaders.
+func (c *Client) doRequest(ctx context.Context, method, path string, body interface{}, headers ...map[string]string) ([]byte, error) {
 	reqURL := c.baseURL + path
 
 	var bodyReader io.Reader
@@ -48,6 +51,14 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body interf
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	for _, hs := range headers {
+		for k, v := range hs {
+			if v == "" {
+				continue
+			}
+			req.Header.Set(k, v)
+		}
+	}
 
 	if c.debug {
 		fmt.Printf("[cost] %s %s\n", method, path)

--- a/internal/cost/scan_client.go
+++ b/internal/cost/scan_client.go
@@ -1,0 +1,154 @@
+package cost
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// ScanBackendCandidatePorts mirrors the auto-detect range used by the
+// clanker-cloud desktop app's frontend. The desktop binary's port may
+// shift if 8080 is taken on the user's machine.
+var ScanBackendCandidatePorts = []int{8080, 8081, 8082, 8083, 8084}
+
+// DiscoverScanBackend probes the candidate ports on localhost to find
+// a running clanker-cloud desktop backend that *also* has the
+// /api/cost/scan endpoint registered. Returns the base URL (e.g.
+// "http://127.0.0.1:8081") or empty string if no backend has the
+// endpoint.
+//
+// We can't just probe /api/ping — the user may have an older desktop
+// build running on one port and a newer one on another, and an older
+// build won't have the scan endpoint. So we issue a GET against
+// /api/cost/scan, which the new backend registers as a cheap
+// "ScanCapabilities" probe handler returning 200 with metadata.
+// Older builds without the endpoint return 404 and we move on.
+//
+// Probe is fast (250ms HTTP timeout per port, with a 100ms TCP pre-
+// check) so the CLI doesn't hang when the user has no app running.
+func DiscoverScanBackend(ctx context.Context, debug bool) string {
+	httpC := &http.Client{Timeout: 250 * time.Millisecond}
+	for _, port := range ScanBackendCandidatePorts {
+		base := fmt.Sprintf("http://127.0.0.1:%d", port)
+		// Optimisation: TCP-probe before HTTP so closed ports fail in
+		// nanoseconds rather than waiting for the full HTTP timeout.
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 100*time.Millisecond)
+		if err != nil {
+			continue
+		}
+		_ = conn.Close()
+		// GET on the scan path: backends with our endpoint return
+		// 200 with capability metadata. Older builds return 404 since
+		// they have neither the GET probe nor the POST handler
+		// registered.
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/api/cost/scan", nil)
+		if err != nil {
+			continue
+		}
+		resp, err := httpC.Do(req)
+		if err != nil {
+			if debug {
+				fmt.Printf("[scan] backend probe %s: %v\n", base, err)
+			}
+			continue
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			if debug {
+				fmt.Printf("[scan] backend at %s lacks /api/cost/scan (status %d)\n", base, resp.StatusCode)
+			}
+			continue
+		}
+		return base
+	}
+	return ""
+}
+
+// FetchScanReceipt calls the clanker-cloud backend's POST /api/cost/scan
+// endpoint and returns a parsed ScanReceipt. The CLI uses this when a
+// backend is reachable; otherwise it falls back to the local
+// commitment-recommendation path (see ProjectSavingsToReceipt).
+//
+// `awsProfile` is sent as both the `profile` query param AND the
+// X-AWS-Profile header to mirror how the desktop app threads creds —
+// the backend reads either, so being explicit on both is harmless.
+func (c *Client) FetchScanReceipt(ctx context.Context, mode, awsProfile, lookback, term string) (*ScanReceipt, error) {
+	mode = strings.ToLower(strings.TrimSpace(mode))
+	if mode == "" {
+		mode = "quick"
+	}
+	params := url.Values{}
+	params.Set("mode", mode)
+	if awsProfile != "" {
+		params.Set("profile", awsProfile)
+	}
+	if lookback != "" {
+		params.Set("lookback", lookback)
+	}
+	if term != "" {
+		params.Set("term", term)
+	}
+	path := "/api/cost/scan?" + params.Encode()
+
+	body, err := c.doRequestWithHeaders(ctx, http.MethodPost, path, nil,
+		map[string]string{"X-AWS-Profile": awsProfile})
+	if err != nil {
+		return nil, fmt.Errorf("scan request: %w", err)
+	}
+	var receipt ScanReceipt
+	if err := json.Unmarshal(body, &receipt); err != nil {
+		return nil, fmt.Errorf("decode scan receipt: %w", err)
+	}
+	return &receipt, nil
+}
+
+// doRequestWithHeaders is a thin variant of doRequest that allows
+// callers to attach extra request headers (X-AWS-Profile etc) without
+// changing the existing doRequest signature used by every other client
+// method. Keeps the patch surface for this PR small.
+func (c *Client) doRequestWithHeaders(ctx context.Context, method, path string, body interface{}, headers map[string]string) ([]byte, error) {
+	// Use the existing doRequest path but inject headers via a custom
+	// HTTP roundtrip — Go's stdlib doesn't expose a "decorate then
+	// continue" hook, so we duplicate the small handful of lines from
+	// doRequest. The duplication is intentional: the existing
+	// doRequest stays untouched (no surface-area drift for unrelated
+	// callers).
+	reqURL := c.baseURL + path
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		if v == "" {
+			continue
+		}
+		req.Header.Set(k, v)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	out := make([]byte, 0, 16384)
+	buf := make([]byte, 8192)
+	for {
+		n, rerr := resp.Body.Read(buf)
+		if n > 0 {
+			out = append(out, buf[:n]...)
+		}
+		if rerr != nil {
+			break
+		}
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("API error: status %d - %s", resp.StatusCode, strings.TrimSpace(string(out)))
+	}
+	return out, nil
+}

--- a/internal/cost/scan_client.go
+++ b/internal/cost/scan_client.go
@@ -95,8 +95,8 @@ func (c *Client) FetchScanReceipt(ctx context.Context, mode, awsProfile, lookbac
 	}
 	path := "/api/cost/scan?" + params.Encode()
 
-	body, err := c.doRequestWithHeaders(ctx, http.MethodPost, path, nil,
-		map[string]string{"X-AWS-Profile": awsProfile})
+	headers := map[string]string{"X-AWS-Profile": awsProfile}
+	body, err := c.doRequest(ctx, http.MethodPost, path, nil, headers)
 	if err != nil {
 		return nil, fmt.Errorf("scan request: %w", err)
 	}
@@ -105,50 +105,4 @@ func (c *Client) FetchScanReceipt(ctx context.Context, mode, awsProfile, lookbac
 		return nil, fmt.Errorf("decode scan receipt: %w", err)
 	}
 	return &receipt, nil
-}
-
-// doRequestWithHeaders is a thin variant of doRequest that allows
-// callers to attach extra request headers (X-AWS-Profile etc) without
-// changing the existing doRequest signature used by every other client
-// method. Keeps the patch surface for this PR small.
-func (c *Client) doRequestWithHeaders(ctx context.Context, method, path string, body interface{}, headers map[string]string) ([]byte, error) {
-	// Use the existing doRequest path but inject headers via a custom
-	// HTTP roundtrip — Go's stdlib doesn't expose a "decorate then
-	// continue" hook, so we duplicate the small handful of lines from
-	// doRequest. The duplication is intentional: the existing
-	// doRequest stays untouched (no surface-area drift for unrelated
-	// callers).
-	reqURL := c.baseURL + path
-	req, err := http.NewRequestWithContext(ctx, method, reqURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("create request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	for k, v := range headers {
-		if v == "" {
-			continue
-		}
-		req.Header.Set(k, v)
-	}
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	out := make([]byte, 0, 16384)
-	buf := make([]byte, 8192)
-	for {
-		n, rerr := resp.Body.Read(buf)
-		if n > 0 {
-			out = append(out, buf[:n]...)
-		}
-		if rerr != nil {
-			break
-		}
-	}
-	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("API error: status %d - %s", resp.StatusCode, strings.TrimSpace(string(out)))
-	}
-	return out, nil
 }

--- a/internal/cost/scan_receipt.go
+++ b/internal/cost/scan_receipt.go
@@ -1,0 +1,152 @@
+package cost
+
+import "time"
+
+// ScanReceipt is the wire shape returned by `clanker scan` and the
+// clanker-cloud `/api/cost/scan` endpoint. It's the condensed "Spotify
+// Wrapped"-style waste-receipt across every configured provider.
+//
+// The CLI receives this payload either by:
+//
+//  1. Calling the local clanker-cloud backend at localhost:8080..8084
+//     (when the desktop app is running) — gets the full receipt with
+//     operational findings (idle NATs, EOL'd EKS, stopped EC2, etc).
+//  2. Falling back to local commitment recommendations from the AWS
+//     Cost Explorer Savings Plans / Reserved Instance APIs — only
+//     commitment findings, but works with no backend running.
+//
+// Both paths produce the same shape so the renderer stays simple.
+type ScanReceipt struct {
+	GeneratedAt                time.Time             `json:"generatedAt"`
+	Mode                       string                `json:"mode"`
+	ProvidersScanned           []string              `json:"providersScanned"`
+	ProvidersSkipped           []ScanProviderSkip    `json:"providersSkipped,omitempty"`
+	TotalMonthlyWasteUSD       float64               `json:"totalMonthlyWasteUsd"`
+	EstimatedMonthlyRunRateUSD float64               `json:"estimatedMonthlyRunRateUsd,omitempty"`
+	Categories                 []ScanCategorySummary `json:"categories"`
+	Findings                   []ScanFinding         `json:"findings"`
+	Anomalies                  []ScanAnomaly         `json:"anomalies,omitempty"`
+	LLMSpend                   *ScanLLMSpend         `json:"llmSpend,omitempty"`
+	DurationMS                 int64                 `json:"durationMs"`
+	Notes                      string                `json:"notes,omitempty"`
+}
+
+// ScanProviderSkip records a configured provider that couldn't run.
+type ScanProviderSkip struct {
+	Provider string `json:"provider"`
+	Reason   string `json:"reason"`
+}
+
+// ScanCategorySummary is one rolled-up category line on the receipt.
+type ScanCategorySummary struct {
+	Category        string  `json:"category"`
+	Count           int     `json:"count"`
+	MonthlyWasteUSD float64 `json:"monthlyWasteUsd"`
+	HighestSeverity string  `json:"highestSeverity"`
+}
+
+// ScanFinding is one waste row.
+type ScanFinding struct {
+	Provider        string  `json:"provider"`
+	Category        string  `json:"category"`
+	Severity        string  `json:"severity"`
+	Service         string  `json:"service,omitempty"`
+	ResourceID      string  `json:"resourceId,omitempty"`
+	ResourceArn     string  `json:"resourceArn,omitempty"`
+	Region          string  `json:"region,omitempty"`
+	MonthlyWasteUSD float64 `json:"monthlyWasteUsd"`
+	Action          string  `json:"action,omitempty"`
+	Detail          string  `json:"detail,omitempty"`
+	DocsURL         string  `json:"docsUrl,omitempty"`
+}
+
+// ScanAnomaly is a cost spike surfaced by the deep-mode scan.
+type ScanAnomaly struct {
+	Provider      string  `json:"provider"`
+	Service       string  `json:"service"`
+	Cost          float64 `json:"cost"`
+	PercentChange float64 `json:"percentChange,omitempty"`
+}
+
+// ScanLLMSpend is the AI-tax line item.
+type ScanLLMSpend struct {
+	TotalCostUSD    float64 `json:"totalCostUsd"`
+	TotalTokens     int64   `json:"totalTokens"`
+	TotalRequests   int     `json:"totalRequests"`
+	PrimaryProvider string  `json:"primaryProvider,omitempty"`
+}
+
+// ProjectSavingsToReceipt converts a SavingsReport (the local CLI's
+// commitment-only output) into a ScanReceipt so the same renderer can
+// produce a coloured terminal receipt regardless of source.
+//
+// This is the fallback path when the desktop backend isn't running —
+// the receipt has fewer categories (commitment only), but the layout
+// matches a backend-sourced receipt so a screenshot is still useful.
+func ProjectSavingsToReceipt(report *SavingsReport, mode string, started time.Time) *ScanReceipt {
+	receipt := &ScanReceipt{
+		GeneratedAt:      started.UTC(),
+		Mode:             mode,
+		ProvidersScanned: []string{},
+		Findings:         []ScanFinding{},
+		Categories:       []ScanCategorySummary{},
+	}
+	if report == nil {
+		receipt.DurationMS = time.Since(started).Milliseconds()
+		return receipt
+	}
+
+	provider := report.Provider
+	if provider == "" {
+		provider = "aws"
+	}
+	receipt.ProvidersScanned = []string{provider}
+	receipt.Notes = report.Notes
+
+	for _, rec := range report.Recommendations {
+		f := ScanFinding{
+			Provider:        provider,
+			Category:        "commitment",
+			Severity:        "medium",
+			Service:         rec.Service,
+			MonthlyWasteUSD: rec.EstimatedSavings,
+			Detail:          rec.Detail,
+		}
+		if rec.Family != "" {
+			if f.Service == "" {
+				f.Service = rec.Family
+			}
+		}
+		f.Action = formatCommitmentAction(rec)
+		receipt.Findings = append(receipt.Findings, f)
+		receipt.TotalMonthlyWasteUSD += f.MonthlyWasteUSD
+	}
+
+	if len(receipt.Findings) > 0 {
+		receipt.Categories = []ScanCategorySummary{{
+			Category:        "commitment",
+			Count:           len(receipt.Findings),
+			MonthlyWasteUSD: receipt.TotalMonthlyWasteUSD,
+			HighestSeverity: "medium",
+		}}
+	}
+	receipt.DurationMS = time.Since(started).Milliseconds()
+	return receipt
+}
+
+// formatCommitmentAction produces a human-friendly action line for a
+// commitment recommendation. Used by both ProjectSavingsToReceipt (the
+// fallback path) and the backend-sourced receipt's row rendering.
+func formatCommitmentAction(rec SavingsRecommendation) string {
+	kind := "Commitment"
+	switch rec.Kind {
+	case SavingsKindSavingsPlan:
+		kind = "Savings Plan"
+	case SavingsKindReservedInstance:
+		kind = "Reserved Instance"
+	}
+	if rec.Term != "" {
+		return kind + " · " + rec.Term + " term"
+	}
+	return kind
+}

--- a/internal/cost/scan_receipt.go
+++ b/internal/cost/scan_receipt.go
@@ -45,13 +45,21 @@ type ScanCategorySummary struct {
 	HighestSeverity string  `json:"highestSeverity"`
 }
 
-// ScanFinding is one waste row.
+// ScanFinding is one waste row. Mirrors clanker-cloud's
+// models.ScanFinding wire shape (see backend/pkg/models/scan.go).
+//
+// ResourceID is the canonical cloud identifier — i-xxx, nat-xxx,
+// vol-xxx, ARN — and is what `clanker scan --fix` uses as a verbatim
+// AWS-CLI argument. Label carries any human-friendly display string
+// (e.g. "eval-dev (i-xxx)") and is used only for terminal output, not
+// commands.
 type ScanFinding struct {
 	Provider        string  `json:"provider"`
 	Category        string  `json:"category"`
 	Severity        string  `json:"severity"`
 	Service         string  `json:"service,omitempty"`
 	ResourceID      string  `json:"resourceId,omitempty"`
+	Label           string  `json:"label,omitempty"`
 	ResourceArn     string  `json:"resourceArn,omitempty"`
 	Region          string  `json:"region,omitempty"`
 	MonthlyWasteUSD float64 `json:"monthlyWasteUsd"`

--- a/internal/cost/scan_receipt.go
+++ b/internal/cost/scan_receipt.go
@@ -60,12 +60,24 @@ type ScanFinding struct {
 	DocsURL         string  `json:"docsUrl,omitempty"`
 }
 
-// ScanAnomaly is a cost spike surfaced by the deep-mode scan.
+// ScanAnomaly is a cost spike surfaced by the deep-mode scan. The
+// shape mirrors clanker-cloud's models.CostAnomaly so JSON-decoding
+// a backend-sourced receipt doesn't silently drop fields. Earlier
+// drafts only carried `Cost` and lost expectedCost/actualCost/
+// description on every deep scan — the renderer now has the data
+// it needs to show context if it ever wants to.
 type ScanAnomaly struct {
-	Provider      string  `json:"provider"`
 	Service       string  `json:"service"`
-	Cost          float64 `json:"cost"`
-	PercentChange float64 `json:"percentChange,omitempty"`
+	Provider      string  `json:"provider"`
+	ExpectedCost  float64 `json:"expectedCost"`
+	ActualCost    float64 `json:"actualCost"`
+	PercentChange float64 `json:"percentChange"`
+	Description   string  `json:"description,omitempty"`
+	// Cost is retained for backwards compatibility — older receipts
+	// produced by the local fallback path before this PR set it
+	// instead of ActualCost. Renderers should prefer ActualCost
+	// when non-zero, falling back to Cost.
+	Cost float64 `json:"cost,omitempty"`
 }
 
 // ScanLLMSpend is the AI-tax line item.

--- a/internal/cost/scan_render.go
+++ b/internal/cost/scan_render.go
@@ -1,0 +1,321 @@
+package cost
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+)
+
+// RenderScanReceipt produces a coloured, tabwriter-aligned terminal
+// receipt for `clanker scan`. Designed to be screenshot-friendly:
+// headlines stand out, finding rows align cleanly, severity tints
+// guide the eye to the worst offenders.
+//
+// The `color` flag mirrors the existing Formatter's pattern — emit
+// raw ANSI when true, plain text when false (set false for piped
+// output / --no-color / NO_COLOR env).
+func RenderScanReceipt(receipt *ScanReceipt, color bool, top int) string {
+	if receipt == nil {
+		return "No scan receipt.\n"
+	}
+	r := &scanRenderer{color: color, top: top}
+	return r.render(receipt)
+}
+
+// RenderScanReceiptJSON serialises the receipt as indented JSON for
+// --format json or --export *.json.
+func RenderScanReceiptJSON(receipt *ScanReceipt) ([]byte, error) {
+	return json.MarshalIndent(receipt, "", "  ")
+}
+
+// RenderScanReceiptMarkdown produces a Markdown export — same content
+// as the terminal version but plain ASCII tables.
+func RenderScanReceiptMarkdown(receipt *ScanReceipt) string {
+	if receipt == nil {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("# Clanker — Cloud scan receipt\n\n")
+	b.WriteString(fmt.Sprintf("Generated: %s\n", receipt.GeneratedAt.Format(time.RFC3339)))
+	b.WriteString(fmt.Sprintf("Mode: %s\n", receipt.Mode))
+	if len(receipt.ProvidersScanned) > 0 {
+		b.WriteString(fmt.Sprintf("Providers scanned: %s\n", strings.Join(receipt.ProvidersScanned, ", ")))
+	}
+	b.WriteString("\n")
+	b.WriteString(fmt.Sprintf("**Total monthly waste: $%.2f**\n", receipt.TotalMonthlyWasteUSD))
+	if receipt.EstimatedMonthlyRunRateUSD > 0 {
+		b.WriteString(fmt.Sprintf("Of $%.2f monthly run-rate\n", receipt.EstimatedMonthlyRunRateUSD))
+	}
+	b.WriteString("\n")
+	if len(receipt.Categories) > 0 {
+		b.WriteString("## By category\n\n")
+		b.WriteString("| Category | Count | Monthly waste | Highest severity |\n")
+		b.WriteString("|---|---:|---:|---|\n")
+		for _, c := range receipt.Categories {
+			sev := c.HighestSeverity
+			if sev == "" {
+				sev = "—"
+			}
+			b.WriteString(fmt.Sprintf("| %s | %d | $%.2f | %s |\n",
+				c.Category, c.Count, c.MonthlyWasteUSD, sev))
+		}
+		b.WriteString("\n")
+	}
+	if len(receipt.Findings) > 0 {
+		b.WriteString("## Findings\n\n")
+		b.WriteString("| Provider | Service | Resource | Severity | $/mo | Action |\n")
+		b.WriteString("|---|---|---|---|---:|---|\n")
+		for _, f := range receipt.Findings {
+			action := strings.ReplaceAll(f.Action, "|", "\\|")
+			action = strings.ReplaceAll(action, "\n", " ")
+			b.WriteString(fmt.Sprintf("| %s | %s | %s | %s | $%.2f | %s |\n",
+				f.Provider, f.Service, f.ResourceID, f.Severity, f.MonthlyWasteUSD, action))
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// scanRenderer holds the shared style state for the terminal receipt.
+type scanRenderer struct {
+	color bool
+	top   int
+}
+
+func (r *scanRenderer) render(receipt *ScanReceipt) string {
+	var b strings.Builder
+
+	// --- Header band -------------------------------------------------
+	b.WriteString(r.color1(colorBold+colorCyan, "\n┌─ CLANKER · CLOUD SCAN RECEIPT ────────────────────────────────────┐\n"))
+	b.WriteString(r.color1(colorCyan, "│"))
+	b.WriteString(fmt.Sprintf(" Generated: %s   Mode: %s",
+		receipt.GeneratedAt.Format("2006-01-02 15:04:05"),
+		strings.ToUpper(receipt.Mode)))
+	pad := 67 - len(fmt.Sprintf(" Generated: %s   Mode: %s",
+		receipt.GeneratedAt.Format("2006-01-02 15:04:05"), strings.ToUpper(receipt.Mode)))
+	if pad > 0 {
+		b.WriteString(strings.Repeat(" ", pad))
+	}
+	b.WriteString(r.color1(colorCyan, "│\n"))
+	b.WriteString(r.color1(colorCyan, "└───────────────────────────────────────────────────────────────────┘\n"))
+
+	// --- Headline total ---------------------------------------------
+	totalText := fmt.Sprintf("$%.2f", receipt.TotalMonthlyWasteUSD)
+	b.WriteString("\n")
+	b.WriteString(r.color1(colorBold+colorGreen, "  "+totalText))
+	b.WriteString(r.color1(colorWhite, " /month of waste"))
+	if receipt.EstimatedMonthlyRunRateUSD > 0 {
+		b.WriteString(r.color1(colorWhite, fmt.Sprintf("  (of $%.2f run-rate)", receipt.EstimatedMonthlyRunRateUSD)))
+	}
+	b.WriteString("\n")
+	if len(receipt.ProvidersScanned) > 0 {
+		b.WriteString(r.color1(colorWhite, fmt.Sprintf("  Providers: %s\n",
+			strings.ToUpper(strings.Join(receipt.ProvidersScanned, ", ")))))
+	}
+	if receipt.DurationMS > 0 {
+		b.WriteString(r.color1(colorWhite, fmt.Sprintf("  Scanned in %.1fs\n",
+			float64(receipt.DurationMS)/1000)))
+	}
+	b.WriteString("\n")
+
+	// --- Provider skips (deep-mode CLI fallback notes etc) ----------
+	if len(receipt.ProvidersSkipped) > 0 {
+		b.WriteString(r.color1(colorYellow, "  Skipped:\n"))
+		for _, s := range receipt.ProvidersSkipped {
+			b.WriteString(fmt.Sprintf("    • %s — %s\n", s.Provider, s.Reason))
+		}
+		b.WriteString("\n")
+	}
+
+	// --- Categories rollup ------------------------------------------
+	if len(receipt.Categories) > 0 {
+		b.WriteString(r.color1(colorBold+colorYellow, "  BY CATEGORY\n"))
+		w := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "    CATEGORY\tCOUNT\t$/MO\tHIGHEST SEVERITY")
+		fmt.Fprintln(w, "    --------\t-----\t----\t----------------")
+		for _, c := range receipt.Categories {
+			sev := c.HighestSeverity
+			if sev == "" {
+				sev = "—"
+			}
+			catLabel := c.Category
+			if r.color {
+				catLabel = r.color1(categoryColor(c.Category), c.Category)
+				sev = r.color1(severityColor(sev), sev)
+			}
+			fmt.Fprintf(w, "    %s\t%d\t$%.2f\t%s\n",
+				catLabel, c.Count, c.MonthlyWasteUSD, sev)
+		}
+		w.Flush()
+		b.WriteString("\n")
+	}
+
+	// --- Findings table (top N) -------------------------------------
+	if len(receipt.Findings) == 0 {
+		b.WriteString(r.color1(colorGreen, "  ✓ No actionable waste detected.\n\n"))
+	} else {
+		findings := receipt.Findings
+		// Findings already arrive savings-desc from the backend, but
+		// guard for the fallback path which may not sort.
+		sort.SliceStable(findings, func(i, j int) bool {
+			return findings[i].MonthlyWasteUSD > findings[j].MonthlyWasteUSD
+		})
+		limit := len(findings)
+		if r.top > 0 && r.top < limit {
+			limit = r.top
+		}
+		b.WriteString(r.color1(colorBold+colorYellow,
+			fmt.Sprintf("  FINDINGS (%d shown of %d)\n", limit, len(findings))))
+		w := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "    PROVIDER\tCATEGORY\tSEV\t$/MO\tRESOURCE")
+		fmt.Fprintln(w, "    --------\t--------\t---\t----\t--------")
+		for _, f := range findings[:limit] {
+			provider := strings.ToUpper(f.Provider)
+			cat := f.Category
+			sev := f.Severity
+			res := f.Service
+			if f.ResourceID != "" {
+				if res != "" {
+					res = res + " · " + truncateScan(f.ResourceID, 32)
+				} else {
+					res = truncateScan(f.ResourceID, 32)
+				}
+			}
+			if f.Region != "" {
+				res = res + " · " + f.Region
+			}
+			if r.color {
+				cat = r.color1(categoryColor(f.Category), cat)
+				sev = r.color1(severityColor(f.Severity), strings.ToUpper(sev))
+			} else {
+				sev = strings.ToUpper(sev)
+			}
+			fmt.Fprintf(w, "    %s\t%s\t%s\t$%.2f\t%s\n",
+				provider, cat, sev, f.MonthlyWasteUSD, res)
+		}
+		w.Flush()
+		if r.top > 0 && len(findings) > r.top {
+			b.WriteString(r.color1(colorWhite,
+				fmt.Sprintf("\n    (showing top %d — pass --top 0 for all)\n", r.top)))
+		}
+		b.WriteString("\n")
+
+		// --- Action details (one block per finding) -----------------
+		b.WriteString(r.color1(colorBold+colorYellow, "  DETAILS\n"))
+		for _, f := range findings[:limit] {
+			b.WriteString(fmt.Sprintf("    %s ", r.color1(colorBold, "•")))
+			b.WriteString(r.color1(colorBold, fmt.Sprintf("%s/%s", strings.ToUpper(f.Provider), f.Service)))
+			if f.ResourceID != "" {
+				b.WriteString(r.color1(colorWhite, " · "+f.ResourceID))
+			}
+			b.WriteString(r.color1(colorGreen, fmt.Sprintf("  $%.2f/mo\n", f.MonthlyWasteUSD)))
+			if f.Action != "" {
+				b.WriteString(fmt.Sprintf("      %s\n", f.Action))
+			}
+			if f.Detail != "" && f.Detail != f.Action {
+				b.WriteString(r.color1(colorWhite, fmt.Sprintf("      %s\n", f.Detail)))
+			}
+			if f.DocsURL != "" {
+				b.WriteString(r.color1(colorBlue, fmt.Sprintf("      → %s\n", f.DocsURL)))
+			}
+		}
+		b.WriteString("\n")
+	}
+
+	// --- Anomalies (deep mode) --------------------------------------
+	if len(receipt.Anomalies) > 0 {
+		b.WriteString(r.color1(colorBold+colorRed, "  ANOMALIES\n"))
+		for _, a := range receipt.Anomalies {
+			b.WriteString(fmt.Sprintf("    • %s/%s — $%.2f", strings.ToUpper(a.Provider), a.Service, a.Cost))
+			if a.PercentChange != 0 {
+				b.WriteString(fmt.Sprintf(" (%.0f%%)", a.PercentChange))
+			}
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+	}
+
+	// --- LLM spend (deep mode) --------------------------------------
+	if receipt.LLMSpend != nil {
+		b.WriteString(r.color1(colorBold+colorPurple, "  AI TAX\n"))
+		b.WriteString(r.color1(colorPurple, fmt.Sprintf("    $%.2f total · %d requests · %s tokens",
+			receipt.LLMSpend.TotalCostUSD,
+			receipt.LLMSpend.TotalRequests,
+			formatTokensScan(receipt.LLMSpend.TotalTokens))))
+		if receipt.LLMSpend.PrimaryProvider != "" {
+			b.WriteString(r.color1(colorWhite, " · primarily "+receipt.LLMSpend.PrimaryProvider))
+		}
+		b.WriteString("\n\n")
+	}
+
+	// --- Footer band ------------------------------------------------
+	b.WriteString(r.color1(colorCyan, "  ─────────────────────────────────────────────────────────────────\n"))
+	b.WriteString(r.color1(colorWhite, "  clankercloud.ai — apply with `clanker scan --fix <out.json>`\n"))
+	if receipt.Notes != "" {
+		b.WriteString(r.color1(colorWhite, "  Notes: "+receipt.Notes+"\n"))
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+func (r *scanRenderer) color1(code, text string) string {
+	if !r.color {
+		return text
+	}
+	return code + text + colorReset
+}
+
+func categoryColor(cat string) string {
+	switch cat {
+	case "version-eol":
+		return colorRed
+	case "orphan":
+		return colorYellow
+	case "rightsize":
+		return colorYellow
+	case "lifecycle":
+		return colorGreen
+	case "commitment":
+		return colorBlue
+	default:
+		return colorCyan
+	}
+}
+
+func severityColor(sev string) string {
+	switch strings.ToLower(sev) {
+	case "critical":
+		return colorRed + colorBold
+	case "high":
+		return colorRed
+	case "medium":
+		return colorYellow
+	case "low":
+		return colorGreen
+	default:
+		return colorWhite
+	}
+}
+
+func truncateScan(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	if max < 4 {
+		return s[:max]
+	}
+	return s[:max-1] + "…"
+}
+
+func formatTokensScan(tokens int64) string {
+	if tokens >= 1_000_000 {
+		return fmt.Sprintf("%.2fM", float64(tokens)/1_000_000)
+	}
+	if tokens >= 1_000 {
+		return fmt.Sprintf("%.1fK", float64(tokens)/1_000)
+	}
+	return fmt.Sprintf("%d", tokens)
+}

--- a/internal/cost/scan_render.go
+++ b/internal/cost/scan_render.go
@@ -229,11 +229,24 @@ func (r *scanRenderer) render(receipt *ScanReceipt) string {
 	if len(receipt.Anomalies) > 0 {
 		b.WriteString(r.color1(colorBold+colorRed, "  ANOMALIES\n"))
 		for _, a := range receipt.Anomalies {
-			b.WriteString(fmt.Sprintf("    • %s/%s — $%.2f", strings.ToUpper(a.Provider), a.Service, a.Cost))
+			// Prefer ActualCost (modern backend shape); fall back to
+			// Cost for receipts produced before the wire shape was
+			// aligned with the backend.
+			cost := a.ActualCost
+			if cost == 0 {
+				cost = a.Cost
+			}
+			b.WriteString(fmt.Sprintf("    • %s/%s — $%.2f", strings.ToUpper(a.Provider), a.Service, cost))
 			if a.PercentChange != 0 {
-				b.WriteString(fmt.Sprintf(" (%.0f%%)", a.PercentChange))
+				b.WriteString(fmt.Sprintf(" (%+.0f%%)", a.PercentChange))
+			}
+			if a.ExpectedCost > 0 && a.ActualCost > 0 {
+				b.WriteString(fmt.Sprintf(" (expected $%.2f)", a.ExpectedCost))
 			}
 			b.WriteString("\n")
+			if a.Description != "" {
+				b.WriteString(r.color1(colorWhite, "      "+a.Description+"\n"))
+			}
 		}
 		b.WriteString("\n")
 	}

--- a/internal/cost/scan_render.go
+++ b/internal/cost/scan_render.go
@@ -177,11 +177,17 @@ func (r *scanRenderer) render(receipt *ScanReceipt) string {
 			cat := f.Category
 			sev := f.Severity
 			res := f.Service
-			if f.ResourceID != "" {
+			// Prefer Label (friendly display, e.g. "eval-dev (i-xxx)")
+			// over the bare ResourceID where the detector provided one.
+			displayID := f.Label
+			if displayID == "" {
+				displayID = f.ResourceID
+			}
+			if displayID != "" {
 				if res != "" {
-					res = res + " · " + truncateScan(f.ResourceID, 32)
+					res = res + " · " + truncateScan(displayID, 40)
 				} else {
-					res = truncateScan(f.ResourceID, 32)
+					res = truncateScan(displayID, 40)
 				}
 			}
 			if f.Region != "" {

--- a/internal/cost/scan_render_test.go
+++ b/internal/cost/scan_render_test.go
@@ -1,0 +1,229 @@
+package cost
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func sampleReceipt() *ScanReceipt {
+	return &ScanReceipt{
+		GeneratedAt:                time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC),
+		Mode:                       "deep",
+		ProvidersScanned:           []string{"aws", "gcp"},
+		TotalMonthlyWasteUSD:       332,
+		EstimatedMonthlyRunRateUSD: 1500,
+		Categories: []ScanCategorySummary{
+			{Category: "version-eol", Count: 1, MonthlyWasteUSD: 288, HighestSeverity: "high"},
+			{Category: "orphan", Count: 1, MonthlyWasteUSD: 32, HighestSeverity: "medium"},
+			{Category: "lifecycle", Count: 1, MonthlyWasteUSD: 12, HighestSeverity: "low"},
+		},
+		Findings: []ScanFinding{
+			{Provider: "aws", Category: "version-eol", Severity: "high", Service: "EKS",
+				ResourceID: "old-cluster", MonthlyWasteUSD: 288, Action: "Upgrade EKS to v1.35"},
+			{Provider: "aws", Category: "orphan", Severity: "medium", Service: "EC2",
+				ResourceID: "nat-0123abc", MonthlyWasteUSD: 32, Action: "Delete idle NAT gateway"},
+			{Provider: "gcp", Category: "lifecycle", Severity: "low", Service: "Storage",
+				ResourceID: "logs-bucket", MonthlyWasteUSD: 12, Action: "Add 90-day lifecycle"},
+		},
+		DurationMS: 1500,
+	}
+}
+
+func TestRenderScanReceipt_TerminalContainsHeadlinesAndFindings(t *testing.T) {
+	out := RenderScanReceipt(sampleReceipt(), false, 20)
+	mustContain(t, out, "$332.00")
+	mustContain(t, out, "/month of waste")
+	mustContain(t, out, "AWS, GCP")
+	mustContain(t, out, "FINDINGS (3 shown of 3)")
+	mustContain(t, out, "old-cluster")
+	mustContain(t, out, "Upgrade EKS to v1.35")
+	mustContain(t, out, "BY CATEGORY")
+	// Run-rate context surfaces.
+	mustContain(t, out, "$1500.00 run-rate")
+}
+
+func TestRenderScanReceipt_TerminalNoColorIsAnsiFree(t *testing.T) {
+	out := RenderScanReceipt(sampleReceipt(), false, 20)
+	if strings.Contains(out, "\x1b[") {
+		t.Errorf("--no-color output contained ANSI escape: %q", out)
+	}
+}
+
+func TestRenderScanReceipt_TerminalColorEmitsAnsi(t *testing.T) {
+	out := RenderScanReceipt(sampleReceipt(), true, 20)
+	if !strings.Contains(out, "\x1b[") {
+		t.Errorf("color=true output missing ANSI escapes")
+	}
+}
+
+func TestRenderScanReceipt_RespectsTopLimit(t *testing.T) {
+	receipt := sampleReceipt()
+	out := RenderScanReceipt(receipt, false, 1)
+	mustContain(t, out, "FINDINGS (1 shown of 3)")
+	mustContain(t, out, "old-cluster") // top finding by waste
+	if strings.Contains(out, "logs-bucket") {
+		t.Errorf("top=1 should hide finding #3; got: %s", out)
+	}
+	mustContain(t, out, "(showing top 1")
+}
+
+func TestRenderScanReceipt_NilIsSafe(t *testing.T) {
+	out := RenderScanReceipt(nil, false, 10)
+	if !strings.Contains(out, "No scan receipt") {
+		t.Errorf("nil receipt should produce a friendly message, got %q", out)
+	}
+}
+
+func TestRenderScanReceipt_EmptyFindingsShowsCleanState(t *testing.T) {
+	receipt := &ScanReceipt{
+		GeneratedAt:      time.Now().UTC(),
+		Mode:             "quick",
+		ProvidersScanned: []string{"aws"},
+		Findings:         []ScanFinding{},
+		Categories:       []ScanCategorySummary{},
+	}
+	out := RenderScanReceipt(receipt, false, 10)
+	mustContain(t, out, "No actionable waste detected")
+}
+
+func TestRenderScanReceipt_AnomaliesAndLLMSurface(t *testing.T) {
+	r := sampleReceipt()
+	r.Anomalies = []ScanAnomaly{
+		{Provider: "aws", Service: "DataTransfer", Cost: 240, PercentChange: 38},
+	}
+	r.LLMSpend = &ScanLLMSpend{
+		TotalCostUSD:    18.42,
+		TotalTokens:     1_250_000,
+		TotalRequests:   312,
+		PrimaryProvider: "anthropic",
+	}
+	out := RenderScanReceipt(r, false, 20)
+	mustContain(t, out, "ANOMALIES")
+	mustContain(t, out, "DataTransfer")
+	mustContain(t, out, "AI TAX")
+	mustContain(t, out, "$18.42 total")
+	mustContain(t, out, "anthropic")
+	// Token formatting check — 1.25M renders compactly.
+	mustContain(t, out, "1.25M")
+}
+
+func TestRenderScanReceiptJSON_RoundTrips(t *testing.T) {
+	bytes, err := RenderScanReceiptJSON(sampleReceipt())
+	if err != nil {
+		t.Fatalf("RenderScanReceiptJSON: %v", err)
+	}
+	var roundTrip ScanReceipt
+	if err := json.Unmarshal(bytes, &roundTrip); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if roundTrip.TotalMonthlyWasteUSD != 332 {
+		t.Errorf("round-trip TotalMonthlyWasteUSD=%.2f, want 332", roundTrip.TotalMonthlyWasteUSD)
+	}
+	if len(roundTrip.Findings) != 3 {
+		t.Errorf("round-trip findings=%d, want 3", len(roundTrip.Findings))
+	}
+}
+
+func TestRenderScanReceiptMarkdown_ContainsTablesAndTotal(t *testing.T) {
+	out := RenderScanReceiptMarkdown(sampleReceipt())
+	mustContain(t, out, "# Clanker — Cloud scan receipt")
+	mustContain(t, out, "Total monthly waste: $332.00")
+	mustContain(t, out, "Of $1500.00 monthly run-rate")
+	mustContain(t, out, "## By category")
+	mustContain(t, out, "| version-eol | 1 | $288.00 | high |")
+	mustContain(t, out, "## Findings")
+	mustContain(t, out, "| aws | EKS | old-cluster | high | $288.00 | Upgrade EKS to v1.35 |")
+}
+
+func TestRenderScanReceiptMarkdown_EscapesPipesInActions(t *testing.T) {
+	r := sampleReceipt()
+	r.Findings[0].Action = "pipe | inside | text\nwith newline"
+	out := RenderScanReceiptMarkdown(r)
+	mustContain(t, out, "pipe \\| inside \\| text with newline")
+}
+
+func TestProjectSavingsToReceipt_ProducesUsableReceipt(t *testing.T) {
+	report := &SavingsReport{
+		Provider: "aws",
+		Recommendations: []SavingsRecommendation{
+			{Provider: "aws", Kind: SavingsKindSavingsPlan, Service: "EC2", Family: "Compute",
+				Term: "ONE_YEAR", EstimatedSavings: 145.50, EstimatedSavingsPc: 24.3},
+			{Provider: "aws", Kind: SavingsKindReservedInstance, Service: "RDS", Family: "db.r6g",
+				Term: "ONE_YEAR", EstimatedSavings: 50.0, EstimatedSavingsPc: 12.0},
+		},
+	}
+	receipt := ProjectSavingsToReceipt(report, "deep", time.Now().UTC().Add(-50*time.Millisecond))
+	if receipt == nil {
+		t.Fatal("expected non-nil receipt")
+	}
+	if receipt.TotalMonthlyWasteUSD != 195.5 {
+		t.Errorf("total=%.2f, want 195.5", receipt.TotalMonthlyWasteUSD)
+	}
+	if len(receipt.Findings) != 2 {
+		t.Fatalf("findings=%d, want 2", len(receipt.Findings))
+	}
+	for _, f := range receipt.Findings {
+		if f.Category != "commitment" {
+			t.Errorf("finding category=%q, want commitment: %+v", f.Category, f)
+		}
+	}
+	if len(receipt.Categories) != 1 || receipt.Categories[0].Category != "commitment" {
+		t.Errorf("expected single 'commitment' category rollup, got %#v", receipt.Categories)
+	}
+}
+
+func TestProjectSavingsToReceipt_NilReportIsSafe(t *testing.T) {
+	receipt := ProjectSavingsToReceipt(nil, "quick", time.Now())
+	if receipt == nil {
+		t.Fatal("expected non-nil receipt for nil input")
+	}
+	if receipt.TotalMonthlyWasteUSD != 0 || len(receipt.Findings) != 0 {
+		t.Errorf("expected empty receipt, got %+v", receipt)
+	}
+}
+
+func TestFormatTokensScan(t *testing.T) {
+	cases := []struct {
+		in   int64
+		want string
+	}{
+		{0, "0"},
+		{42, "42"},
+		{1500, "1.5K"},
+		{1_000_000, "1.00M"},
+		{1_250_000, "1.25M"},
+	}
+	for _, tc := range cases {
+		if got := formatTokensScan(tc.in); got != tc.want {
+			t.Errorf("formatTokensScan(%d)=%q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestSeverityAndCategoryColorsAreDistinct(t *testing.T) {
+	// Smoke test — make sure the helpers don't panic and return non-empty
+	// strings for every documented value.
+	for _, s := range []string{"critical", "high", "medium", "low", "unknown"} {
+		if severityColor(s) == "" {
+			t.Errorf("severityColor(%q) returned empty", s)
+		}
+	}
+	for _, c := range []string{"version-eol", "orphan", "rightsize", "lifecycle", "commitment", "other"} {
+		if categoryColor(c) == "" {
+			t.Errorf("categoryColor(%q) returned empty", c)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------
+
+func mustContain(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if !strings.Contains(haystack, needle) {
+		t.Errorf("expected output to contain %q\n--- output ---\n%s", needle, haystack)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `clanker scan` — a top-level "find every dollar of cloud waste in 60 seconds and print a receipt" command. Composes the existing clanker-cloud \`/api/cost/scan\` endpoint (operational detectors across every configured provider — idle NATs, EOL'd EKS, stopped EC2 with EBS, GP2→GP3 upgrades, GKE extended-support, etc.) with the CLI's local AWS Cost Explorer commitment-recommendation surface.

Companion to clanker-cloud PR #403 (which ships the backend endpoint + the floating \$ scan button in the desktop UI).

## Usage

\`\`\`bash
# Default: full deep scan (~15–30s)
clanker scan

# Fast: detectors only (~5–10s)
clanker scan --quick

# Pipe-friendly outputs
clanker scan --quick --format json
clanker scan --format markdown --export receipt.md

# Generate a maker plan with one command per finding (review before apply)
clanker scan --fix waste-fix.json
clanker maker estimate --plan waste-fix.json
\`\`\`

## How it works

* **Auto-discovers** a running clanker-cloud desktop backend on \`localhost:8080..8084\` via a GET probe to \`/api/cost/scan\`. When found, gets the rich receipt with operational findings.
* **Falls back gracefully** to local AWS Cost Explorer commitment recs when no backend is reachable. Receipt format is identical, just fewer categories.
* **Coloured terminal receipt** with category tints + tabwriter alignment. Honours \`--no-color\` and the \`NO_COLOR\` env var.
* **\`--fix <path>\`** projects each finding onto a \`maker.Command\` stub (\`aws ec2 describe-…\`-style placeholders so the operator inspects before any destructive action) and writes a \`maker.Plan\` JSON file.

## Live results against a real AWS account

| Mode | Findings | Total |
|---|---|---|
| Backend-quick | 2 NAT gateways + 1 stopped EC2 | \$72.80/mo |
| Backend-deep | + 4 commitment recs + 1 anomaly | \$171.57/mo |
| Local fallback | 4 commitment recs only | \$98.77/mo |

## Test plan

- [x] 13 cases in \`internal/cost/scan_render_test.go\` — receipt rendering across formats, \`--top\` limit, anomaly + LLM surfacing, Markdown pipe-escape, \`ProjectSavingsToReceipt\` nil safety.
- [x] 5 cases in \`cmd/scan_test.go\` — \`stripANSI\`, \`displayName\`, \`primaryProvider\`, \`buildFixCommandArgs\` per category, end-to-end \`writeFixPlan\` producing valid \`maker.Plan\` JSON.
- [x] \`go test ./... -count=1 -short\` — all packages green.
- [x] \`gofmt -l\` + \`go vet ./...\` — clean.
- [x] Live end-to-end against running clanker-cloud backend on \`:8081\` — \`--quick\`, \`--no-color\`, \`--format json\`, \`--format markdown\`, \`--fix\`, \`--local\`, \`NO_COLOR\` env all work as documented.

## Files

- \`cmd/scan.go\` — cobra wiring + fix-plan generator (mirrors \`cmd/cost_savings.go\` patterns)
- \`internal/cost/scan_receipt.go\` — wire shape + \`ProjectSavingsToReceipt\` adapter
- \`internal/cost/scan_render.go\` — terminal/JSON/Markdown renderers
- \`internal/cost/scan_client.go\` — \`DiscoverScanBackend\` + \`FetchScanReceipt\` method on \`cost.Client\`
- \`internal/cost/scan_render_test.go\` + \`cmd/scan_test.go\` — coverage