### PR TITLE
fix(security): tighten conversation-history file perms to 0600

### DIFF
--- a/internal/cloudflare/conversation.go
+++ b/internal/cloudflare/conversation.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/bgdnvk/clanker/internal/secfile"
 )
 
 // ConversationEntry represents a single Q&A exchange
@@ -151,7 +153,7 @@ func (h *ConversationHistory) Save() error {
 		return err
 	}
 
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := secfile.EnsurePrivateDir(dir); err != nil {
 		return fmt.Errorf("failed to create conversation directory: %w", err)
 	}
 
@@ -161,7 +163,7 @@ func (h *ConversationHistory) Save() error {
 		return fmt.Errorf("failed to marshal conversation history: %w", err)
 	}
 
-	if err := os.WriteFile(filename, data, 0644); err != nil {
+	if err := secfile.WritePrivate(filename, data); err != nil {
 		return fmt.Errorf("failed to write conversation file: %w", err)
 	}
 
@@ -179,7 +181,7 @@ func (h *ConversationHistory) Load() error {
 	}
 
 	filename := filepath.Join(dir, fmt.Sprintf("cloudflare_%s.json", sanitizeFilename(h.AccountID)))
-	data, err := os.ReadFile(filename)
+	data, err := secfile.ReadPrivate(filename)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// No history yet, that is fine

--- a/internal/flyio/conversation.go
+++ b/internal/flyio/conversation.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/bgdnvk/clanker/internal/secfile"
 )
 
 // ConversationEntry represents a single Q&A exchange.
@@ -99,7 +101,7 @@ func (h *ConversationHistory) Save() error {
 		return err
 	}
 
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := secfile.EnsurePrivateDir(dir); err != nil {
 		return fmt.Errorf("failed to create conversation directory: %w", err)
 	}
 
@@ -118,7 +120,7 @@ func (h *ConversationHistory) Save() error {
 	}
 
 	tmp := filename + ".tmp"
-	if err := os.WriteFile(tmp, data, 0644); err != nil {
+	if err := secfile.WritePrivate(tmp, data); err != nil {
 		return fmt.Errorf("failed to write temp conversation file: %w", err)
 	}
 	if err := os.Rename(tmp, filename); err != nil {
@@ -138,7 +140,7 @@ func (h *ConversationHistory) Load() error {
 	if err != nil {
 		return err
 	}
-	data, err := os.ReadFile(path)
+	data, err := secfile.ReadPrivate(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil

--- a/internal/flyio/conversation_test.go
+++ b/internal/flyio/conversation_test.go
@@ -3,6 +3,7 @@ package flyio
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -58,8 +59,24 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 
 	// File should land at ~/.clanker/conversations/flyio_acme.json.
 	want := filepath.Join(dir, ".clanker", "conversations", "flyio_acme.json")
-	if _, err := os.Stat(want); err != nil {
+	info, err := os.Stat(want)
+	if err != nil {
 		t.Fatalf("expected file %s: %v", want, err)
+	}
+	if runtime.GOOS != "windows" {
+		// Saved files must not be world-readable — they contain raw
+		// operator Q&A (account IDs, ARNs, policy fragments). Drift
+		// guard for #22.
+		if mode := info.Mode().Perm(); mode != 0o600 {
+			t.Errorf("file mode = %04o, want 0600", mode)
+		}
+		convDir, err := os.Stat(filepath.Dir(want))
+		if err != nil {
+			t.Fatalf("stat conv dir: %v", err)
+		}
+		if mode := convDir.Mode().Perm(); mode != 0o700 {
+			t.Errorf("conversations dir mode = %04o, want 0700", mode)
+		}
 	}
 
 	loaded := NewConversationHistory("acme")

--- a/internal/iam/conversation.go
+++ b/internal/iam/conversation.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/bgdnvk/clanker/internal/secfile"
 )
 
 // ConversationEntry represents a single Q&A exchange
@@ -146,7 +148,7 @@ func (h *ConversationHistory) Save() error {
 		return err
 	}
 
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := secfile.EnsurePrivateDir(dir); err != nil {
 		return fmt.Errorf("failed to create conversation directory: %w", err)
 	}
 
@@ -156,7 +158,7 @@ func (h *ConversationHistory) Save() error {
 		return fmt.Errorf("failed to marshal conversation history: %w", err)
 	}
 
-	if err := os.WriteFile(filename, data, 0644); err != nil {
+	if err := secfile.WritePrivate(filename, data); err != nil {
 		return fmt.Errorf("failed to write conversation file: %w", err)
 	}
 
@@ -174,7 +176,7 @@ func (h *ConversationHistory) Load() error {
 	}
 
 	filename := filepath.Join(dir, fmt.Sprintf("iam_%s.json", sanitizeFilename(h.AccountID)))
-	data, err := os.ReadFile(filename)
+	data, err := secfile.ReadPrivate(filename)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// No history yet, that is fine

--- a/internal/k8s/conversation.go
+++ b/internal/k8s/conversation.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/bgdnvk/clanker/internal/secfile"
 )
 
 // ConversationEntry represents a single Q&A exchange
@@ -177,7 +179,7 @@ func (h *ConversationHistory) Save() error {
 		return err
 	}
 
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := secfile.EnsurePrivateDir(dir); err != nil {
 		return fmt.Errorf("failed to create conversation directory: %w", err)
 	}
 
@@ -187,7 +189,7 @@ func (h *ConversationHistory) Save() error {
 		return fmt.Errorf("failed to marshal conversation history: %w", err)
 	}
 
-	if err := os.WriteFile(filename, data, 0644); err != nil {
+	if err := secfile.WritePrivate(filename, data); err != nil {
 		return fmt.Errorf("failed to write conversation file: %w", err)
 	}
 
@@ -205,7 +207,7 @@ func (h *ConversationHistory) Load() error {
 	}
 
 	filename := filepath.Join(dir, fmt.Sprintf("k8s_%s.json", sanitizeFilename(h.ClusterName)))
-	data, err := os.ReadFile(filename)
+	data, err := secfile.ReadPrivate(filename)
 	if err != nil {
 		if os.IsNotExist(err) {
 			// No history yet, that is fine

--- a/internal/linear/conversation.go
+++ b/internal/linear/conversation.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/bgdnvk/clanker/internal/secfile"
 )
 
 // ConversationEntry is a single Q&A turn against the Linear ask agent.
@@ -129,7 +131,7 @@ func historyPath(workspaceID string) (string, error) {
 		return "", err
 	}
 	dir := filepath.Join(home, ".clanker")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := secfile.EnsurePrivateDir(dir); err != nil {
 		return "", err
 	}
 	return filepath.Join(dir, fmt.Sprintf("linear-%s.json", safeSlug(workspaceID))), nil
@@ -140,7 +142,7 @@ func (h *ConversationHistory) Load() error {
 	if err != nil {
 		return err
 	}
-	data, err := os.ReadFile(path)
+	data, err := secfile.ReadPrivate(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -163,5 +165,5 @@ func (h *ConversationHistory) Save() error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0o600)
+	return secfile.WritePrivate(path, data)
 }

--- a/internal/notion/conversation.go
+++ b/internal/notion/conversation.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/bgdnvk/clanker/internal/secfile"
 )
 
 const (
@@ -128,7 +130,7 @@ func historyPath(workspaceName string) (string, error) {
 		return "", err
 	}
 	dir := filepath.Join(home, ".clanker")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := secfile.EnsurePrivateDir(dir); err != nil {
 		return "", err
 	}
 	return filepath.Join(dir, fmt.Sprintf("notion-%s.json", safeSlug(workspaceName))), nil
@@ -139,7 +141,7 @@ func (h *ConversationHistory) Load() error {
 	if err != nil {
 		return err
 	}
-	data, err := os.ReadFile(path)
+	data, err := secfile.ReadPrivate(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -162,5 +164,5 @@ func (h *ConversationHistory) Save() error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0o600)
+	return secfile.WritePrivate(path, data)
 }

--- a/internal/railway/conversation.go
+++ b/internal/railway/conversation.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/bgdnvk/clanker/internal/secfile"
 )
 
 // ConversationEntry represents a single Q&A exchange.
@@ -112,7 +114,7 @@ func (h *ConversationHistory) Save() error {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := secfile.EnsurePrivateDir(dir); err != nil {
 		return fmt.Errorf("failed to create conversation directory: %w", err)
 	}
 
@@ -120,7 +122,7 @@ func (h *ConversationHistory) Save() error {
 
 	// Atomic write: temp + rename.
 	tmp := filename + ".tmp"
-	if err := os.WriteFile(tmp, data, 0644); err != nil {
+	if err := secfile.WritePrivate(tmp, data); err != nil {
 		return fmt.Errorf("failed to write temp conversation file: %w", err)
 	}
 	if err := os.Rename(tmp, filename); err != nil {
@@ -140,7 +142,7 @@ func (h *ConversationHistory) Load() error {
 	if err != nil {
 		return err
 	}
-	data, err := os.ReadFile(path)
+	data, err := secfile.ReadPrivate(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil

--- a/internal/secfile/drift_test.go
+++ b/internal/secfile/drift_test.go
@@ -1,0 +1,93 @@
+package secfile_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestConversationFilesDoNotWriteWorldReadable walks every
+// internal/<provider>/conversation.go file and fails the build if any
+// of them call os.WriteFile / os.MkdirAll with a loose Unix mode
+// literal, or call os.ReadFile (which bypasses the chmod-on-load
+// repair). The intent is to lock in #22 so a tenth provider can't
+// reintroduce the leak by copy-pasting the historic pattern.
+func TestConversationFilesDoNotWriteWorldReadable(t *testing.T) {
+	root, err := repoRoot()
+	if err != nil {
+		t.Fatalf("locate repo root: %v", err)
+	}
+
+	var files []string
+	if err := filepath.WalkDir(filepath.Join(root, "internal"), func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if filepath.Base(path) == "conversation.go" {
+			files = append(files, path)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+
+	if len(files) < 9 {
+		t.Fatalf("expected >= 9 conversation.go files (one per provider); found %d. Did the layout change?", len(files))
+	}
+
+	fset := token.NewFileSet()
+	for _, path := range files {
+		t.Run(relpath(root, path), func(t *testing.T) {
+			file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+			if err != nil {
+				t.Fatalf("parse %s: %v", path, err)
+			}
+
+			ast.Inspect(file, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok {
+					return true
+				}
+				pkg, ok := sel.X.(*ast.Ident)
+				if !ok || pkg.Name != "os" {
+					return true
+				}
+				switch sel.Sel.Name {
+				case "WriteFile", "ReadFile":
+					t.Errorf("%s uses os.%s directly — must go through secfile.WritePrivate/ReadPrivate (drift guard for #22)", fset.Position(call.Pos()), sel.Sel.Name)
+				case "MkdirAll":
+					t.Errorf("%s uses os.MkdirAll directly — must go through secfile.EnsurePrivateDir (drift guard for #22)", fset.Position(call.Pos()))
+				}
+				return true
+			})
+		})
+	}
+}
+
+func repoRoot() (string, error) {
+	// internal/secfile/drift_test.go → ../..
+	abs, err := filepath.Abs(".")
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(filepath.Join(abs, "..", "..")), nil
+}
+
+func relpath(root, p string) string {
+	rel, err := filepath.Rel(root, p)
+	if err != nil {
+		return p
+	}
+	return strings.ReplaceAll(rel, string(filepath.Separator), "/")
+}

--- a/internal/secfile/secfile.go
+++ b/internal/secfile/secfile.go
@@ -1,0 +1,74 @@
+// Package secfile holds small file-permission primitives used by the
+// nine provider conversation-history modules. It exists to keep the
+// hardening from drifting again (issue #22): every history-file Save
+// goes through WritePrivate and every Load goes through ReadPrivate,
+// so adding a tenth provider can't reintroduce world-readable Q&A.
+//
+// This is a security primitive (file modes + Chmod-repair), not a
+// conversation-history abstraction. The larger refactor — extracting
+// shared Load/Save logic across providers — is tracked in #25.
+package secfile
+
+import (
+	"io"
+	"os"
+	"runtime"
+)
+
+// PrivateDirMode and PrivateFileMode are the modes we want every
+// history file and its parent directory to end up at. 0o700 / 0o600
+// keeps conversation contents out of non-owner reach on shared boxes
+// (CI runners, EC2 bastions, multi-UID containers).
+const (
+	PrivateDirMode  os.FileMode = 0o700
+	PrivateFileMode os.FileMode = 0o600
+)
+
+// EnsurePrivateDir creates dir (and parents) with 0o700, then Chmods
+// it to 0o700 in case it already existed with looser perms. Chmod is
+// a no-op on Windows; safe to call on every Save.
+func EnsurePrivateDir(dir string) error {
+	if err := os.MkdirAll(dir, PrivateDirMode); err != nil {
+		return err
+	}
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	return os.Chmod(dir, PrivateDirMode)
+}
+
+// WritePrivate writes data to path with 0o600. If the file already
+// exists with looser perms (pre-fix users), WriteFile does NOT
+// re-apply the mode — so we Chmod afterwards as a belt-and-braces
+// repair. Chmod is a no-op on Windows.
+func WritePrivate(path string, data []byte) error {
+	if err := os.WriteFile(path, data, PrivateFileMode); err != nil {
+		return err
+	}
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+	// Idempotent: if WriteFile honored the mode (file is new), this
+	// is a no-op. If the file pre-existed with 0o644, this tightens it.
+	return os.Chmod(path, PrivateFileMode)
+}
+
+// ReadPrivate opens path read-only, repairs its perms via the file
+// descriptor (NOT the path — avoids TOCTOU where a local attacker
+// could rename or symlink between read and chmod), then reads it
+// all. Returns the file contents.
+func ReadPrivate(path string) ([]byte, error) {
+	f, err := os.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	if runtime.GOOS != "windows" {
+		// Best-effort: ignore EPERM (read-only FS, NFS without chmod).
+		// We still want the read to succeed so the user isn't blocked.
+		_ = f.Chmod(PrivateFileMode)
+	}
+
+	return io.ReadAll(f)
+}

--- a/internal/secfile/secfile_test.go
+++ b/internal/secfile/secfile_test.go
@@ -1,0 +1,118 @@
+package secfile
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestEnsurePrivateDir_CreatesAt0700(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mode bits not meaningful on Windows")
+	}
+	dir := filepath.Join(t.TempDir(), "fresh", "nested")
+	if err := EnsurePrivateDir(dir); err != nil {
+		t.Fatalf("EnsurePrivateDir: %v", err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != PrivateDirMode {
+		t.Errorf("dir mode = %04o, want %04o", got, PrivateDirMode)
+	}
+}
+
+func TestEnsurePrivateDir_TightensExistingLooseDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mode bits not meaningful on Windows")
+	}
+	dir := filepath.Join(t.TempDir(), "loose")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := EnsurePrivateDir(dir); err != nil {
+		t.Fatalf("EnsurePrivateDir: %v", err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != PrivateDirMode {
+		t.Errorf("existing-loose dir mode = %04o, want %04o", got, PrivateDirMode)
+	}
+}
+
+func TestWritePrivate_NewFileIs0600(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mode bits not meaningful on Windows")
+	}
+	path := filepath.Join(t.TempDir(), "history.json")
+	if err := WritePrivate(path, []byte(`{"hi":1}`)); err != nil {
+		t.Fatalf("WritePrivate: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != PrivateFileMode {
+		t.Errorf("new-file mode = %04o, want %04o", got, PrivateFileMode)
+	}
+}
+
+func TestWritePrivate_TightensExistingLooseFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mode bits not meaningful on Windows")
+	}
+	path := filepath.Join(t.TempDir(), "history.json")
+	if err := os.WriteFile(path, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := WritePrivate(path, []byte("new")); err != nil {
+		t.Fatalf("WritePrivate: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != PrivateFileMode {
+		t.Errorf("overwritten-file mode = %04o, want %04o", got, PrivateFileMode)
+	}
+}
+
+func TestReadPrivate_RepairsLoosePerms(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mode bits not meaningful on Windows")
+	}
+	path := filepath.Join(t.TempDir(), "history.json")
+	want := []byte(`{"entries":[]}`)
+	if err := os.WriteFile(path, want, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadPrivate(path)
+	if err != nil {
+		t.Fatalf("ReadPrivate: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("contents = %q, want %q", got, want)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode := info.Mode().Perm(); mode != PrivateFileMode {
+		t.Errorf("post-read mode = %04o, want %04o (chmod-on-load did not run)", mode, PrivateFileMode)
+	}
+}
+
+func TestReadPrivate_MissingFile(t *testing.T) {
+	_, err := ReadPrivate(filepath.Join(t.TempDir(), "nope.json"))
+	if err == nil {
+		t.Fatal("expected error reading missing file")
+	}
+	if !os.IsNotExist(err) {
+		t.Errorf("expected IsNotExist, got: %v", err)
+	}
+}

--- a/internal/sentry/conversation.go
+++ b/internal/sentry/conversation.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/bgdnvk/clanker/internal/secfile"
 )
 
 // ConversationEntry is a single Q&A turn against the Sentry ask agent.
@@ -134,7 +136,7 @@ func historyPath(orgSlug string) (string, error) {
 		return "", err
 	}
 	dir := filepath.Join(home, ".clanker")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := secfile.EnsurePrivateDir(dir); err != nil {
 		return "", err
 	}
 	return filepath.Join(dir, fmt.Sprintf("sentry-%s.json", safeSlug(orgSlug))), nil
@@ -145,7 +147,7 @@ func (h *ConversationHistory) Load() error {
 	if err != nil {
 		return err
 	}
-	data, err := os.ReadFile(path)
+	data, err := secfile.ReadPrivate(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -168,5 +170,5 @@ func (h *ConversationHistory) Save() error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0o600)
+	return secfile.WritePrivate(path, data)
 }

--- a/internal/vercel/conversation.go
+++ b/internal/vercel/conversation.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/bgdnvk/clanker/internal/secfile"
 )
 
 // ConversationEntry represents a single Q&A exchange.
@@ -93,7 +95,7 @@ func (h *ConversationHistory) Save() error {
 		return err
 	}
 
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := secfile.EnsurePrivateDir(dir); err != nil {
 		return fmt.Errorf("failed to create conversation directory: %w", err)
 	}
 
@@ -114,7 +116,7 @@ func (h *ConversationHistory) Save() error {
 
 	// Atomic write: write to temp file first, then rename.
 	tmp := filename + ".tmp"
-	if err := os.WriteFile(tmp, data, 0644); err != nil {
+	if err := secfile.WritePrivate(tmp, data); err != nil {
 		return fmt.Errorf("failed to write temp conversation file: %w", err)
 	}
 	if err := os.Rename(tmp, filename); err != nil {
@@ -135,7 +137,7 @@ func (h *ConversationHistory) Load() error {
 	if err != nil {
 		return err
 	}
-	data, err := os.ReadFile(path)
+	data, err := secfile.ReadPrivate(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil // No history yet — that is fine.

--- a/internal/verda/conversation.go
+++ b/internal/verda/conversation.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/bgdnvk/clanker/internal/secfile"
 )
 
 // fileLocks serializes Save+Load per ScopeID so two concurrent
@@ -127,11 +129,13 @@ func (h *ConversationHistory) Save() error {
 	if err != nil {
 		return err
 	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := secfile.EnsurePrivateDir(dir); err != nil {
 		return fmt.Errorf("create conversation dir: %w", err)
 	}
 
 	path := filepath.Join(dir, fmt.Sprintf("verda_%s.json", scopeName))
+	// os.CreateTemp creates files at 0o600 on Unix by default — Rename
+	// below preserves that, so the persisted file ends up private.
 	tmp, err := os.CreateTemp(dir, "verda_*.json.tmp")
 	if err != nil {
 		return fmt.Errorf("create tmp: %w", err)
@@ -172,7 +176,7 @@ func (h *ConversationHistory) Load() error {
 		return err
 	}
 	path := filepath.Join(dir, fmt.Sprintf("verda_%s.json", scopeName))
-	data, err := os.ReadFile(path)
+	data, err := secfile.ReadPrivate(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil


### PR DESCRIPTION
## Summary

Six of the ten provider conversation-history modules were writing the Q&A log world-readable (`0644`). The files routinely contain account IDs, ARNs, IPs, role names, and — for `iam` — entire policy fragments copied verbatim into the LLM answer.

### Approach

- New \`internal/secfile\` package with three primitives:
  - \`EnsurePrivateDir(dir)\` — \`MkdirAll 0o700\` then \`Chmod 0o700\` (idempotent tighten of pre-existing loose dirs)
  - \`WritePrivate(path, data)\` — \`WriteFile 0o600\` then \`Chmod 0o600\` (defends against \`WriteFile\` not re-applying mode when the file pre-exists)
  - \`ReadPrivate(path)\` — open → **fd-based** \`Chmod\` → \`ReadAll\` (no TOCTOU window between read and repair)
- All ten conversation modules routed through \`secfile\` — chmod-on-load auto-repairs files installed by older 0644 binaries, so users don't need to \`chmod\` anything manually.
- AST-based **drift guard** (\`internal/secfile/drift_test.go\`): walks the repo, finds every \`conversation.go\`, and fails the build if any of them calls \`os.WriteFile\` / \`os.ReadFile\` / \`os.MkdirAll\` directly. The test caught one provider missed by the original audit — \`internal/verda/conversation.go\` — which is now also patched.
- End-to-end assertion in \`internal/flyio/conversation_test.go::TestSaveLoadRoundTrip\` that the on-disk file mode is \`0600\` and dir is \`0700\`.

### Files touched

| File | Was | Now |
|---|---|---|
| \`internal/cloudflare/conversation.go\` | 0644 | secfile |
| \`internal/k8s/conversation.go\` | 0644 | secfile |
| \`internal/iam/conversation.go\` | 0644 | secfile |
| \`internal/flyio/conversation.go\` | 0644 | secfile |
| \`internal/railway/conversation.go\` | 0644 | secfile |
| \`internal/vercel/conversation.go\` | 0644 | secfile |
| \`internal/sentry/conversation.go\` | 0o600 / 0o755 dir | secfile |
| \`internal/linear/conversation.go\` | 0o600 / 0o755 dir | secfile |
| \`internal/notion/conversation.go\` | 0o600 / 0o755 dir | secfile |
| \`internal/verda/conversation.go\` | 0o755 dir, read-only | secfile |

### Notes for reviewers

- **Windows**: \`Chmod\` is short-circuited via \`runtime.GOOS == "windows"\` because Unix mode bits aren't meaningful there. Default ACLs already create owner-only.
- **Out of scope**: \`internal/convhistory\` extraction (#25) and the path-traversal in \`sanitizeFilename\` (#23). Both are intentionally deferred so this hotfix stays narrow.
- **Sibling bug**: \`clanker-cloud\`'s \`backend/internal/{vercel,flyio,railway}/conversation.go\` are copy-paste duplicates that also write \`0644\` — will file a separate issue against that repo after this lands.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test -race -count=1 ./...\` — all packages pass
- [x] \`secfile\` unit tests: new file is 0600, existing loose file tightened to 0600, dir tightened to 0700, ReadPrivate repairs perms
- [x] \`flyio\` round-trip test: end-to-end file-on-disk is 0600, dir is 0700
- [x] Drift test fails the build if any \`conversation.go\` regresses to \`os.WriteFile\` / \`os.ReadFile\` / \`os.MkdirAll\`

Closes #22