### PR TITLE
fix(router): stop database fall-through on ambiguous bare tokens

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -1817,10 +1817,17 @@ func shouldIncludeDatabaseContextWithContext(question string, dbConnection strin
 	if shouldRouteToDatabaseAgentWithContext(q, dbConnection) {
 		return true
 	}
-	if containsAnyPhrase(q, "supabase", "neon", "sqlite", "sqlite3", "database connection", "db connection", "schema", "schemas", "column", "columns", "migration", "migrations") {
+	// NOTE: dropped bare "schema"/"schemas", "column"/"columns", and
+	// "index"/"indexes" from these phrase lists. They matched GraphQL/JSON/
+	// zod schemas, search indexes, web pages, and spreadsheet-style
+	// questions that have nothing to do with databases. The unambiguous
+	// engine names + multi-word phrases ("sql query", "sql schema",
+	// "foreign key", "database connection") still pull in DB context.
+	// See clanker-cloud router fix #409 for the matching backend change.
+	if containsAnyPhrase(q, "supabase", "neon", "sqlite", "sqlite3", "database connection", "db connection", "migration", "migrations") {
 		return true
 	}
-	if containsAnyPhrase(q, "table", "tables", "sql query", "sql schema", "foreign key", "primary key", "index", "indexes") {
+	if containsAnyPhrase(q, "tables", "sql query", "sql schema", "foreign key", "primary key") {
 		return true
 	}
 	if containsAnyPhrase(q, "postgres", "postgresql", "mysql") && containsAnyPhrase(q, "table", "tables", "schema", "schemas", "column", "columns", "sql", "query", "connect", "connection") {

--- a/cmd/domain_agents.go
+++ b/cmd/domain_agents.go
@@ -1386,7 +1386,15 @@ func shouldRouteToDatabaseAgent(question string) bool {
 		!containsAnyPhrase(lower, "database", "schema", "sql", "nosql", "table", "tables", "column", "columns", "migration", "postgres", "mysql", "sqlite", "supabase", "neon", "dynamodb", "firestore", "spanner", "bigtable", "cosmos", "d1", "redis", "mongo") {
 		return false
 	}
-	if containsAnyPhrase(lower, "schema", "schemas", "sql query", "sql", "nosql", "migration", "migrations", "foreign key", "primary key", "index", "indexes", "connection string", "database connection", "db connection") {
+	// NOTE: dropped bare "schema"/"schemas" and bare "index"/"indexes" from
+	// this phrase list. "schema" alone matches GraphQL/JSON/zod/OpenAPI
+	// schemas; "index" alone matches search indexes, web pages, etc. Real
+	// database schema/index questions still match via the engine-name +
+	// table/column combo below (line gated by a database engine list) or
+	// the explicit "database"/engine phrases lower down. Mirrors the
+	// equivalent fix in clanker-cloud/backend/internal/agent/router.go
+	// (#409 — universal fall-through to database agent).
+	if containsAnyPhrase(lower, "sql query", "sql", "nosql", "migration", "migrations", "foreign key", "primary key", "connection string", "database connection", "db connection") {
 		return true
 	}
 	if containsAnyPhrase(lower, "table", "tables", "column", "columns") &&

--- a/cmd/routing_test.go
+++ b/cmd/routing_test.go
@@ -1,0 +1,120 @@
+package cmd
+
+import "testing"
+
+// Routing-decision regression suite. The CLI re-runs its own routing on
+// every `clanker ask` call (see ask.go:936 and the route-only path used
+// by clanker-cloud's backend), so the same bare-token false-positives
+// that bit the backend router will bite the CLI too. These tests pin the
+// fix from clanker-cloud #409 in the CLI: bare "schema"/"index"/"db"
+// tokens must NOT force database routing for non-database questions.
+
+func TestShouldRouteToDatabaseAgent_NoFalsePositives(t *testing.T) {
+	cases := []string{
+		"fix my deploy db backup script",
+		"are there any new dbs in staging",
+		"the graphql schema is broken",
+		"validate the json schema for this payload",
+		"my k8s namespace is called db, list pods",
+		"the search index is stale",
+		"reindex the page index",
+		"what's my aws bill this month",
+		"list ec2 instances",
+		"why is my lambda timing out",
+		"check cloudwatch logs",
+		"my pod is crashlooping",
+	}
+	for _, q := range cases {
+		if shouldRouteToDatabaseAgent(q) {
+			t.Errorf("query %q should NOT route to database agent", q)
+		}
+	}
+}
+
+func TestShouldRouteToDatabaseAgent_TrueMatches(t *testing.T) {
+	cases := []string{
+		"show me my postgres tables",
+		"where is the redis cache",
+		"list databases in production",
+		"what are my mysql users",
+		"check the dynamodb tables i have",
+		"my supabase connection is failing",
+	}
+	for _, q := range cases {
+		if !shouldRouteToDatabaseAgent(q) {
+			t.Errorf("query %q SHOULD route to database agent", q)
+		}
+	}
+}
+
+// shouldIncludeDatabaseContextWithContext is the other gate that injects
+// DB context into the Clanker prompt. Even if the agent isn't database,
+// a true here taints the prompt with database information and biases the
+// model's answer toward DB phrasing. The same bare-token cleanup applies.
+func TestShouldIncludeDatabaseContextWithContext_NoFalsePositives(t *testing.T) {
+	cases := []string{
+		"the graphql schema is broken",
+		"validate the json schema",
+		"the search index is stale",
+		"i have a column problem in this table tennis matchup",
+		"reindex the docs site",
+		"list ec2 instances",
+		"my pod is crashlooping",
+	}
+	for _, q := range cases {
+		if shouldIncludeDatabaseContextWithContext(q, "") {
+			t.Errorf("query %q should NOT trigger DB context inclusion", q)
+		}
+	}
+}
+
+func TestShouldIncludeDatabaseContextWithContext_TrueMatches(t *testing.T) {
+	cases := []string{
+		"show me my postgres tables",
+		"my database connection is timing out",
+		"how do i run a migration",
+		"foreign key constraint failed in mysql",
+		"connect to supabase",
+	}
+	for _, q := range cases {
+		if !shouldIncludeDatabaseContextWithContext(q, "") {
+			t.Errorf("query %q SHOULD trigger DB context inclusion", q)
+		}
+	}
+}
+
+// End-to-end check: the routing decision function used by --route-only
+// and by the in-process `clanker ask` dispatch must agree with our gates.
+// If this drifts, the CLI will say "agent-cli" on the routing probe but
+// then internally hijack to database during execution (or vice versa).
+func TestDetermineRoutingDecision_NoDatabaseFallthroughs(t *testing.T) {
+	cases := []string{
+		"fix my deploy db backup script",
+		"the graphql schema is broken",
+		"validate the json schema",
+		"what's my aws bill",
+		"list ec2 instances",
+		"my pod is crashlooping",
+		"the search index is stale",
+	}
+	for _, q := range cases {
+		decision := determineRoutingDecisionDetailsWithContext(q, "")
+		if decision.Agent == "agent-database" {
+			t.Errorf("query %q routed to %s (reason=%q) — must not be database", q, decision.Agent, decision.Reason)
+		}
+	}
+}
+
+func TestDetermineRoutingDecision_DatabaseMatchesStillRoute(t *testing.T) {
+	cases := []string{
+		"show me my postgres tables",
+		"list databases in production",
+		"what are my mysql users",
+	}
+	for _, q := range cases {
+		decision := determineRoutingDecisionDetailsWithContext(q, "")
+		if decision.Agent != "agent-database" {
+			t.Errorf("query %q routed to %s, want agent-database (reason=%q)", q, decision.Agent, decision.Reason)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Mirrors clankercloud/clanker-cloud#409 in the CLI side of the stack. The CLI runs its **own** routing decision on every \`clanker ask\` call — both via \`--route-only\` (used by clanker-cloud's backend when its own LLM router is unavailable) and via the in-process dispatch at \`ask.go:936\` that hijacks to \`handleDatabaseQuery\` when \`shouldRouteToDatabaseAgentWithContext\` returns true. The same bare-token patterns that bit the backend bit the CLI.

### Bugs fixed

\`cmd/domain_agents.go::shouldRouteToDatabaseAgent\` — dropped bare \`schema\` / \`schemas\` / \`index\` / \`indexes\` from the phrase list. They fired on:
- "the graphql schema is broken"
- "validate the json schema for this payload"
- "the search index is stale"
- "reindex the page index"

\`cmd/ask.go::shouldIncludeDatabaseContextWithContext\` — same cleanup, plus dropped bare \`table\` (singular), \`column\` / \`columns\`, \`index\` / \`indexes\`. This is the gate that injects DB context into the Clanker prompt. Even when the agent isn't database, taint here biases the model toward DB phrasing on non-DB questions. Multi-word phrases (\`sql query\`, \`sql schema\`, \`foreign key\`, \`primary key\`, \`database connection\`) and engine names (\`postgres\`, \`mysql\`, \`supabase\`, etc.) stay.

### Tests

New \`cmd/routing_test.go\` with 6 tests:
- \`TestShouldRouteToDatabaseAgent_NoFalsePositives\` — 12 ambiguous queries that must NOT route to database
- \`TestShouldRouteToDatabaseAgent_TrueMatches\` — 6 real DB queries that SHOULD still route
- \`TestShouldIncludeDatabaseContextWithContext_NoFalsePositives\` — 7 cases that must NOT taint with DB context
- \`TestShouldIncludeDatabaseContextWithContext_TrueMatches\` — 5 real DB cases
- \`TestDetermineRoutingDecision_NoDatabaseFallthroughs\` — end-to-end via \`determineRoutingDecisionDetailsWithContext\`
- \`TestDetermineRoutingDecision_DatabaseMatchesStillRoute\` — end-to-end positive cases

## Test plan

- [x] \`go test -short ./...\` — all packages green
- [x] \`go vet ./cmd/...\` — clean
- [x] \`go build ./cmd/...\` — clean
- [ ] Manual smoke via clanker-cloud: ask "fix my deploy db backup" with the rebuilt CLI bundled → routes to clanker, not db