### PR TITLE
feat(k8s): expose apply/exec/port-forward + node lifecycle CLI

### DIFF
--- a/cmd/k8s_exec_apply.go
+++ b/cmd/k8s_exec_apply.go
@@ -2,12 +2,15 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/bgdnvk/clanker/internal/k8s"
 	"github.com/spf13/cobra"
@@ -29,8 +32,6 @@ var (
 
 	// exec
 	k8sExecContainer string
-	k8sExecStdin     bool
-	k8sExecTTY       bool
 
 	// port-forward
 	k8sPFAddresses string
@@ -103,11 +104,11 @@ func init() {
 	k8sApplyCmd.Flags().BoolVar(&k8sApplyServerDry, "server-dry-run", false, "Submit server-side dry-run (kubectl apply --dry-run=server)")
 
 	k8sExecCmd.Flags().StringVarP(&k8sExecContainer, "container", "c", "", "Container name (if pod has multiple)")
-	// stdin/tty flags are accepted but not yet streaming — once the
-	// WebSocket-backed interactive exec lands we'll wire them through
-	// without breaking flag compat.
-	k8sExecCmd.Flags().BoolVarP(&k8sExecStdin, "stdin", "i", false, "Pass stdin to the container (not yet streaming)")
-	k8sExecCmd.Flags().BoolVarP(&k8sExecTTY, "tty", "t", false, "Allocate a TTY (not yet streaming)")
+	// '-i' and '-t' are intentionally not surfaced here: this exec
+	// captures stdout/stderr into a buffer (one-shot), so passing them
+	// through to kubectl would break the run ('-t' errors with 'stdin
+	// is not a tty'). They will land alongside the WebSocket-backed
+	// interactive exec in the cloud backend.
 
 	k8sPortForwardCmd.Flags().StringVar(&k8sPFAddresses, "address", "", "Addresses to listen on (default localhost)")
 	k8sPortForwardCmd.Flags().StringVar(&k8sPFKind, "kind", "pod", "Target kind: pod, svc, or deploy (used only when the arg has no kind/ prefix)")
@@ -210,12 +211,6 @@ func runK8sExec(cmd *cobra.Command, args []string) error {
 	if k8sExecContainer != "" {
 		kubectlArgs = append(kubectlArgs, "-c", k8sExecContainer)
 	}
-	if k8sExecStdin {
-		kubectlArgs = append(kubectlArgs, "-i")
-	}
-	if k8sExecTTY {
-		kubectlArgs = append(kubectlArgs, "-t")
-	}
 	kubectlArgs = append(kubectlArgs, "--")
 	kubectlArgs = append(kubectlArgs, command...)
 
@@ -283,20 +278,61 @@ func runK8sPortForward(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("start port-forward %s %s: %w", target, portSpec, err)
 	}
 
-	// Forward SIGINT/SIGTERM to kubectl so Ctrl-C tears it down cleanly.
+	// On Ctrl-C, give kubectl SIGINT so it can release the local socket
+	// gracefully; only fall back to context-cancel (SIGKILL) if it
+	// refuses to die within a short window. Without this kubectl gets
+	// killed hard and may leave the port half-bound on rapid reconnects.
 	sigCh := make(chan os.Signal, 1)
+	done := make(chan struct{})
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
 	go func() {
-		<-sigCh
-		cancel()
+		select {
+		case <-sigCh:
+			if pf.Process != nil {
+				_ = pf.Process.Signal(syscall.SIGINT)
+			}
+			// Hard cancel after a grace window if kubectl is still up.
+			select {
+			case <-time.After(2 * time.Second):
+				cancel()
+			case <-done:
+			}
+		case <-done:
+		}
 	}()
 
-	if err := pf.Wait(); err != nil {
-		if ctx.Err() != nil {
-			// User cancelled via signal — clean exit.
+	err = pf.Wait()
+	close(done)
+	if err != nil {
+		// kubectl exits non-zero on SIGINT/SIGTERM; treat that as clean
+		// shutdown so we don't paper the user with a useless error.
+		if ctx.Err() != nil || isInterruptedExit(err) {
 			return nil
 		}
 		return fmt.Errorf("port-forward exited: %w", err)
 	}
 	return nil
+}
+
+// isInterruptedExit returns true when the underlying *exec.ExitError was
+// produced by a SIGINT/SIGTERM/SIGKILL — i.e., the user (or our cancel
+// path) tore down kubectl on purpose.
+func isInterruptedExit(err error) bool {
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		return false
+	}
+	ws, ok := exitErr.Sys().(syscall.WaitStatus)
+	if !ok {
+		return false
+	}
+	if !ws.Signaled() {
+		return false
+	}
+	switch ws.Signal() {
+	case syscall.SIGINT, syscall.SIGTERM, syscall.SIGKILL:
+		return true
+	}
+	return false
 }

--- a/cmd/k8s_exec_apply.go
+++ b/cmd/k8s_exec_apply.go
@@ -1,0 +1,302 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/bgdnvk/clanker/internal/k8s"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	// shared connection flags for apply / exec / port-forward
+	k8sCOpsNamespace  string
+	k8sCOpsContext    string
+	k8sCOpsKubeconfig string
+	k8sCOpsDebug      bool
+
+	// apply
+	k8sApplyFile      string
+	k8sApplyManifest  string
+	k8sApplyStdin     bool
+	k8sApplyServerDry bool
+
+	// exec
+	k8sExecContainer string
+	k8sExecStdin     bool
+	k8sExecTTY       bool
+
+	// port-forward
+	k8sPFAddresses string
+	k8sPFKind      string
+)
+
+var k8sApplyCmd = &cobra.Command{
+	Use:   "apply",
+	Short: "Apply a manifest to the active cluster",
+	Long: `Apply a Kubernetes manifest to the active kubeconfig context. The
+manifest can be read from a file (-f), from stdin (--stdin), or supplied
+inline via --manifest.
+
+Example:
+  clanker k8s apply -f ./deployment.yaml
+  cat deployment.yaml | clanker k8s apply --stdin
+  clanker k8s apply --manifest "$(cat deployment.yaml)" -n prod
+  clanker k8s apply -f ./deploy.yaml --server-dry-run`,
+	RunE: runK8sApply,
+}
+
+var k8sExecCmd = &cobra.Command{
+	Use:   "exec [pod] -- [command...]",
+	Short: "Execute a command in a pod (one-shot, non-interactive)",
+	Long: `Execute a command in a pod. This is one-shot only (stdout/stderr is
+captured and printed); interactive TTY sessions will land in the cloud
+backend as a WebSocket endpoint in a follow-up phase.
+
+Use '--' to separate the pod name from the command and its arguments.
+
+Example:
+  clanker k8s exec my-pod -- env
+  clanker k8s exec my-pod -c sidecar -- ls /var/log
+  clanker k8s exec my-pod -n prod -- /bin/sh -c "ps aux | head"`,
+	Args: cobra.MinimumNArgs(2),
+	RunE: runK8sExec,
+}
+
+var k8sPortForwardCmd = &cobra.Command{
+	Use:     "port-forward [pod-or-svc] [local:remote]",
+	Short:   "Forward a local port to a pod or service in the cluster",
+	Aliases: []string{"pf"},
+	Long: `Forward a local port to a pod or service running on the cluster.
+The command blocks until you press Ctrl-C.
+
+Example:
+  clanker k8s port-forward my-pod 8080:80
+  clanker k8s port-forward svc/my-svc 5432:5432 -n db
+  clanker k8s port-forward my-svc 5432:5432 --kind svc -n db
+  clanker k8s port-forward my-pod 0:80    # let kubectl pick the local port`,
+	Args: cobra.ExactArgs(2),
+	RunE: runK8sPortForward,
+}
+
+func init() {
+	k8sCmd.AddCommand(k8sApplyCmd)
+	k8sCmd.AddCommand(k8sExecCmd)
+	k8sCmd.AddCommand(k8sPortForwardCmd)
+
+	for _, cmd := range []*cobra.Command{k8sApplyCmd, k8sExecCmd, k8sPortForwardCmd} {
+		cmd.Flags().StringVarP(&k8sCOpsNamespace, "namespace", "n", "default", "Kubernetes namespace")
+		cmd.Flags().StringVar(&k8sCOpsContext, "context", "", "kubectl context to use")
+		cmd.Flags().StringVar(&k8sCOpsKubeconfig, "kubeconfig", "", "Path to kubeconfig file (default: ~/.kube/config)")
+		cmd.Flags().BoolVar(&k8sCOpsDebug, "debug", false, "Enable debug output")
+	}
+
+	k8sApplyCmd.Flags().StringVarP(&k8sApplyFile, "file", "f", "", "Path to manifest file")
+	k8sApplyCmd.Flags().StringVar(&k8sApplyManifest, "manifest", "", "Inline manifest YAML")
+	k8sApplyCmd.Flags().BoolVar(&k8sApplyStdin, "stdin", false, "Read manifest from stdin")
+	k8sApplyCmd.Flags().BoolVar(&k8sApplyServerDry, "server-dry-run", false, "Submit server-side dry-run (kubectl apply --dry-run=server)")
+
+	k8sExecCmd.Flags().StringVarP(&k8sExecContainer, "container", "c", "", "Container name (if pod has multiple)")
+	// stdin/tty flags are accepted but not yet streaming — once the
+	// WebSocket-backed interactive exec lands we'll wire them through
+	// without breaking flag compat.
+	k8sExecCmd.Flags().BoolVarP(&k8sExecStdin, "stdin", "i", false, "Pass stdin to the container (not yet streaming)")
+	k8sExecCmd.Flags().BoolVarP(&k8sExecTTY, "tty", "t", false, "Allocate a TTY (not yet streaming)")
+
+	k8sPortForwardCmd.Flags().StringVar(&k8sPFAddresses, "address", "", "Addresses to listen on (default localhost)")
+	k8sPortForwardCmd.Flags().StringVar(&k8sPFKind, "kind", "pod", "Target kind: pod, svc, or deploy (used only when the arg has no kind/ prefix)")
+}
+
+func buildK8sClusterOpsClient() *k8s.Client {
+	debug := k8sCOpsDebug || viper.GetBool("debug")
+	kubeconfig := k8sCOpsKubeconfig
+	if kubeconfig == "" {
+		kubeconfig = getKubeconfigPath()
+	}
+	client := k8s.NewClient(kubeconfig, k8sCOpsContext, debug)
+	if k8sCOpsNamespace != "" {
+		client.SetNamespace(k8sCOpsNamespace)
+	}
+	return client
+}
+
+// resolveApplyManifest returns the manifest text from whichever source the
+// user picked (-f, --manifest, --stdin). Exactly one source must be set.
+func resolveApplyManifest() (string, error) {
+	picks := 0
+	if k8sApplyFile != "" {
+		picks++
+	}
+	if k8sApplyManifest != "" {
+		picks++
+	}
+	if k8sApplyStdin {
+		picks++
+	}
+	if picks == 0 {
+		return "", fmt.Errorf("provide one of --file/-f, --manifest, or --stdin")
+	}
+	if picks > 1 {
+		return "", fmt.Errorf("use only one of --file/-f, --manifest, or --stdin")
+	}
+
+	switch {
+	case k8sApplyFile != "":
+		data, err := os.ReadFile(k8sApplyFile)
+		if err != nil {
+			return "", fmt.Errorf("read manifest file %q: %w", k8sApplyFile, err)
+		}
+		return string(data), nil
+	case k8sApplyManifest != "":
+		return k8sApplyManifest, nil
+	default:
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return "", fmt.Errorf("read manifest from stdin: %w", err)
+		}
+		return string(data), nil
+	}
+}
+
+func runK8sApply(cmd *cobra.Command, args []string) error {
+	manifest, err := resolveApplyManifest()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	client := buildK8sClusterOpsClient()
+
+	var output string
+	if k8sApplyServerDry {
+		output, err = client.ApplyDryRunServer(ctx, manifest, k8sCOpsNamespace)
+	} else {
+		output, err = client.Apply(ctx, manifest, k8sCOpsNamespace)
+	}
+	if err != nil {
+		return fmt.Errorf("apply failed: %w", err)
+	}
+	fmt.Print(output)
+	if !strings.HasSuffix(output, "\n") {
+		fmt.Println()
+	}
+	return nil
+}
+
+func runK8sExec(cmd *cobra.Command, args []string) error {
+	pod := args[0]
+	command := args[1:]
+	// Cobra strips a literal "--" between flags and positional args, but
+	// some shells / older invocations still pass it through; drop it if
+	// present so `clanker k8s exec my-pod -- env` and `clanker k8s exec
+	// my-pod env` behave identically.
+	if len(command) > 0 && command[0] == "--" {
+		command = command[1:]
+	}
+	if len(command) == 0 {
+		return fmt.Errorf("a command to exec is required after the pod name")
+	}
+
+	ctx := context.Background()
+	client := buildK8sClusterOpsClient()
+
+	kubectlArgs := []string{"exec", pod}
+	if k8sExecContainer != "" {
+		kubectlArgs = append(kubectlArgs, "-c", k8sExecContainer)
+	}
+	if k8sExecStdin {
+		kubectlArgs = append(kubectlArgs, "-i")
+	}
+	if k8sExecTTY {
+		kubectlArgs = append(kubectlArgs, "-t")
+	}
+	kubectlArgs = append(kubectlArgs, "--")
+	kubectlArgs = append(kubectlArgs, command...)
+
+	output, err := client.RunWithNamespace(ctx, k8sCOpsNamespace, kubectlArgs...)
+	if err != nil {
+		return fmt.Errorf("exec pod/%s failed: %w", pod, err)
+	}
+	fmt.Print(output)
+	if !strings.HasSuffix(output, "\n") {
+		fmt.Println()
+	}
+	return nil
+}
+
+// parsePortPair validates a "<local>:<remote>" port spec; returns it
+// unchanged if valid, error otherwise. Empty local is allowed ("kubectl
+// pick" semantic; e.g., ":80" or "0:80").
+func parsePortPair(s string) (string, error) {
+	parts := strings.SplitN(s, ":", 2)
+	if len(parts) != 2 {
+		return "", fmt.Errorf("port spec %q must be <local>:<remote>", s)
+	}
+	if parts[1] == "" {
+		return "", fmt.Errorf("port spec %q is missing the remote port", s)
+	}
+	return s, nil
+}
+
+// normalizePFTarget prepends the chosen kind (pod/svc/deploy) to bare names.
+// If the user already passed "svc/foo" we pass it through unchanged.
+func normalizePFTarget(raw, kind string) string {
+	if strings.Contains(raw, "/") {
+		return raw
+	}
+	switch strings.ToLower(kind) {
+	case "svc", "service":
+		return "svc/" + raw
+	case "deploy", "deployment":
+		return "deployment/" + raw
+	default:
+		return "pod/" + raw
+	}
+}
+
+func runK8sPortForward(cmd *cobra.Command, args []string) error {
+	target := normalizePFTarget(args[0], k8sPFKind)
+	portSpec, err := parsePortPair(args[1])
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := buildK8sClusterOpsClient()
+
+	pf, err := client.PortForwardStream(ctx, k8sCOpsNamespace, k8s.PortForwardStreamOptions{
+		Target:    target,
+		PortSpec:  portSpec,
+		Addresses: k8sPFAddresses,
+		Stdout:    os.Stdout,
+		Stderr:    os.Stderr,
+	})
+	if err != nil {
+		return fmt.Errorf("start port-forward %s %s: %w", target, portSpec, err)
+	}
+
+	// Forward SIGINT/SIGTERM to kubectl so Ctrl-C tears it down cleanly.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+
+	if err := pf.Wait(); err != nil {
+		if ctx.Err() != nil {
+			// User cancelled via signal — clean exit.
+			return nil
+		}
+		return fmt.Errorf("port-forward exited: %w", err)
+	}
+	return nil
+}

--- a/cmd/k8s_exec_apply_test.go
+++ b/cmd/k8s_exec_apply_test.go
@@ -1,0 +1,140 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParsePortPair(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantErr bool
+	}{
+		{"8080:80", false},
+		{"0:80", false},
+		{":80", false},
+		{"8080", true},
+		{"8080:", true},
+		{"", true},
+	}
+	for _, c := range cases {
+		_, err := parsePortPair(c.in)
+		if c.wantErr && err == nil {
+			t.Errorf("parsePortPair(%q) expected error, got nil", c.in)
+		}
+		if !c.wantErr && err != nil {
+			t.Errorf("parsePortPair(%q) unexpected error: %v", c.in, err)
+		}
+	}
+}
+
+func TestNormalizePFTarget(t *testing.T) {
+	cases := []struct {
+		raw  string
+		kind string
+		want string
+	}{
+		{"my-pod", "pod", "pod/my-pod"},
+		{"my-pod", "", "pod/my-pod"},
+		{"my-svc", "svc", "svc/my-svc"},
+		{"my-svc", "service", "svc/my-svc"},
+		{"my-deploy", "deploy", "deployment/my-deploy"},
+		{"my-deploy", "deployment", "deployment/my-deploy"},
+		{"svc/already-prefixed", "pod", "svc/already-prefixed"},
+		{"deployment/foo", "svc", "deployment/foo"},
+	}
+	for _, c := range cases {
+		got := normalizePFTarget(c.raw, c.kind)
+		if got != c.want {
+			t.Errorf("normalizePFTarget(%q, %q) = %q, want %q", c.raw, c.kind, got, c.want)
+		}
+	}
+}
+
+func TestResolveApplyManifest_FromFile(t *testing.T) {
+	// Reset state from any other test.
+	resetApplyFlags()
+	defer resetApplyFlags()
+
+	dir := t.TempDir()
+	f := filepath.Join(dir, "m.yaml")
+	if err := os.WriteFile(f, []byte("apiVersion: v1\nkind: Pod"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	k8sApplyFile = f
+
+	got, err := resolveApplyManifest()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(got, "kind: Pod") {
+		t.Errorf("manifest content not returned; got %q", got)
+	}
+}
+
+func TestResolveApplyManifest_FromManifestFlag(t *testing.T) {
+	resetApplyFlags()
+	defer resetApplyFlags()
+	k8sApplyManifest = "kind: ConfigMap"
+
+	got, err := resolveApplyManifest()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "kind: ConfigMap" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestResolveApplyManifest_NoneAndTooMany(t *testing.T) {
+	resetApplyFlags()
+	defer resetApplyFlags()
+
+	if _, err := resolveApplyManifest(); err == nil {
+		t.Error("expected error when no manifest source is set")
+	}
+
+	k8sApplyFile = "/tmp/nope"
+	k8sApplyManifest = "kind: X"
+	if _, err := resolveApplyManifest(); err == nil {
+		t.Error("expected error when both --file and --manifest set")
+	}
+}
+
+func TestK8sApplyExecPortForward_RegisteredOnK8sRoot(t *testing.T) {
+	want := map[string]bool{"apply": true, "exec": true, "port-forward": true}
+	for _, c := range k8sCmd.Commands() {
+		name := strings.SplitN(c.Use, " ", 2)[0]
+		delete(want, name)
+	}
+	if len(want) != 0 {
+		t.Errorf("missing registered subcommands on k8s root: %v", want)
+	}
+}
+
+func TestK8sExecCmd_RequiresPodAndCommand(t *testing.T) {
+	if err := k8sExecCmd.Args(k8sExecCmd, []string{"my-pod"}); err == nil {
+		t.Error("expected error for exec with no command")
+	}
+	if err := k8sExecCmd.Args(k8sExecCmd, []string{"my-pod", "env"}); err != nil {
+		t.Errorf("exec with command should be valid: %v", err)
+	}
+}
+
+func TestK8sPortForwardCmd_RequiresTwoArgs(t *testing.T) {
+	if err := k8sPortForwardCmd.Args(k8sPortForwardCmd, []string{"my-pod"}); err == nil {
+		t.Error("expected error for pf with only one arg")
+	}
+	if err := k8sPortForwardCmd.Args(k8sPortForwardCmd, []string{"my-pod", "8080:80"}); err != nil {
+		t.Errorf("pf with two args should be valid: %v", err)
+	}
+}
+
+func resetApplyFlags() {
+	k8sApplyFile = ""
+	k8sApplyManifest = ""
+	k8sApplyStdin = false
+	k8sApplyServerDry = false
+}

--- a/cmd/k8s_exec_apply_test.go
+++ b/cmd/k8s_exec_apply_test.go
@@ -123,6 +123,18 @@ func TestK8sExecCmd_RequiresPodAndCommand(t *testing.T) {
 	}
 }
 
+func TestK8sExecCmd_NoInteractiveFlags(t *testing.T) {
+	// '-i' and '-t' would silently break the run (kubectl errors with
+	// 'stdin is not a tty' because we buffer stdout). They will land
+	// alongside the WebSocket-backed interactive exec; until then the
+	// flags must not be advertised.
+	for _, name := range []string{"stdin", "tty"} {
+		if k8sExecCmd.Flags().Lookup(name) != nil {
+			t.Errorf("k8s exec should not advertise --%s until interactive exec is wired up", name)
+		}
+	}
+}
+
 func TestK8sPortForwardCmd_RequiresTwoArgs(t *testing.T) {
 	if err := k8sPortForwardCmd.Args(k8sPortForwardCmd, []string{"my-pod"}); err == nil {
 		t.Error("expected error for pf with only one arg")

--- a/cmd/k8s_nodes.go
+++ b/cmd/k8s_nodes.go
@@ -1,0 +1,172 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/bgdnvk/clanker/internal/k8s"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	// shared connection flags for the node lifecycle subcommands
+	k8sNodeContext    string
+	k8sNodeKubeconfig string
+	k8sNodeDebug      bool
+
+	// drain flags (kubectl semantics)
+	k8sDrainForce              bool
+	k8sDrainIgnoreDaemonSets   bool
+	k8sDrainDeleteEmptyDirData bool
+	k8sDrainGracePeriod        int
+	k8sDrainTimeout            string
+	k8sDrainPodSelector        string
+	k8sDrainDisableEviction    bool
+)
+
+var k8sNodeCmd = &cobra.Command{
+	Use:   "node",
+	Short: "Manage node lifecycle (cordon, drain, uncordon)",
+	Long: `Manage Kubernetes node lifecycle on the active kubeconfig context:
+cordon a node (mark unschedulable), drain it (evict its workloads), or
+uncordon it (return it to the scheduler).`,
+}
+
+var k8sNodeCordonCmd = &cobra.Command{
+	Use:   "cordon [node]",
+	Short: "Mark a node as unschedulable",
+	Long: `Mark a node as unschedulable. New pods will not be placed on it; existing
+pods are left alone (use 'drain' to evict).
+
+Example:
+  clanker k8s node cordon ip-10-0-1-23.ec2.internal`,
+	Args: cobra.ExactArgs(1),
+	RunE: runK8sNodeCordon,
+}
+
+var k8sNodeUncordonCmd = &cobra.Command{
+	Use:   "uncordon [node]",
+	Short: "Mark a node as schedulable",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runK8sNodeUncordon,
+}
+
+var k8sNodeDrainCmd = &cobra.Command{
+	Use:   "drain [node]",
+	Short: "Drain workloads from a node",
+	Long: `Cordon a node and evict its pods so it can be safely removed or rebooted.
+Honours the same flags as 'kubectl drain' — daemonsets are skipped by
+default (use --ignore-daemonsets=false to require none exist).
+
+Example:
+  clanker k8s node drain ip-10-0-1-23.ec2.internal --ignore-daemonsets --delete-emptydir-data
+  clanker k8s node drain my-node --grace-period 60 --timeout 5m`,
+	Args: cobra.ExactArgs(1),
+	RunE: runK8sNodeDrain,
+}
+
+func init() {
+	k8sCmd.AddCommand(k8sNodeCmd)
+	k8sNodeCmd.AddCommand(k8sNodeCordonCmd)
+	k8sNodeCmd.AddCommand(k8sNodeUncordonCmd)
+	k8sNodeCmd.AddCommand(k8sNodeDrainCmd)
+
+	for _, cmd := range []*cobra.Command{k8sNodeCordonCmd, k8sNodeUncordonCmd, k8sNodeDrainCmd} {
+		cmd.Flags().StringVar(&k8sNodeContext, "context", "", "kubectl context to use")
+		cmd.Flags().StringVar(&k8sNodeKubeconfig, "kubeconfig", "", "Path to kubeconfig file (default: ~/.kube/config)")
+		cmd.Flags().BoolVar(&k8sNodeDebug, "debug", false, "Enable debug output")
+	}
+
+	// Drain-specific flags mirror kubectl's surface.
+	k8sNodeDrainCmd.Flags().BoolVar(&k8sDrainForce, "force", false, "Force eviction of pods not managed by a controller")
+	k8sNodeDrainCmd.Flags().BoolVar(&k8sDrainIgnoreDaemonSets, "ignore-daemonsets", true, "Ignore DaemonSet-managed pods")
+	k8sNodeDrainCmd.Flags().BoolVar(&k8sDrainDeleteEmptyDirData, "delete-emptydir-data", false, "Allow eviction of pods using emptyDir volumes (data is lost)")
+	k8sNodeDrainCmd.Flags().IntVar(&k8sDrainGracePeriod, "grace-period", -1, "Grace period in seconds (-1 = use the pod's terminationGracePeriodSeconds)")
+	k8sNodeDrainCmd.Flags().StringVar(&k8sDrainTimeout, "timeout", "0s", "Time to wait before giving up (e.g., 5m0s, 0s = no timeout)")
+	k8sNodeDrainCmd.Flags().StringVar(&k8sDrainPodSelector, "pod-selector", "", "Label selector to filter which pods to drain")
+	k8sNodeDrainCmd.Flags().BoolVar(&k8sDrainDisableEviction, "disable-eviction", false, "Bypass the eviction API and delete pods directly")
+}
+
+func buildK8sNodeClient() *k8s.Client {
+	debug := k8sNodeDebug || viper.GetBool("debug")
+	kubeconfig := k8sNodeKubeconfig
+	if kubeconfig == "" {
+		kubeconfig = getKubeconfigPath()
+	}
+	// Node ops are cluster-scoped — leave the client's default namespace
+	// unset so buildArgs doesn't inject a stray '-n' for `kubectl cordon`.
+	client := k8s.NewClient(kubeconfig, k8sNodeContext, debug)
+	client.SetNamespace("all")
+	return client
+}
+
+func printAndNewline(s string) {
+	fmt.Print(s)
+	if !strings.HasSuffix(s, "\n") {
+		fmt.Println()
+	}
+}
+
+func runK8sNodeCordon(cmd *cobra.Command, args []string) error {
+	node := args[0]
+	ctx := context.Background()
+	client := buildK8sNodeClient()
+
+	out, err := client.Run(ctx, "cordon", node)
+	if err != nil {
+		return fmt.Errorf("cordon node %q failed: %w", node, err)
+	}
+	printAndNewline(out)
+	return nil
+}
+
+func runK8sNodeUncordon(cmd *cobra.Command, args []string) error {
+	node := args[0]
+	ctx := context.Background()
+	client := buildK8sNodeClient()
+
+	out, err := client.Run(ctx, "uncordon", node)
+	if err != nil {
+		return fmt.Errorf("uncordon node %q failed: %w", node, err)
+	}
+	printAndNewline(out)
+	return nil
+}
+
+func runK8sNodeDrain(cmd *cobra.Command, args []string) error {
+	node := args[0]
+	ctx := context.Background()
+	client := buildK8sNodeClient()
+
+	drainArgs := []string{"drain", node}
+	if k8sDrainForce {
+		drainArgs = append(drainArgs, "--force")
+	}
+	if k8sDrainIgnoreDaemonSets {
+		drainArgs = append(drainArgs, "--ignore-daemonsets")
+	}
+	if k8sDrainDeleteEmptyDirData {
+		drainArgs = append(drainArgs, "--delete-emptydir-data")
+	}
+	if k8sDrainGracePeriod >= 0 {
+		drainArgs = append(drainArgs, fmt.Sprintf("--grace-period=%d", k8sDrainGracePeriod))
+	}
+	if k8sDrainTimeout != "" && k8sDrainTimeout != "0s" {
+		drainArgs = append(drainArgs, "--timeout", k8sDrainTimeout)
+	}
+	if k8sDrainPodSelector != "" {
+		drainArgs = append(drainArgs, "--pod-selector", k8sDrainPodSelector)
+	}
+	if k8sDrainDisableEviction {
+		drainArgs = append(drainArgs, "--disable-eviction")
+	}
+
+	out, err := client.Run(ctx, drainArgs...)
+	if err != nil {
+		return fmt.Errorf("drain node %q failed: %w", node, err)
+	}
+	printAndNewline(out)
+	return nil
+}

--- a/cmd/k8s_nodes_test.go
+++ b/cmd/k8s_nodes_test.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestK8sNodeCmd_HasAllSubcommands(t *testing.T) {
+	want := []string{"cordon", "uncordon", "drain"}
+	got := make(map[string]bool, len(k8sNodeCmd.Commands()))
+	for _, c := range k8sNodeCmd.Commands() {
+		got[strings.SplitN(c.Use, " ", 2)[0]] = true
+	}
+	for _, name := range want {
+		if !got[name] {
+			t.Errorf("k8s node missing subcommand %q (have: %v)", name, got)
+		}
+	}
+}
+
+func TestK8sNodeDrain_HasKubectlFlags(t *testing.T) {
+	for _, name := range []string{
+		"force", "ignore-daemonsets", "delete-emptydir-data",
+		"grace-period", "timeout", "pod-selector", "disable-eviction",
+	} {
+		if k8sNodeDrainCmd.Flags().Lookup(name) == nil {
+			t.Errorf("k8s node drain is missing --%s flag", name)
+		}
+	}
+}
+
+func TestK8sNodeCordon_RequiresOneArg(t *testing.T) {
+	if err := k8sNodeCordonCmd.Args(k8sNodeCordonCmd, nil); err == nil {
+		t.Error("expected error when no node arg passed to cordon")
+	}
+	if err := k8sNodeCordonCmd.Args(k8sNodeCordonCmd, []string{"my-node"}); err != nil {
+		t.Errorf("cordon with one arg should be valid: %v", err)
+	}
+}
+
+func TestK8sNodeCmd_RegisteredOnK8sRoot(t *testing.T) {
+	for _, c := range k8sCmd.Commands() {
+		if strings.SplitN(c.Use, " ", 2)[0] == "node" {
+			return
+		}
+	}
+	t.Fatal("k8s node not registered on k8sCmd")
+}

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -150,9 +151,28 @@ func (c *Client) RunJSON(ctx context.Context, args ...string) ([]byte, error) {
 	return []byte(output), nil
 }
 
+// ApplyDryRunServer runs `kubectl apply -f - --dry-run=server` against the
+// active context. Mirrors Apply but appends --dry-run=server so callers can
+// preview what apply would do without mutating the cluster. Returned output
+// is the server's response (which kubectl prints in its normal "<kind>/<name>
+// configured (server dry run)" form).
+func (c *Client) ApplyDryRunServer(ctx context.Context, manifest, namespace string) (string, error) {
+	return c.applyManifest(ctx, manifest, namespace, true)
+}
+
 // Apply applies a manifest from a string
 func (c *Client) Apply(ctx context.Context, manifest string, namespace string) (string, error) {
-	cmdArgs := c.buildArgs(namespace, []string{"apply", "-f", "-"})
+	return c.applyManifest(ctx, manifest, namespace, false)
+}
+
+// applyManifest is the shared implementation behind Apply / ApplyDryRunServer.
+// dryRunServer toggles --dry-run=server.
+func (c *Client) applyManifest(ctx context.Context, manifest, namespace string, dryRunServer bool) (string, error) {
+	applyArgs := []string{"apply", "-f", "-"}
+	if dryRunServer {
+		applyArgs = append(applyArgs, "--dry-run=server")
+	}
+	cmdArgs := c.buildArgs(namespace, applyArgs)
 
 	if c.debug {
 		fmt.Printf("[kubectl] apply manifest (%d bytes)\n", len(manifest))
@@ -277,6 +297,50 @@ func (c *Client) PortForward(ctx context.Context, podName, namespace string, loc
 		return nil, fmt.Errorf("failed to start port forward: %w", err)
 	}
 
+	return cmd, nil
+}
+
+// PortForwardStreamOptions controls PortForwardStream behaviour. Wire
+// Stdout/Stderr to your own writers (typically os.Stdout/os.Stderr) so the
+// caller can see kubectl's "Forwarding from ..." log in real time.
+type PortForwardStreamOptions struct {
+	Target    string    // e.g. "pod/my-pod" or "svc/my-svc"; required.
+	PortSpec  string    // "<local>:<remote>" or ":<remote>"; required.
+	Addresses string    // optional, passed to --address
+	Stdout    io.Writer // optional; nil = discard.
+	Stderr    io.Writer // optional; nil = discard.
+}
+
+// PortForwardStream starts `kubectl port-forward` with stdout/stderr wired
+// to the supplied writers and returns the running *exec.Cmd. Use this when
+// you want to surface kubectl's log lines live (the CLI port-forward verb
+// does), as opposed to PortForward which discards them.
+func (c *Client) PortForwardStream(ctx context.Context, namespace string, opts PortForwardStreamOptions) (*exec.Cmd, error) {
+	if opts.Target == "" {
+		return nil, fmt.Errorf("PortForwardStream: Target is required")
+	}
+	if opts.PortSpec == "" {
+		return nil, fmt.Errorf("PortForwardStream: PortSpec is required")
+	}
+
+	pfArgs := []string{"port-forward", opts.Target, opts.PortSpec}
+	if opts.Addresses != "" {
+		pfArgs = append(pfArgs, "--address", opts.Addresses)
+	}
+	args := c.buildArgs(namespace, pfArgs)
+
+	cmd := exec.CommandContext(ctx, "kubectl", args...)
+	cmd.Env = os.Environ()
+	if opts.Stdout != nil {
+		cmd.Stdout = opts.Stdout
+	}
+	if opts.Stderr != nil {
+		cmd.Stderr = opts.Stderr
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("failed to start port forward: %w", err)
+	}
 	return cmd, nil
 }
 


### PR DESCRIPTION
## Summary
Adds the remaining Phase 1c mutation verbs so users (and downstream MCP / cloud handlers) can drive ad-hoc resource ops and node lifecycle from the CLI:

- `clanker k8s apply` (-f / --manifest / --stdin, plus `--server-dry-run`)
- `clanker k8s exec <pod> -- <cmd…>` (one-shot, non-interactive — TTY/streaming lands when the cloud WebSocket exec ships)
- `clanker k8s port-forward <target> <local:remote>` (with `--kind`, streams kubectl's log live, Ctrl-C tears down cleanly)
- `clanker k8s node {cordon, uncordon, drain}` (drain mirrors kubectl's full flag surface)

## Client additions
Two small, focused additions to `*k8s.Client`:
- `ApplyDryRunServer(ctx, manifest, ns)` — shares the apply pipeline with `--dry-run=server` appended.
- `PortForwardStream(ctx, ns, opts)` — variant of `PortForward` that wires stdout/stderr to caller writers so the CLI can surface kubectl's \"Forwarding from …\" log live (the existing `PortForward` discarded it, which was fine for backend use but not the CLI).

## Surface
\`\`\`
clanker k8s apply -f ./deployment.yaml
clanker k8s apply --stdin < ./deployment.yaml
clanker k8s apply -f ./deploy.yaml --server-dry-run
clanker k8s exec my-pod -- env
clanker k8s exec my-pod -c sidecar -- ls /var/log
clanker k8s port-forward my-pod 8080:80
clanker k8s port-forward svc/my-svc 5432:5432 -n db
clanker k8s node cordon my-node
clanker k8s node drain my-node --ignore-daemonsets --delete-emptydir-data
clanker k8s node uncordon my-node
\`\`\`

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`gofmt -l\` clean
- [x] \`go test ./cmd/... ./internal/k8s/...\` — 12 new tests green, full suite green
- [x] \`clanker k8s --help\` lists all four new verbs (apply, exec, port-forward, node)

## Follow-ups (separate phases)
- Native MCP tool wrappers for these verbs (Phase 1e)
- Backend `/api/k8s/{apply,exec,port-forward,node}` handlers — exec/port-forward will need WebSocket (Phase 2)
- Frontend exec terminal + manifest editor + port-forward modal (Phase 3)