### PR TITLE
feat(k8s/sre/4a): playbook framework + crashloop-recovery + CLI fix subcommand

### DIFF
--- a/cmd/k8s_fix.go
+++ b/cmd/k8s_fix.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -60,6 +61,7 @@ func init() {
 }
 
 func runK8sFix(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
 	registry := sre.NewPlaybookRegistry()
 
 	if len(args) == 0 {
@@ -67,6 +69,17 @@ func runK8sFix(cmd *cobra.Command, args []string) error {
 	}
 	if len(args) > 1 {
 		return fmt.Errorf("expected 0 or 1 playbook ID, got %d", len(args))
+	}
+
+	// Validate --approve BEFORE planning so a typo doesn't waste a
+	// cluster round-trip generating a plan we'll then refuse to act
+	// on. Plan generation can be expensive (fetches logs, queries
+	// rollout state); fail fast on cheap input errors.
+	approve := strings.ToLower(strings.TrimSpace(k8sFixApprove))
+	switch approve {
+	case "step", "auto", "plan-only":
+	default:
+		return fmt.Errorf("--approve must be one of: step, auto, plan-only (got %q)", k8sFixApprove)
 	}
 
 	id := strings.TrimSpace(args[0])
@@ -79,7 +92,7 @@ func runK8sFix(cmd *cobra.Command, args []string) error {
 	kubeconfig := getKubeconfigPath()
 	client := newSREClient(kubeconfig, k8sFixContext, debug)
 
-	plan, err := playbook.Plan(context.Background(), client, sre.PlaybookInput{
+	plan, err := playbook.Plan(ctx, client, sre.PlaybookInput{
 		Namespace: k8sFixNamespace,
 		Name:      k8sFixName,
 		Context:   k8sFixContext,
@@ -90,16 +103,16 @@ func runK8sFix(cmd *cobra.Command, args []string) error {
 	}
 
 	if k8sFixJSON {
-		out, _ := json.MarshalIndent(plan, "", "  ")
+		// The cloud backend shells out to `clanker k8s fix --json`
+		// and unmarshals the stdout. A silent marshal error would
+		// produce empty stdout and a confusing decode error on the
+		// backend — surface it explicitly.
+		out, err := json.MarshalIndent(plan, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshal playbook plan: %w", err)
+		}
 		fmt.Println(string(out))
 		return nil
-	}
-
-	approve := strings.ToLower(strings.TrimSpace(k8sFixApprove))
-	switch approve {
-	case "step", "auto", "plan-only":
-	default:
-		return fmt.Errorf("--approve must be one of: step, auto, plan-only (got %q)", k8sFixApprove)
 	}
 
 	printPlaybookPlan(os.Stdout, plan)
@@ -112,12 +125,13 @@ func runK8sFix(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	return executePlaybookPlan(context.Background(), plan, approve)
+	return executePlaybookPlan(ctx, plan, approve)
 }
 
 // listPlaybooks prints a table of registered playbooks for the user
-// who ran 'clanker k8s fix' with no arguments.
-func listPlaybooks(out *os.File, registry *sre.PlaybookRegistry) error {
+// who ran 'clanker k8s fix' with no arguments. Takes io.Writer so
+// tests can pass a buffer and assert the rendered table.
+func listPlaybooks(out io.Writer, registry *sre.PlaybookRegistry) error {
 	playbooks := registry.All()
 	if len(playbooks) == 0 {
 		fmt.Fprintln(out, "No playbooks registered.")
@@ -139,8 +153,9 @@ func listPlaybooks(out *os.File, registry *sre.PlaybookRegistry) error {
 
 // printPlaybookPlan renders the plan as a human-readable summary so
 // the user can review before approving. Mirrors the layout the
-// frontend's K8sPlaybookRunner will use (Phase 4e).
-func printPlaybookPlan(out *os.File, plan *sre.PlaybookPlan) {
+// frontend's K8sPlaybookRunner will use (Phase 4e). Takes io.Writer
+// so tests can pass a buffer and assert the rendered output.
+func printPlaybookPlan(out io.Writer, plan *sre.PlaybookPlan) {
 	fmt.Fprintf(out, "Playbook: %s\n", plan.Title)
 	if plan.Target != "" {
 		fmt.Fprintf(out, "Target:   %s\n", plan.Target)

--- a/cmd/k8s_fix.go
+++ b/cmd/k8s_fix.go
@@ -1,0 +1,232 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/bgdnvk/clanker/internal/k8s"
+	"github.com/bgdnvk/clanker/internal/k8s/sre"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// Shared flags for the fix subcommand tree.
+var (
+	k8sFixNamespace string
+	k8sFixName      string
+	k8sFixContext   string
+	k8sFixCluster   string
+	k8sFixApprove   string // "step" (default) | "auto" | "plan-only"
+	k8sFixJSON      bool
+	k8sFixDebug     bool
+)
+
+var k8sFixCmd = &cobra.Command{
+	Use:   "fix [playbook-id]",
+	Short: "Run a remediation playbook against the active cluster",
+	Long: `Run a curated remediation playbook. Each playbook emits an ordered
+set of diagnostic + mutation steps with per-step approval gates.
+
+Use 'clanker k8s fix' with no arguments to list the available
+playbooks. Use '--approve plan-only' to inspect the plan without
+running any step. Use '--approve auto' to skip per-step prompts
+EXCEPT for steps the playbook marks as requiring explicit approval.
+
+Examples:
+  clanker k8s fix
+  clanker k8s fix crashloop-recovery --name my-pod -n prod
+  clanker k8s fix crashloop-recovery --name my-pod -n prod --approve plan-only
+  clanker k8s fix crashloop-recovery --name my-pod --approve auto`,
+	RunE: runK8sFix,
+}
+
+func init() {
+	k8sCmd.AddCommand(k8sFixCmd)
+
+	k8sFixCmd.Flags().StringVarP(&k8sFixNamespace, "namespace", "n", "default", "Kubernetes namespace")
+	k8sFixCmd.Flags().StringVar(&k8sFixName, "name", "", "Target resource name (required by most playbooks)")
+	k8sFixCmd.Flags().StringVar(&k8sFixContext, "context", "", "kubectl context (defaults to active context)")
+	k8sFixCmd.Flags().StringVar(&k8sFixCluster, "cluster", "", "Cluster name (informational; used in audit log)")
+	k8sFixCmd.Flags().StringVar(&k8sFixApprove, "approve", "step",
+		"Approval mode: step (prompt per step) | auto (skip prompts except for forced-approval steps) | plan-only (print plan, don't run)")
+	k8sFixCmd.Flags().BoolVar(&k8sFixJSON, "json", false, "Emit the playbook plan as JSON (forces --approve plan-only)")
+	k8sFixCmd.Flags().BoolVar(&k8sFixDebug, "debug", false, "Enable debug output")
+}
+
+func runK8sFix(cmd *cobra.Command, args []string) error {
+	registry := sre.NewPlaybookRegistry()
+
+	if len(args) == 0 {
+		return listPlaybooks(os.Stdout, registry)
+	}
+	if len(args) > 1 {
+		return fmt.Errorf("expected 0 or 1 playbook ID, got %d", len(args))
+	}
+
+	id := strings.TrimSpace(args[0])
+	playbook, err := registry.Get(id)
+	if err != nil {
+		return err
+	}
+
+	debug := k8sFixDebug || viper.GetBool("debug")
+	kubeconfig := getKubeconfigPath()
+	client := newSREClient(kubeconfig, k8sFixContext, debug)
+
+	plan, err := playbook.Plan(context.Background(), client, sre.PlaybookInput{
+		Namespace: k8sFixNamespace,
+		Name:      k8sFixName,
+		Context:   k8sFixContext,
+		Cluster:   k8sFixCluster,
+	})
+	if err != nil {
+		return fmt.Errorf("plan failed: %w", err)
+	}
+
+	if k8sFixJSON {
+		out, _ := json.MarshalIndent(plan, "", "  ")
+		fmt.Println(string(out))
+		return nil
+	}
+
+	approve := strings.ToLower(strings.TrimSpace(k8sFixApprove))
+	switch approve {
+	case "step", "auto", "plan-only":
+	default:
+		return fmt.Errorf("--approve must be one of: step, auto, plan-only (got %q)", k8sFixApprove)
+	}
+
+	printPlaybookPlan(os.Stdout, plan)
+
+	if approve == "plan-only" {
+		return nil
+	}
+	if len(plan.Steps) == 0 {
+		fmt.Println("Nothing to do.")
+		return nil
+	}
+
+	return executePlaybookPlan(context.Background(), plan, approve)
+}
+
+// listPlaybooks prints a table of registered playbooks for the user
+// who ran 'clanker k8s fix' with no arguments.
+func listPlaybooks(out *os.File, registry *sre.PlaybookRegistry) error {
+	playbooks := registry.All()
+	if len(playbooks) == 0 {
+		fmt.Fprintln(out, "No playbooks registered.")
+		return nil
+	}
+	fmt.Fprintln(out, "Available playbooks:")
+	fmt.Fprintln(out)
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tTITLE\tDESCRIPTION")
+	fmt.Fprintln(w, "──\t─────\t───────────")
+	for _, p := range playbooks {
+		fmt.Fprintf(w, "%s\t%s\t%s\n", p.ID(), p.Title(), p.Description())
+	}
+	w.Flush()
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "Run 'clanker k8s fix <id>' to start a playbook.")
+	return nil
+}
+
+// printPlaybookPlan renders the plan as a human-readable summary so
+// the user can review before approving. Mirrors the layout the
+// frontend's K8sPlaybookRunner will use (Phase 4e).
+func printPlaybookPlan(out *os.File, plan *sre.PlaybookPlan) {
+	fmt.Fprintf(out, "Playbook: %s\n", plan.Title)
+	if plan.Target != "" {
+		fmt.Fprintf(out, "Target:   %s\n", plan.Target)
+	}
+	fmt.Fprintf(out, "Summary:  %s\n", plan.Summary)
+	if len(plan.Notes) > 0 {
+		fmt.Fprintln(out)
+		for _, n := range plan.Notes {
+			fmt.Fprintf(out, "Note: %s\n", n)
+		}
+	}
+	fmt.Fprintln(out)
+	fmt.Fprintf(out, "Steps (%d):\n", len(plan.Steps))
+	for i, s := range plan.Steps {
+		marker := "•"
+		if s.Mutating {
+			marker = "✎"
+		}
+		fmt.Fprintf(out, "  %d. %s  %s\n", i+1, marker, s.Description)
+		if s.Reason != "" {
+			fmt.Fprintf(out, "       reason: %s\n", s.Reason)
+		}
+		fmt.Fprintf(out, "       run:    %s %s\n", s.Command, strings.Join(s.Args, " "))
+		if s.Risk != "" {
+			fmt.Fprintf(out, "       risk:   %s\n", s.Risk)
+		}
+		if s.RequiresApproval {
+			fmt.Fprintln(out, "       (requires explicit approval even in auto mode)")
+		}
+	}
+	fmt.Fprintln(out)
+}
+
+// executePlaybookPlan runs the steps in order, honouring the approval
+// mode. Returns on the first step error so the user can investigate
+// without the rest of the plan running on a broken state.
+func executePlaybookPlan(ctx context.Context, plan *sre.PlaybookPlan, approve string) error {
+	reader := bufio.NewReader(os.Stdin)
+	for i, step := range plan.Steps {
+		needApproval := approve == "step" || step.RequiresApproval
+		if needApproval {
+			fmt.Printf("Step %d/%d: %s\n", i+1, len(plan.Steps), step.Description)
+			fmt.Printf("  $ %s %s\n", step.Command, strings.Join(step.Args, " "))
+			fmt.Print("Approve? [y/N/q]: ")
+			line, _ := reader.ReadString('\n')
+			ans := strings.ToLower(strings.TrimSpace(line))
+			switch ans {
+			case "y", "yes":
+				// continue
+			case "q", "quit":
+				return fmt.Errorf("playbook aborted by user at step %d", i+1)
+			default:
+				fmt.Println("  skipped.")
+				continue
+			}
+		} else {
+			fmt.Printf("Step %d/%d: %s\n", i+1, len(plan.Steps), step.Description)
+		}
+
+		output, err := runPlaybookStep(ctx, step)
+		fmt.Print(output)
+		if !strings.HasSuffix(output, "\n") {
+			fmt.Println()
+		}
+		if err != nil {
+			return fmt.Errorf("step %d (%s) failed: %w", i+1, step.ID, err)
+		}
+	}
+	return nil
+}
+
+// runPlaybookStep invokes the step's command + args via os/exec. We
+// shell out directly (not through clanker's k8s.Client) because each
+// playbook step already carries the fully-rendered argv — including
+// the --namespace / --context flags — so we don't need to re-thread
+// kubeconfig.
+func runPlaybookStep(ctx context.Context, step sre.PlaybookStep) (string, error) {
+	cmd := exec.CommandContext(ctx, step.Command, step.Args...)
+	cmd.Env = os.Environ()
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// newSREClient builds an sre.K8sClient backed by the existing kubectl
+// shellout, via the same NewSREAdapter the other SRE commands use
+// (autoscaler, health, hpa-validate, karpenter, workloads).
+func newSREClient(kubeconfig, kubectlContext string, debug bool) sre.K8sClient {
+	return k8s.NewSREAdapter(k8s.NewClient(kubeconfig, kubectlContext, debug))
+}

--- a/cmd/k8s_fix_test.go
+++ b/cmd/k8s_fix_test.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/bgdnvk/clanker/internal/k8s/sre"
+)
+
+func TestK8sFixCmd_Wiring(t *testing.T) {
+	if k8sFixCmd.Use == "" {
+		t.Fatal("k8sFixCmd.Use is empty")
+	}
+	if k8sFixCmd.RunE == nil {
+		t.Fatal("k8sFixCmd.RunE is nil")
+	}
+	for _, name := range []string{"namespace", "name", "context", "cluster", "approve", "json", "debug"} {
+		if k8sFixCmd.Flags().Lookup(name) == nil {
+			t.Errorf("k8s fix is missing --%s flag", name)
+		}
+	}
+}
+
+func TestK8sFixCmd_RegisteredOnK8sRoot(t *testing.T) {
+	for _, c := range k8sCmd.Commands() {
+		if strings.SplitN(c.Use, " ", 2)[0] == "fix" {
+			return
+		}
+	}
+	t.Fatal("k8s fix not registered on k8sCmd")
+}
+
+func TestListPlaybooks_RendersTable(t *testing.T) {
+	r := sre.NewPlaybookRegistry()
+	var buf bytes.Buffer
+
+	// listPlaybooks signature takes *os.File; use a thin shim via the
+	// underlying tabwriter rendering rather than restructure the
+	// helper for testability. We assert the *content* by re-rendering
+	// what the function would render through a regular Stdout-like
+	// path: that's hard to do without DI, so we compromise and
+	// assert the registry side of the contract — listPlaybooks
+	// reads All() and prints each playbook's ID + Description.
+	playbooks := r.All()
+	if len(playbooks) == 0 {
+		t.Skip("no built-in playbooks registered; list table check requires at least one")
+	}
+	for _, p := range playbooks {
+		if p.ID() == "" {
+			t.Errorf("playbook missing ID: %#v", p)
+		}
+		if p.Title() == "" {
+			t.Errorf("playbook %q missing title", p.ID())
+		}
+		if p.Description() == "" {
+			t.Errorf("playbook %q missing description", p.ID())
+		}
+	}
+	_ = buf
+}

--- a/cmd/k8s_fix_test.go
+++ b/cmd/k8s_fix_test.go
@@ -33,29 +33,31 @@ func TestK8sFixCmd_RegisteredOnK8sRoot(t *testing.T) {
 
 func TestListPlaybooks_RendersTable(t *testing.T) {
 	r := sre.NewPlaybookRegistry()
-	var buf bytes.Buffer
-
-	// listPlaybooks signature takes *os.File; use a thin shim via the
-	// underlying tabwriter rendering rather than restructure the
-	// helper for testability. We assert the *content* by re-rendering
-	// what the function would render through a regular Stdout-like
-	// path: that's hard to do without DI, so we compromise and
-	// assert the registry side of the contract — listPlaybooks
-	// reads All() and prints each playbook's ID + Description.
 	playbooks := r.All()
 	if len(playbooks) == 0 {
 		t.Skip("no built-in playbooks registered; list table check requires at least one")
 	}
+
+	var buf bytes.Buffer
+	if err := listPlaybooks(&buf, r); err != nil {
+		t.Fatalf("listPlaybooks: %v", err)
+	}
+	out := buf.String()
+	// Sanity: header rendered, every registered playbook's ID + title
+	// surfaced. The exact tabwriter spacing isn't load-bearing, so we
+	// match on substrings rather than full lines.
+	if !strings.Contains(out, "Available playbooks") {
+		t.Errorf("expected 'Available playbooks' header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "ID") || !strings.Contains(out, "TITLE") {
+		t.Errorf("expected table header columns, got:\n%s", out)
+	}
 	for _, p := range playbooks {
-		if p.ID() == "" {
-			t.Errorf("playbook missing ID: %#v", p)
+		if !strings.Contains(out, p.ID()) {
+			t.Errorf("rendered list missing playbook ID %q\n%s", p.ID(), out)
 		}
-		if p.Title() == "" {
-			t.Errorf("playbook %q missing title", p.ID())
-		}
-		if p.Description() == "" {
-			t.Errorf("playbook %q missing description", p.ID())
+		if !strings.Contains(out, p.Title()) {
+			t.Errorf("rendered list missing playbook title %q\n%s", p.Title(), out)
 		}
 	}
-	_ = buf
 }

--- a/internal/k8s/sre/playbooks.go
+++ b/internal/k8s/sre/playbooks.go
@@ -1,0 +1,250 @@
+package sre
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// PlaybookStep is one step in a generated remediation plan. It carries
+// the kubectl/helm/clanker invocation the executor will run plus
+// metadata for the approval UI (why this step exists, how risky it is,
+// whether it can be auto-applied).
+//
+// The shape is deliberately close to sre.RemediationStep — we could
+// have re-used that type, but playbooks emit ORDERED multi-step plans
+// where a later step depends on an earlier one's effect, while
+// RemediationStep is currently used for one-shot human-readable
+// recommendations. Keeping the playbook step distinct avoids
+// retrofitting the diagnostics types with sequencing concerns.
+type PlaybookStep struct {
+	ID          string   `json:"id"`
+	Description string   `json:"description"`
+	Command     string   `json:"command"`            // "kubectl" | "helm" | "clanker"
+	Args        []string `json:"args"`               // pre-shellquoted argv
+	Reason      string   `json:"reason,omitempty"`   // human-facing "why this"
+	Risk        string   `json:"risk,omitempty"`     // low | medium | high
+	Mutating    bool     `json:"mutating,omitempty"` // false = read-only / diagnostic
+	// RequiresApproval forces a per-step confirmation even when the
+	// caller asked for auto-apply. Used for irreversible steps
+	// (delete, drain) so 'auto' mode still pauses on the dangerous ones.
+	RequiresApproval bool `json:"requiresApproval,omitempty"`
+}
+
+// PlaybookPlan is the ordered list of steps a playbook emits, plus
+// some metadata the runner / UI uses to render and audit. The Plan
+// itself does NOT execute — that's the caller's job. This keeps
+// playbooks pure functions of (context, k8s state) → steps.
+type PlaybookPlan struct {
+	PlaybookID  string         `json:"playbookId"`
+	Title       string         `json:"title"`
+	Target      string         `json:"target"` // 'pod/foo@ns' or similar
+	Summary     string         `json:"summary"`
+	Steps       []PlaybookStep `json:"steps"`
+	GeneratedAt time.Time      `json:"generatedAt"`
+	// Notes is free-form text the runner can render verbatim above
+	// the step list — used to surface context the LLM diagnosed
+	// (e.g., "container OOMKilled 3 times in the last 10m").
+	Notes []string `json:"notes,omitempty"`
+}
+
+// PlaybookInput is the request shape that drives a playbook. Not every
+// playbook uses every field; each playbook documents what it needs.
+type PlaybookInput struct {
+	Namespace string `json:"namespace,omitempty"`
+	// Name is the target resource the playbook should operate on
+	// (a pod for crashloop, a deployment for stuck rollout, etc.).
+	// Optional for cluster-wide playbooks.
+	Name string `json:"name,omitempty"`
+	// Cluster / Context: optional kubectl context override. The
+	// playbook itself doesn't switch context — it emits steps that
+	// honour whichever context the runner sets.
+	Context string `json:"context,omitempty"`
+	Cluster string `json:"cluster,omitempty"`
+}
+
+// Playbook is a deterministic plan generator. Each playbook reads the
+// current cluster state via the supplied K8sClient and returns a
+// PlaybookPlan that the caller (CLI / backend / agent) executes —
+// usually with per-step approval gates.
+type Playbook interface {
+	// ID is the stable identifier used to invoke the playbook
+	// (e.g., 'crashloop-recovery'). Kebab-case.
+	ID() string
+	// Title is the human-readable name shown in the UI.
+	Title() string
+	// Description summarises when and why to use this playbook.
+	Description() string
+	// Plan inspects the cluster state and returns an ordered set of
+	// remediation steps. Returning an empty Steps slice (with a
+	// non-empty Summary) signals "nothing to do" — the runner
+	// should surface the summary as a no-op outcome.
+	Plan(ctx context.Context, client K8sClient, input PlaybookInput) (*PlaybookPlan, error)
+}
+
+// PlaybookRegistry maps IDs to playbooks. Used by the CLI 'fix'
+// subcommand and the backend /api/k8s/playbook/run handler.
+type PlaybookRegistry struct {
+	playbooks map[string]Playbook
+}
+
+// NewPlaybookRegistry returns a registry pre-populated with every
+// built-in playbook this package ships. Callers can add their own
+// playbooks via Register before invoking Get/List.
+func NewPlaybookRegistry() *PlaybookRegistry {
+	r := &PlaybookRegistry{playbooks: make(map[string]Playbook)}
+	for _, p := range builtinPlaybooks() {
+		r.Register(p)
+	}
+	return r
+}
+
+// Register adds a playbook to the registry. Overwrites any existing
+// playbook with the same ID — callers that need to compose registries
+// (e.g., a test that injects a mock for one of the built-ins) should
+// register after NewPlaybookRegistry.
+func (r *PlaybookRegistry) Register(p Playbook) {
+	r.playbooks[p.ID()] = p
+}
+
+// Get returns the playbook by ID, or an error listing the known IDs
+// if no match. The error message lists the valid IDs alphabetically
+// so the CLI / API surface gets a stable hint.
+func (r *PlaybookRegistry) Get(id string) (Playbook, error) {
+	if p, ok := r.playbooks[id]; ok {
+		return p, nil
+	}
+	known := r.IDs()
+	return nil, fmt.Errorf("unknown playbook %q (known: %s)", id, strings.Join(known, ", "))
+}
+
+// IDs returns every registered playbook ID in deterministic
+// (alphabetical) order — exposed so CLI help and the
+// /api/k8s/playbook/list endpoint can render a stable list.
+func (r *PlaybookRegistry) IDs() []string {
+	ids := make([]string, 0, len(r.playbooks))
+	for id := range r.playbooks {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// All returns every registered playbook, sorted by ID. Useful for
+// rendering a 'clanker k8s fix' help table with descriptions.
+func (r *PlaybookRegistry) All() []Playbook {
+	ids := r.IDs()
+	out := make([]Playbook, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, r.playbooks[id])
+	}
+	return out
+}
+
+// builtinPlaybooks returns the standard set shipped with this package.
+// Adding a new playbook to the library = adding a constructor here
+// (and writing a focused test).
+func builtinPlaybooks() []Playbook {
+	return []Playbook{
+		&crashLoopRecoveryPlaybook{},
+	}
+}
+
+// =====================================================================
+// crashLoopRecoveryPlaybook
+// =====================================================================
+//
+// Common pattern: a pod stuck in CrashLoopBackOff because the
+// container exits non-zero on startup. Recovery is a sequence:
+//   1. Capture recent logs from the previous container (so the user /
+//      LLM has data to diagnose with).
+//   2. Describe the pod (events, container statuses, restart count).
+//   3. Delete the pod, letting its controller (ReplicaSet, StatefulSet)
+//      recreate it — sometimes the failure was a transient kube state
+//      issue and a fresh pod recovers on its own.
+//
+// This playbook deliberately does NOT mutate the underlying workload
+// (no scale-down, no image rollback). That's a separate playbook
+// (stuck-rollout) that the user explicitly asks for. We stop after
+// the pod delete and let the user observe whether the new pod is
+// healthy — agents can chain into stuck-rollout if it isn't.
+
+type crashLoopRecoveryPlaybook struct{}
+
+func (p *crashLoopRecoveryPlaybook) ID() string    { return "crashloop-recovery" }
+func (p *crashLoopRecoveryPlaybook) Title() string { return "CrashLoopBackOff recovery" }
+func (p *crashLoopRecoveryPlaybook) Description() string {
+	return "Capture previous-container logs + events, then delete the crashing pod so its controller recreates it. Stops at the delete; chain stuck-rollout if the new pod is unhealthy too."
+}
+
+func (p *crashLoopRecoveryPlaybook) Plan(ctx context.Context, _ K8sClient, input PlaybookInput) (*PlaybookPlan, error) {
+	if input.Name == "" {
+		return nil, fmt.Errorf("crashloop-recovery: pod name is required (use the --name flag)")
+	}
+	ns := input.Namespace
+	if ns == "" {
+		ns = "default"
+	}
+	pod := input.Name
+	target := fmt.Sprintf("pod/%s@%s", pod, ns)
+
+	steps := []PlaybookStep{
+		{
+			ID:          "logs-previous",
+			Description: fmt.Sprintf("Capture last 200 lines from the previous %s container", pod),
+			Command:     "kubectl",
+			Args:        kubectlArgs(input, "logs", pod, "--previous", "--tail=200"),
+			Reason:      "The current container is restarting, so 'kubectl logs' alone would only show the post-restart state. --previous catches the crash output.",
+			Risk:        "low",
+			Mutating:    false,
+		},
+		{
+			ID:          "describe",
+			Description: fmt.Sprintf("Describe %s for events + container statuses", pod),
+			Command:     "kubectl",
+			Args:        kubectlArgs(input, "describe", "pod", pod),
+			Reason:      "Surfaces the kubelet-reported exit code, last termination reason (OOMKilled, Error, …), and any image-pull / probe events leading up to the crash.",
+			Risk:        "low",
+			Mutating:    false,
+		},
+		{
+			ID:               "delete-pod",
+			Description:      fmt.Sprintf("Delete %s so its controller recreates a fresh pod", pod),
+			Command:          "kubectl",
+			Args:             kubectlArgs(input, "delete", "pod", pod),
+			Reason:           "Transient kube state (e.g., a stuck volume attach, a flapping probe) often clears on pod restart. The owning controller (ReplicaSet, StatefulSet) brings a new pod up automatically.",
+			Risk:             "medium",
+			Mutating:         true,
+			RequiresApproval: true,
+		},
+	}
+
+	return &PlaybookPlan{
+		PlaybookID:  p.ID(),
+		Title:       p.Title(),
+		Target:      target,
+		Summary:     fmt.Sprintf("Diagnose and recycle %s. Stops before re-applying workload changes — chain stuck-rollout if the recreated pod also fails.", target),
+		Steps:       steps,
+		GeneratedAt: time.Now().UTC(),
+		Notes: []string{
+			"This plan captures diagnostics first, then deletes the pod. If you're operating without LLM assistance, scan the 'logs-previous' output for OOMKilled / image-pull errors before approving the delete.",
+		},
+	}, nil
+}
+
+// kubectlArgs prepends '-n <ns>' / '--context <ctx>' (when set) to the
+// caller-supplied kubectl args. Keeps each step's Args list self-
+// contained so the executor doesn't have to thread context separately.
+func kubectlArgs(input PlaybookInput, args ...string) []string {
+	out := make([]string, 0, len(args)+4)
+	if input.Namespace != "" {
+		out = append(out, "-n", input.Namespace)
+	}
+	if input.Context != "" {
+		out = append(out, "--context", input.Context)
+	}
+	out = append(out, args...)
+	return out
+}

--- a/internal/k8s/sre/playbooks.go
+++ b/internal/k8s/sre/playbooks.go
@@ -149,6 +149,8 @@ func (r *PlaybookRegistry) All() []Playbook {
 func builtinPlaybooks() []Playbook {
 	return []Playbook{
 		&crashLoopRecoveryPlaybook{},
+		&stuckRolloutPlaybook{},
+		&pendingPodSchedulingPlaybook{},
 	}
 }
 
@@ -232,6 +234,185 @@ func (p *crashLoopRecoveryPlaybook) Plan(ctx context.Context, _ K8sClient, input
 			"This plan captures diagnostics first, then deletes the pod. If you're operating without LLM assistance, scan the 'logs-previous' output for OOMKilled / image-pull errors before approving the delete.",
 		},
 	}, nil
+}
+
+// =====================================================================
+// stuckRolloutPlaybook
+// =====================================================================
+//
+// A deployment rollout stuck in progress (image-pull failure, failing
+// readiness probe on the new pod spec, missing ConfigMap) usually has
+// only one safe recovery: roll back to the last known-good revision.
+// This playbook captures the rollout state + history so the user
+// can see WHY it's stuck, then offers the undo step.
+
+type stuckRolloutPlaybook struct{}
+
+func (p *stuckRolloutPlaybook) ID() string    { return "stuck-rollout" }
+func (p *stuckRolloutPlaybook) Title() string { return "Stuck deployment rollout" }
+func (p *stuckRolloutPlaybook) Description() string {
+	return "Inspect the rollout status + revision history of a deployment, then roll back to the previous revision. Use when a rollout has been stalled for minutes with one or more pods stuck Pending / ImagePullBackOff / CrashLoopBackOff."
+}
+
+func (p *stuckRolloutPlaybook) Plan(ctx context.Context, _ K8sClient, input PlaybookInput) (*PlaybookPlan, error) {
+	if input.Name == "" {
+		return nil, fmt.Errorf("stuck-rollout: deployment name is required (use the --name flag)")
+	}
+	ns := input.Namespace
+	if ns == "" {
+		ns = "default"
+	}
+	dep := input.Name
+	target := fmt.Sprintf("deployment/%s@%s", dep, ns)
+
+	steps := []PlaybookStep{
+		{
+			ID:          "rollout-status",
+			Description: fmt.Sprintf("Read current rollout status of %s", dep),
+			Command:     "kubectl",
+			Args:        kubectlArgs(input, "rollout", "status", "deployment/"+dep, "--watch=false"),
+			Reason:      "Shows where the rollout is stuck (waiting on ReplicaSet scale-up, failing probes, etc).",
+			Risk:        "low",
+			Mutating:    false,
+		},
+		{
+			ID:          "rollout-history",
+			Description: fmt.Sprintf("List the revision history of %s", dep),
+			Command:     "kubectl",
+			Args:        kubectlArgs(input, "rollout", "history", "deployment/"+dep),
+			Reason:      "We need the previous revision number to know what we're rolling back TO.",
+			Risk:        "low",
+			Mutating:    false,
+		},
+		{
+			ID:          "describe",
+			Description: fmt.Sprintf("Describe %s for events + condition reasons", dep),
+			Command:     "kubectl",
+			Args:        kubectlArgs(input, "describe", "deployment/"+dep),
+			Reason:      "Surfaces ProgressDeadlineExceeded / ReplicaFailure conditions and the kubelet events behind them.",
+			Risk:        "low",
+			Mutating:    false,
+		},
+		{
+			ID:               "rollout-undo",
+			Description:      fmt.Sprintf("Roll %s back to the previous revision", dep),
+			Command:          "kubectl",
+			Args:             kubectlArgs(input, "rollout", "undo", "deployment/"+dep),
+			Reason:           "If the current revision is broken, rolling back to the previous one restores the known-good state. The deployment's revisionHistoryLimit must be >= 1 (default is 10).",
+			Risk:             "medium",
+			Mutating:         true,
+			RequiresApproval: true,
+		},
+	}
+
+	return &PlaybookPlan{
+		PlaybookID:  p.ID(),
+		Title:       p.Title(),
+		Target:      target,
+		Summary:     fmt.Sprintf("Inspect and roll back the stuck rollout of %s. Stops after undo — chain crashloop-recovery if the rolled-back pods still fail.", target),
+		Steps:       steps,
+		GeneratedAt: time.Now().UTC(),
+		Notes: []string{
+			"Roll back is destructive: any config changes baked into the current revision (env vars, image tag, args) will revert. Verify the rollout history shows the right previous revision before approving.",
+		},
+	}, nil
+}
+
+// =====================================================================
+// pendingPodSchedulingPlaybook
+// =====================================================================
+//
+// A pod stuck in Pending is almost always a scheduler problem: no
+// node has enough CPU/memory, no node matches the pod's tolerations
+// / nodeSelector / affinity, or PV bindings are blocking. The right
+// remediation depends on the cluster shape (Karpenter? fixed
+// node-pool? cluster-autoscaler?), so this playbook is diagnostic-
+// only: surface the data the user / LLM needs to choose between
+// 'add capacity', 'relax constraints', and 'fix the volume binding'.
+// No mutating step.
+
+type pendingPodSchedulingPlaybook struct{}
+
+func (p *pendingPodSchedulingPlaybook) ID() string    { return "pending-pod-scheduling" }
+func (p *pendingPodSchedulingPlaybook) Title() string { return "Diagnose pending pod scheduling" }
+func (p *pendingPodSchedulingPlaybook) Description() string {
+	return "Surface why a pod is stuck Pending: scheduler events, node capacity, taints/tolerations. Diagnostic-only — the right fix (add nodes / scale HPA / relax selectors / fix PVC binding) depends on the cluster topology, so this playbook stops at the data-gathering step."
+}
+
+func (p *pendingPodSchedulingPlaybook) Plan(ctx context.Context, _ K8sClient, input PlaybookInput) (*PlaybookPlan, error) {
+	if input.Name == "" {
+		return nil, fmt.Errorf("pending-pod-scheduling: pod name is required (use the --name flag)")
+	}
+	ns := input.Namespace
+	if ns == "" {
+		ns = "default"
+	}
+	pod := input.Name
+	target := fmt.Sprintf("pod/%s@%s", pod, ns)
+
+	steps := []PlaybookStep{
+		{
+			ID:          "describe-pod",
+			Description: fmt.Sprintf("Describe %s — scheduler events go here", pod),
+			Command:     "kubectl",
+			Args:        kubectlArgs(input, "describe", "pod", pod),
+			Reason:      "The Events section will show FailedScheduling messages with the exact reason (insufficient cpu/memory, no matching node, PVC not bound, …).",
+			Risk:        "low",
+			Mutating:    false,
+		},
+		{
+			ID:          "get-nodes",
+			Description: "List nodes with their allocatable capacity",
+			Command:     "kubectl",
+			// No --namespace: nodes are cluster-scoped. We still want
+			// --context if the caller set one.
+			Args:     kubectlArgsClusterScoped(input, "get", "nodes", "-o", "wide"),
+			Reason:   "Shows which nodes exist and roughly how full they are. Empty cluster + Karpenter would show one or two nodes; full cluster + fixed pool shows everyone Ready.",
+			Risk:     "low",
+			Mutating: false,
+		},
+		{
+			ID:          "top-nodes",
+			Description: "Show per-node CPU/memory pressure",
+			Command:     "kubectl",
+			Args:        kubectlArgsClusterScoped(input, "top", "nodes"),
+			Reason:      "Confirms whether the cluster is genuinely out of capacity vs. has free room but a constraint mismatch.",
+			Risk:        "low",
+			Mutating:    false,
+		},
+		{
+			ID:          "events",
+			Description: fmt.Sprintf("Tail recent events for %s", pod),
+			Command:     "kubectl",
+			Args:        kubectlArgs(input, "get", "events", "--field-selector", "involvedObject.name="+pod, "--sort-by=.lastTimestamp"),
+			Reason:      "Picks up scheduler retries that may have surfaced different reasons over time.",
+			Risk:        "low",
+			Mutating:    false,
+		},
+	}
+
+	return &PlaybookPlan{
+		PlaybookID:  p.ID(),
+		Title:       p.Title(),
+		Target:      target,
+		Summary:     fmt.Sprintf("Gather scheduler diagnostics for %s. Read the describe + events output to identify the remediation: add node capacity, relax selectors, fix PVC binding, or scale the HPA.", target),
+		Steps:       steps,
+		GeneratedAt: time.Now().UTC(),
+		Notes: []string{
+			"This playbook is intentionally read-only. The mutation that fixes a Pending pod (scale node pool, edit tolerations, create the missing PVC) depends on the cluster topology — chain into 'clanker k8s helm install' for an HPA, 'clanker k8s apply' for a config change, or your cloud's node-pool API.",
+		},
+	}, nil
+}
+
+// kubectlArgsClusterScoped is kubectlArgs minus the namespace flag.
+// Cluster-scoped resources (nodes, PVs, ClusterRoles) reject -n.
+func kubectlArgsClusterScoped(input PlaybookInput, args ...string) []string {
+	out := make([]string, 0, len(args)+2)
+	if input.Context != "" {
+		out = append(out, "--context", input.Context)
+	}
+	out = append(out, args...)
+	return out
 }
 
 // kubectlArgs prepends '-n <ns>' / '--context <ctx>' (when set) to the

--- a/internal/k8s/sre/playbooks_test.go
+++ b/internal/k8s/sre/playbooks_test.go
@@ -2,6 +2,7 @@ package sre
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -51,6 +52,91 @@ func TestRegistry_GetUnknownIDReturnsHelpfulError(t *testing.T) {
 	// Error should list the known IDs so the CLI surface gets a hint.
 	if !strings.Contains(err.Error(), "crashloop-recovery") {
 		t.Errorf("error should list known IDs, got %q", err.Error())
+	}
+}
+
+// TestValidationErrorStrings_BackwardsCompatibleWithCloudBackend pins
+// the exact substrings the clanker-cloud backend uses to discriminate
+// 400 (client error) from 500 (execution failure). The cloud's
+// isPlaybookClientValidationError does:
+//
+//	strings.Contains(msg, "unknown playbook")  → 400
+//	strings.Contains(msg, "name is required")  → 400
+//	strings.Contains(msg, "playbookId is required") → 400
+//
+// If anyone reworks these messages (say, to "--name is required") the
+// cloud silently regresses to 500 on a user typo. This test makes the
+// contract explicit so a refactor at least sees a failing assertion
+// it can update intentionally.
+func TestValidationErrorStrings_BackwardsCompatibleWithCloudBackend(t *testing.T) {
+	r := NewPlaybookRegistry()
+	t.Run("unknown playbook id contains 'unknown playbook'", func(t *testing.T) {
+		_, err := r.Get("definitely-not-real")
+		if err == nil || !strings.Contains(err.Error(), "unknown playbook") {
+			t.Errorf("unknown-id error must contain 'unknown playbook', got %v", err)
+		}
+	})
+	t.Run("crashloop-recovery missing name contains 'name is required'", func(t *testing.T) {
+		p, _ := r.Get("crashloop-recovery")
+		_, err := p.Plan(context.Background(), &stubK8sClient{}, PlaybookInput{})
+		if err == nil || !strings.Contains(err.Error(), "name is required") {
+			t.Errorf("missing-name error must contain 'name is required', got %v", err)
+		}
+	})
+	t.Run("stuck-rollout missing name contains 'name is required'", func(t *testing.T) {
+		p, _ := r.Get("stuck-rollout")
+		_, err := p.Plan(context.Background(), &stubK8sClient{}, PlaybookInput{})
+		if err == nil || !strings.Contains(err.Error(), "name is required") {
+			t.Errorf("missing-name error must contain 'name is required', got %v", err)
+		}
+	})
+	t.Run("pending-pod-scheduling missing name contains 'name is required'", func(t *testing.T) {
+		p, _ := r.Get("pending-pod-scheduling")
+		_, err := p.Plan(context.Background(), &stubK8sClient{}, PlaybookInput{})
+		if err == nil || !strings.Contains(err.Error(), "name is required") {
+			t.Errorf("missing-name error must contain 'name is required', got %v", err)
+		}
+	})
+}
+
+// TestPlaybookPlan_JSONRoundTrip pins the wire format the cloud
+// backend depends on when it shells out to `clanker k8s fix --json`.
+// If a field's json tag changes or a non-marshallable type sneaks in,
+// the cloud's json.Unmarshal returns a confusing decode error with
+// zero context — this test catches it at the CLI test layer instead.
+func TestPlaybookPlan_JSONRoundTrip(t *testing.T) {
+	p := &crashLoopRecoveryPlaybook{}
+	plan, err := p.Plan(context.Background(), &stubK8sClient{}, PlaybookInput{
+		Name:      "my-pod",
+		Namespace: "prod",
+	})
+	if err != nil {
+		t.Fatalf("plan: %v", err)
+	}
+	raw, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got PlaybookPlan
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v\nwire: %s", err, raw)
+	}
+	if got.PlaybookID != plan.PlaybookID {
+		t.Errorf("PlaybookID lost in round-trip: got %q want %q", got.PlaybookID, plan.PlaybookID)
+	}
+	if got.Target != plan.Target {
+		t.Errorf("Target lost: got %q want %q", got.Target, plan.Target)
+	}
+	if len(got.Steps) != len(plan.Steps) {
+		t.Fatalf("Steps length lost: got %d want %d", len(got.Steps), len(plan.Steps))
+	}
+	for i := range plan.Steps {
+		if got.Steps[i].ID != plan.Steps[i].ID {
+			t.Errorf("Steps[%d].ID lost: got %q want %q", i, got.Steps[i].ID, plan.Steps[i].ID)
+		}
+		if got.Steps[i].Mutating != plan.Steps[i].Mutating {
+			t.Errorf("Steps[%d].Mutating lost: got %v want %v", i, got.Steps[i].Mutating, plan.Steps[i].Mutating)
+		}
 	}
 }
 

--- a/internal/k8s/sre/playbooks_test.go
+++ b/internal/k8s/sre/playbooks_test.go
@@ -1,0 +1,208 @@
+package sre
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// stubK8sClient satisfies sre.K8sClient for unit tests. None of the
+// built-in playbooks actually CALL the client in their Plan(...) yet
+// — they're pure functions of PlaybookInput today, with cluster-state
+// inspection deferred to future playbooks (stuck-rollout, pending-
+// pod-scheduling). Keeping the stub here so adding those is a no-op.
+type stubK8sClient struct {
+	runOutput     string
+	runErr        error
+	runJSONOutput []byte
+	runJSONErr    error
+}
+
+func (s *stubK8sClient) Run(ctx context.Context, args ...string) (string, error) {
+	return s.runOutput, s.runErr
+}
+func (s *stubK8sClient) RunWithNamespace(ctx context.Context, ns string, args ...string) (string, error) {
+	return s.runOutput, s.runErr
+}
+func (s *stubK8sClient) RunJSON(ctx context.Context, args ...string) ([]byte, error) {
+	return s.runJSONOutput, s.runJSONErr
+}
+
+// ============================================================
+// Registry
+// ============================================================
+
+func TestNewPlaybookRegistry_ContainsCrashLoopRecovery(t *testing.T) {
+	r := NewPlaybookRegistry()
+	if _, err := r.Get("crashloop-recovery"); err != nil {
+		t.Fatalf("expected crashloop-recovery to be registered: %v", err)
+	}
+}
+
+func TestRegistry_GetUnknownIDReturnsHelpfulError(t *testing.T) {
+	r := NewPlaybookRegistry()
+	_, err := r.Get("not-a-playbook")
+	if err == nil {
+		t.Fatal("expected error for unknown id")
+	}
+	if !strings.Contains(err.Error(), "unknown playbook") {
+		t.Errorf("error should mention 'unknown playbook', got %q", err.Error())
+	}
+	// Error should list the known IDs so the CLI surface gets a hint.
+	if !strings.Contains(err.Error(), "crashloop-recovery") {
+		t.Errorf("error should list known IDs, got %q", err.Error())
+	}
+}
+
+func TestRegistry_IDsAreSorted(t *testing.T) {
+	r := NewPlaybookRegistry()
+	// Register a second mock so we have 2 items to verify ordering.
+	r.Register(&mockPlaybook{id: "aaa-first"})
+	r.Register(&mockPlaybook{id: "zzz-last"})
+	ids := r.IDs()
+	for i := 1; i < len(ids); i++ {
+		if ids[i-1] > ids[i] {
+			t.Errorf("IDs not sorted: %v", ids)
+		}
+	}
+}
+
+func TestRegistry_RegisterOverwritesExisting(t *testing.T) {
+	r := NewPlaybookRegistry()
+	r.Register(&mockPlaybook{id: "crashloop-recovery", title: "MOCKED"})
+	p, err := r.Get("crashloop-recovery")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Title() != "MOCKED" {
+		t.Errorf("Register did not overwrite; got title %q", p.Title())
+	}
+}
+
+// ============================================================
+// crashLoopRecoveryPlaybook
+// ============================================================
+
+func TestCrashLoopRecovery_RequiresPodName(t *testing.T) {
+	p := &crashLoopRecoveryPlaybook{}
+	_, err := p.Plan(context.Background(), &stubK8sClient{}, PlaybookInput{Namespace: "prod"})
+	if err == nil {
+		t.Fatal("expected error when name is empty")
+	}
+	if !strings.Contains(err.Error(), "pod name is required") {
+		t.Errorf("error should mention pod name, got %q", err.Error())
+	}
+}
+
+func TestCrashLoopRecovery_EmitsThreeStepPlan(t *testing.T) {
+	p := &crashLoopRecoveryPlaybook{}
+	plan, err := p.Plan(context.Background(), &stubK8sClient{}, PlaybookInput{
+		Name:      "my-pod",
+		Namespace: "prod",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(plan.Steps) != 3 {
+		t.Fatalf("expected 3 steps, got %d", len(plan.Steps))
+	}
+	wantIDs := []string{"logs-previous", "describe", "delete-pod"}
+	for i, want := range wantIDs {
+		if plan.Steps[i].ID != want {
+			t.Errorf("step %d id = %q, want %q", i, plan.Steps[i].ID, want)
+		}
+	}
+}
+
+func TestCrashLoopRecovery_DiagnosticsStepsAreReadOnly(t *testing.T) {
+	p := &crashLoopRecoveryPlaybook{}
+	plan, _ := p.Plan(context.Background(), &stubK8sClient{}, PlaybookInput{
+		Name: "my-pod", Namespace: "prod",
+	})
+	// Steps 0+1 are logs/describe — must be non-mutating.
+	if plan.Steps[0].Mutating || plan.Steps[1].Mutating {
+		t.Errorf("logs/describe steps should be non-mutating: %v", plan.Steps[:2])
+	}
+	// Step 2 is delete-pod — mutating + requires approval.
+	if !plan.Steps[2].Mutating {
+		t.Error("delete-pod step should be mutating")
+	}
+	if !plan.Steps[2].RequiresApproval {
+		t.Error("delete-pod step should require explicit approval even in auto mode")
+	}
+}
+
+func TestCrashLoopRecovery_AppliesNamespaceAndContextToEveryStep(t *testing.T) {
+	p := &crashLoopRecoveryPlaybook{}
+	plan, _ := p.Plan(context.Background(), &stubK8sClient{}, PlaybookInput{
+		Name:      "my-pod",
+		Namespace: "prod",
+		Context:   "my-eks",
+	})
+	for i, step := range plan.Steps {
+		if !contains(step.Args, "-n") || !contains(step.Args, "prod") {
+			t.Errorf("step %d missing -n prod: %v", i, step.Args)
+		}
+		if !contains(step.Args, "--context") || !contains(step.Args, "my-eks") {
+			t.Errorf("step %d missing --context my-eks: %v", i, step.Args)
+		}
+	}
+}
+
+func TestCrashLoopRecovery_DefaultsNamespaceToDefault(t *testing.T) {
+	p := &crashLoopRecoveryPlaybook{}
+	plan, _ := p.Plan(context.Background(), &stubK8sClient{}, PlaybookInput{
+		Name: "my-pod",
+	})
+	// Target string should use 'default' as the ns.
+	if !strings.Contains(plan.Target, "@default") {
+		t.Errorf("target should default to @default ns, got %q", plan.Target)
+	}
+}
+
+func TestCrashLoopRecovery_TargetEncodesPodAndNS(t *testing.T) {
+	p := &crashLoopRecoveryPlaybook{}
+	plan, _ := p.Plan(context.Background(), &stubK8sClient{}, PlaybookInput{
+		Name: "my-pod", Namespace: "prod",
+	})
+	if plan.Target != "pod/my-pod@prod" {
+		t.Errorf("target = %q, want pod/my-pod@prod", plan.Target)
+	}
+}
+
+func TestKubectlArgs_OmitsFlagsWhenEmpty(t *testing.T) {
+	got := kubectlArgs(PlaybookInput{}, "get", "pods")
+	if contains(got, "-n") {
+		t.Errorf("empty namespace should not produce -n: %v", got)
+	}
+	if contains(got, "--context") {
+		t.Errorf("empty context should not produce --context: %v", got)
+	}
+	if !contains(got, "get") || !contains(got, "pods") {
+		t.Errorf("caller args missing from output: %v", got)
+	}
+}
+
+// ============================================================
+// helpers
+// ============================================================
+
+func contains(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+type mockPlaybook struct {
+	id, title string
+}
+
+func (m *mockPlaybook) ID() string          { return m.id }
+func (m *mockPlaybook) Title() string       { return m.title }
+func (m *mockPlaybook) Description() string { return "mock" }
+func (m *mockPlaybook) Plan(_ context.Context, _ K8sClient, _ PlaybookInput) (*PlaybookPlan, error) {
+	return &PlaybookPlan{PlaybookID: m.id, Steps: []PlaybookStep{}}, nil
+}

--- a/internal/k8s/sre/playbooks_test.go
+++ b/internal/k8s/sre/playbooks_test.go
@@ -183,6 +183,140 @@ func TestKubectlArgs_OmitsFlagsWhenEmpty(t *testing.T) {
 	}
 }
 
+func TestKubectlArgsClusterScoped_NeverEmitsNamespace(t *testing.T) {
+	got := kubectlArgsClusterScoped(PlaybookInput{Namespace: "prod", Context: "my-eks"}, "get", "nodes")
+	if contains(got, "-n") || contains(got, "prod") {
+		t.Errorf("cluster-scoped helper must not emit namespace: %v", got)
+	}
+	if !contains(got, "--context") || !contains(got, "my-eks") {
+		t.Errorf("cluster-scoped helper should still pass --context: %v", got)
+	}
+}
+
+// ============================================================
+// stuckRolloutPlaybook
+// ============================================================
+
+func TestStuckRollout_RequiresDeploymentName(t *testing.T) {
+	p := &stuckRolloutPlaybook{}
+	_, err := p.Plan(context.Background(), &stubK8sClient{}, PlaybookInput{Namespace: "prod"})
+	if err == nil {
+		t.Fatal("expected error when name is empty")
+	}
+	if !strings.Contains(err.Error(), "deployment name is required") {
+		t.Errorf("error should mention deployment name, got %q", err.Error())
+	}
+}
+
+func TestStuckRollout_EmitsCanonicalPlan(t *testing.T) {
+	p := &stuckRolloutPlaybook{}
+	plan, err := p.Plan(context.Background(), &stubK8sClient{}, PlaybookInput{
+		Name: "my-app", Namespace: "prod",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	wantIDs := []string{"rollout-status", "rollout-history", "describe", "rollout-undo"}
+	if len(plan.Steps) != len(wantIDs) {
+		t.Fatalf("expected %d steps, got %d", len(wantIDs), len(plan.Steps))
+	}
+	for i, want := range wantIDs {
+		if plan.Steps[i].ID != want {
+			t.Errorf("step %d id = %q, want %q", i, plan.Steps[i].ID, want)
+		}
+	}
+}
+
+func TestStuckRollout_OnlyUndoIsMutating(t *testing.T) {
+	p := &stuckRolloutPlaybook{}
+	plan, _ := p.Plan(context.Background(), &stubK8sClient{}, PlaybookInput{
+		Name: "my-app", Namespace: "prod",
+	})
+	for i, step := range plan.Steps {
+		isUndo := step.ID == "rollout-undo"
+		if step.Mutating != isUndo {
+			t.Errorf("step %d (%s) mutating=%v; want %v", i, step.ID, step.Mutating, isUndo)
+		}
+		if isUndo && !step.RequiresApproval {
+			t.Errorf("rollout-undo must require explicit approval")
+		}
+	}
+}
+
+func TestStuckRollout_TargetEncodesDeploymentAndNS(t *testing.T) {
+	p := &stuckRolloutPlaybook{}
+	plan, _ := p.Plan(context.Background(), &stubK8sClient{}, PlaybookInput{
+		Name: "my-app", Namespace: "prod",
+	})
+	if plan.Target != "deployment/my-app@prod" {
+		t.Errorf("target = %q, want deployment/my-app@prod", plan.Target)
+	}
+}
+
+// ============================================================
+// pendingPodSchedulingPlaybook
+// ============================================================
+
+func TestPendingPodScheduling_RequiresPodName(t *testing.T) {
+	p := &pendingPodSchedulingPlaybook{}
+	_, err := p.Plan(context.Background(), &stubK8sClient{}, PlaybookInput{Namespace: "prod"})
+	if err == nil {
+		t.Fatal("expected error when name is empty")
+	}
+}
+
+func TestPendingPodScheduling_AllStepsAreReadOnly(t *testing.T) {
+	p := &pendingPodSchedulingPlaybook{}
+	plan, err := p.Plan(context.Background(), &stubK8sClient{}, PlaybookInput{
+		Name: "my-pod", Namespace: "prod",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for i, step := range plan.Steps {
+		if step.Mutating {
+			t.Errorf("step %d (%s) is marked mutating; pending-pod-scheduling is diagnostic-only", i, step.ID)
+		}
+		if step.RequiresApproval {
+			t.Errorf("step %d (%s) requires approval; diagnostic-only playbook shouldn't", i, step.ID)
+		}
+	}
+}
+
+func TestPendingPodScheduling_GetNodesIsClusterScoped(t *testing.T) {
+	p := &pendingPodSchedulingPlaybook{}
+	plan, _ := p.Plan(context.Background(), &stubK8sClient{}, PlaybookInput{
+		Name: "my-pod", Namespace: "prod", Context: "my-eks",
+	})
+	var nodeStep *PlaybookStep
+	for i := range plan.Steps {
+		if plan.Steps[i].ID == "get-nodes" {
+			nodeStep = &plan.Steps[i]
+			break
+		}
+	}
+	if nodeStep == nil {
+		t.Fatal("get-nodes step missing from plan")
+	}
+	// Nodes are cluster-scoped → no -n flag.
+	if contains(nodeStep.Args, "-n") || contains(nodeStep.Args, "prod") {
+		t.Errorf("get-nodes must not emit -n: %v", nodeStep.Args)
+	}
+	// Context still propagates.
+	if !contains(nodeStep.Args, "--context") || !contains(nodeStep.Args, "my-eks") {
+		t.Errorf("get-nodes should pass --context: %v", nodeStep.Args)
+	}
+}
+
+func TestRegistry_ContainsAllThreePlaybooks(t *testing.T) {
+	r := NewPlaybookRegistry()
+	for _, id := range []string{"crashloop-recovery", "stuck-rollout", "pending-pod-scheduling"} {
+		if _, err := r.Get(id); err != nil {
+			t.Errorf("playbook %q not registered: %v", id, err)
+		}
+	}
+}
+
 // ============================================================
 // helpers
 // ============================================================


### PR DESCRIPTION
## Summary
First slice of Phase 4 (agentic remediation playbooks). Lays the playbook framework on the CLI so the upcoming backend SSE handler (4c) and frontend runner UI (4e) have a concrete shape to wrap.

## Library surface (\`internal/k8s/sre/playbooks.go\`)
- \`Playbook\` interface: \`ID\` / \`Title\` / \`Description\` / \`Plan(ctx, client, input)\`. Plan is a pure function of (k8s state, input) → ordered steps — no execution side-effect.
- \`PlaybookStep\` carries the kubectl/helm/clanker argv plus \`risk\` / \`mutating\` / \`RequiresApproval\` metadata so the runner can prompt per step.
- \`PlaybookPlan\` wraps the ordered steps with a \`Summary\` + \`Notes\` for the UI to render verbatim.
- \`PlaybookRegistry\`: map-backed, pre-populated with built-ins. \`Register()\` overwrites by ID so tests can mock.

## First playbook
**\`crashloop-recovery\`** — three steps:
1. \`logs --previous --tail=200\` (read-only)
2. \`describe pod\` (read-only)
3. \`delete pod\` (mutating, forces approval even in \`auto\` mode)

The plan deliberately stops at the delete; chaining into \`stuck-rollout\` is a separate playbook landing in 4b.

## CLI surface (\`cmd/k8s_fix.go\`)
\`\`\`
clanker k8s fix                                    # list registered playbooks
clanker k8s fix crashloop-recovery --name my-pod -n prod
clanker k8s fix crashloop-recovery ... --approve plan-only
clanker k8s fix crashloop-recovery ... --approve auto    # skip prompts except for forced ones
clanker k8s fix crashloop-recovery ... --json            # emit plan as JSON (implies plan-only)
\`\`\`

Approval modes: \`step\` (default) prompts per step, \`auto\` only prompts on \`RequiresApproval\` steps, \`plan-only\` prints and exits.

## Smoke test
\`\`\`
$ clanker k8s fix
Available playbooks:
ID                  TITLE                      DESCRIPTION
crashloop-recovery  CrashLoopBackOff recovery  Capture previous-container logs + events, then delete the crashing pod ...

$ clanker k8s fix crashloop-recovery --name my-pod -n prod --approve plan-only
Playbook: CrashLoopBackOff recovery
Target:   pod/my-pod@prod
Steps (3):
  1. •  Capture last 200 lines from the previous my-pod container
       run:    kubectl -n prod logs my-pod --previous --tail=200
  2. •  Describe my-pod for events + container statuses
       run:    kubectl -n prod describe pod my-pod
  3. ✎  Delete my-pod so its controller recreates a fresh pod
       run:    kubectl -n prod delete pod my-pod
       (requires explicit approval even in auto mode)
\`\`\`

## Test plan
15 new tests across \`internal/k8s/sre\` + \`cmd\`:
- [x] Registry: contains built-in, unknown-ID error lists known IDs, IDs sorted alphabetically, Register overwrites by ID
- [x] CrashLoopRecovery: requires pod name, emits 3 steps in canonical order, diagnostic steps non-mutating, delete-pod mutating + forced-approval, namespace + context flow into every step, default namespace, target string shape
- [x] \`kubectlArgs\` helper: omits empty flags
- [x] CLI: wiring + flag presence, registered on \`k8sCmd\` root, list table rendering shape

\`go build ./...\` / \`go vet ./...\` / \`go test ./...\` all green.

## Follow-up slices
- **4b** — \`pending-pod-scheduling\`, \`stuck-rollout\`, \`resource-exhaustion\` playbooks
- **4c** — backend \`POST /api/k8s/playbook/run\` (SSE per step)
- **4d** — backend \`POST /api/k8s/playbook/approve\` for step-mode approval
- **4e** — frontend \`K8sPlaybookRunner\` modal + 'Auto-fix' buttons on the health audit