### PR TITLE
feat: add Terraform adoption analysis

### DIFF
--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -1,8 +1,13 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"sort"
+	"strings"
 
+	tfclient "github.com/bgdnvk/clanker/internal/terraform"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -65,7 +70,148 @@ var terraformListCmd = &cobra.Command{
 	},
 }
 
+var terraformAnalyzeCmd = &cobra.Command{
+	Use:   "analyze [workspace-or-path]",
+	Short: "Analyze Terraform/OpenTofu state, drift, and IaC alternatives",
+	Long: `Analyze a Terraform or OpenTofu workspace.
+
+By default this scans local configuration/state metadata only. Add --drift to run
+a refresh-only drift check, or --plan to run a normal detailed-exitcode plan.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		workspace, _ := cmd.Flags().GetString("workspace")
+		if len(args) > 0 {
+			workspace = args[0]
+		}
+		tool, _ := cmd.Flags().GetString("tool")
+		format, _ := cmd.Flags().GetString("format")
+		checkDrift, _ := cmd.Flags().GetBool("drift")
+		includePlan, _ := cmd.Flags().GetBool("plan")
+		maxLines, _ := cmd.Flags().GetInt("max-lines")
+
+		client, err := tfclient.NewClientWithTool(workspace, tool)
+		if err != nil {
+			return err
+		}
+		report, err := client.Analyze(cmd.Context(), tfclient.AnalysisOptions{
+			Tool:           tool,
+			CheckDrift:     checkDrift,
+			IncludePlan:    includePlan,
+			MaxOutputLines: maxLines,
+		})
+		if err != nil {
+			return err
+		}
+
+		if strings.EqualFold(format, "json") {
+			encoder := json.NewEncoder(os.Stdout)
+			encoder.SetIndent("", "  ")
+			return encoder.Encode(report)
+		}
+		fmt.Print(formatTerraformAnalysis(report))
+		return nil
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(terraformCmd)
-	terraformCmd.AddCommand(terraformListCmd)
+	terraformCmd.AddCommand(terraformListCmd, terraformAnalyzeCmd)
+	terraformAnalyzeCmd.Flags().String("workspace", "", "Configured workspace name or local path")
+	terraformAnalyzeCmd.Flags().String("tool", "", "IaC binary to use: terraform or tofu (default auto-detect)")
+	terraformAnalyzeCmd.Flags().Bool("drift", false, "Run refresh-only drift detection with detailed exit codes")
+	terraformAnalyzeCmd.Flags().Bool("plan", false, "Run a normal speculative plan with detailed exit codes")
+	terraformAnalyzeCmd.Flags().Int("max-lines", 80, "Maximum command output lines to include")
+	terraformAnalyzeCmd.Flags().String("format", "text", "Output format: text or json")
+}
+
+func formatTerraformAnalysis(report tfclient.AnalysisReport) string {
+	var out strings.Builder
+	out.WriteString("Terraform analysis\n")
+	out.WriteString(fmt.Sprintf("Workspace: %s\n", fallbackText(report.Workspace, "local")))
+	out.WriteString(fmt.Sprintf("Path: %s\n", report.Path))
+	out.WriteString(fmt.Sprintf("Tool: %s", report.Tool))
+	if report.ToolPath != "" {
+		out.WriteString(fmt.Sprintf(" (%s)", report.ToolPath))
+	}
+	out.WriteString("\n")
+	out.WriteString(fmt.Sprintf("Mode: %s\n", fallbackText(report.Mode, "unknown")))
+	out.WriteString(fmt.Sprintf("Files: %d\n", len(report.Files)))
+	if len(report.Backends) > 0 {
+		out.WriteString(fmt.Sprintf("Backends: %s\n", strings.Join(report.Backends, ", ")))
+	}
+	if len(report.ProviderSources) > 0 {
+		out.WriteString(fmt.Sprintf("Providers: %s\n", strings.Join(report.ProviderSources, ", ")))
+	}
+	if len(report.Modules) > 0 {
+		out.WriteString(fmt.Sprintf("Modules: %s\n", strings.Join(report.Modules, ", ")))
+	}
+	if report.State != nil {
+		out.WriteString(fmt.Sprintf("State resources: %d\n", report.State.ResourceCount))
+		if len(report.State.ResourceTypes) > 0 {
+			out.WriteString("Resource types:\n")
+			for _, line := range sortedCountLines(report.State.ResourceTypes) {
+				out.WriteString("  " + line + "\n")
+			}
+		}
+	}
+	if len(report.StaleArtifacts) > 0 {
+		out.WriteString("\nStale artifacts:\n")
+		for _, artifact := range report.StaleArtifacts {
+			out.WriteString(fmt.Sprintf("- %s (%s, age %s): %s\n", artifact.Path, artifact.Kind, artifact.Age, artifact.Recommendation))
+		}
+	}
+	if report.Drift != nil {
+		out.WriteString("\nDrift/plan:\n")
+		out.WriteString(fmt.Sprintf("Command: %s\n", report.Drift.Command))
+		out.WriteString(fmt.Sprintf("Exit code: %d\n", report.Drift.ExitCode))
+		out.WriteString(fmt.Sprintf("Changes present: %v\n", report.Drift.HasChanges))
+		for _, line := range report.Drift.Summary {
+			out.WriteString("  " + line + "\n")
+		}
+		if report.Drift.Error != "" {
+			out.WriteString("Error: " + report.Drift.Error + "\n")
+		}
+	} else {
+		out.WriteString("\nDrift/plan: not checked (use --drift or --plan)\n")
+	}
+	if len(report.Alternatives) > 0 {
+		out.WriteString("\nIaC alternatives:\n")
+		for _, alt := range report.Alternatives {
+			status := "not detected"
+			if alt.Detected {
+				status = "detected"
+			}
+			out.WriteString(fmt.Sprintf("- %s: %s; %s; drift/diff: %s (%s)\n", alt.Name, status, alt.Category, fallbackText(alt.DriftCommand, "n/a"), alt.DocsURL))
+		}
+	}
+	if len(report.Warnings) > 0 {
+		out.WriteString("\nWarnings:\n")
+		for _, warning := range report.Warnings {
+			out.WriteString("- " + warning + "\n")
+		}
+	}
+	if len(report.Recommendations) > 0 {
+		out.WriteString("\nRecommendations:\n")
+		for _, recommendation := range report.Recommendations {
+			out.WriteString("- " + recommendation + "\n")
+		}
+	}
+	return out.String()
+}
+
+func sortedCountLines(values map[string]int) []string {
+	lines := make([]string, 0, len(values))
+	for key, count := range values {
+		lines = append(lines, fmt.Sprintf("%s: %d", key, count))
+	}
+	sort.Strings(lines)
+	return lines
+}
+
+func fallbackText(value string, fallback string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback
+	}
+	return value
 }

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -152,9 +152,11 @@ func InferContext(question string) ServiceContext {
 
 	terraformKeywords := []string{
 		// Core
-		"terraform", "tf ", "hcl", "plan", "apply", "destroy", "init",
+		"terraform", "opentofu", "open tofu", "tofu", "tf ", "hcl", "plan", "apply", "destroy", "init",
 		"workspace", "state", "backend", "provider", "resource", "data",
 		"module", "variable", "output", "local",
+		// Terraform alternatives
+		"pulumi", "crossplane", "cloudformation", "aws cdk", "cdktf", "bicep", "infrastructure manager",
 		// Operations
 		"infrastructure-as-code", "iac", "provisioning", "deployment",
 		"environment", "stack", "configuration", "template",

--- a/internal/sre/sre.go
+++ b/internal/sre/sre.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	tfclient "github.com/bgdnvk/clanker/internal/terraform"
 	"github.com/spf13/viper"
 )
 
@@ -107,7 +108,7 @@ type RunOptions struct {
 func Discover(ctx context.Context) Discovery {
 	_ = ctx
 	hostname, _ := os.Hostname()
-	tools := detectTools([]string{"docker", "kubectl", "helm", "otelcol", "otelcol-contrib", "prometheus", "loki", "aws", "gcloud", "az", "doctl", "hcloud", "vercel", "railway", "verda", "terraform", "git"})
+	tools := detectTools([]string{"docker", "kubectl", "helm", "otelcol", "otelcol-contrib", "prometheus", "loki", "aws", "gcloud", "az", "doctl", "hcloud", "vercel", "railway", "verda", "terraform", "tofu", "pulumi", "cdk", "crossplane", "git"})
 	toolMap := make(map[string]ToolStatus, len(tools))
 	for _, tool := range tools {
 		toolMap[tool.Name] = tool
@@ -509,8 +510,24 @@ func CollectObservations(ctx context.Context, discovery Discovery) map[string]an
 		terraform := map[string]any{
 			"signals": discovery.Terraform.Signals,
 		}
-		if output, err := runCommandOutput(ctx, 1500*time.Millisecond, "terraform", "workspace", "show"); err == nil {
+		binary := terraformSREBinary()
+		if output, err := runCommandOutput(ctx, 1500*time.Millisecond, binary, "workspace", "show"); err == nil {
 			terraform["workspace"] = strings.TrimSpace(output)
+		}
+		workspace := terraformWorkspaceForSRE()
+		if workspace != "" {
+			client, err := tfclient.NewClientWithTool(workspace, binary)
+			if err != nil {
+				terraform["analysisError"] = err.Error()
+			} else if report, err := client.Analyze(ctx, tfclient.AnalysisOptions{
+				Tool:           binary,
+				CheckDrift:     terraformSREDriftEnabled(),
+				MaxOutputLines: 20,
+			}); err == nil {
+				terraform["analysis"] = report
+			} else {
+				terraform["analysisError"] = err.Error()
+			}
 		}
 		observations["terraform"] = terraform
 	}
@@ -613,7 +630,12 @@ func BuildFindings(discovery Discovery, observations map[string]any) []string {
 		findings = append(findings, "ci/cd signals detected")
 	}
 	if discovery.Terraform.Available {
-		findings = append(findings, "terraform workspace signals detected")
+		findings = append(findings, "iac workspace signals detected")
+		if tf, ok := observations["terraform"].(map[string]any); ok {
+			if analysis, ok := tf["analysis"].(tfclient.AnalysisReport); ok && analysis.Drift != nil && analysis.Drift.HasChanges {
+				findings = append(findings, "ALERT: terraform/opentofu drift or pending plan changes detected")
+			}
+		}
 	}
 	if logs, ok := observations["logs"].(map[string]any); ok {
 		if journal, ok := logs["journal"].([]string); ok && len(journal) > 0 {
@@ -894,10 +916,96 @@ func detectCICD(tools map[string]ToolStatus) CapabilityStatus {
 }
 
 func detectTerraform(tools map[string]ToolStatus) CapabilityStatus {
-	if tools["terraform"].Available || viper.IsSet("terraform.workspaces") || viper.GetString("terraform.default_workspace") != "" {
-		return CapabilityStatus{Available: true, Detail: "terraform cli/config detected", Signals: []string{"terraform"}}
+	signals := []string{}
+	for _, tool := range []string{"terraform", "tofu", "pulumi", "cdk", "crossplane"} {
+		if tools[tool].Available {
+			signals = append(signals, tool)
+		}
 	}
-	return CapabilityStatus{Available: false, Detail: "terraform not detected"}
+	if viper.IsSet("terraform.workspaces") || viper.GetString("terraform.default_workspace") != "" || viper.GetString("terraform.workspace") != "" {
+		signals = append(signals, "terraform-config")
+	}
+	if len(signals) > 0 {
+		return CapabilityStatus{Available: true, Detail: "iac cli/config detected", Signals: dedupeStrings(signals)}
+	}
+	return CapabilityStatus{Available: false, Detail: "iac tooling not detected"}
+}
+
+func terraformSREBinary() string {
+	if tool := strings.TrimSpace(os.Getenv("CLANKER_TERRAFORM_TOOL")); tool != "" {
+		if strings.EqualFold(tool, "opentofu") {
+			return "tofu"
+		}
+		return tool
+	}
+	if _, err := exec.LookPath("terraform"); err == nil {
+		return "terraform"
+	}
+	if _, err := exec.LookPath("tofu"); err == nil {
+		return "tofu"
+	}
+	return "terraform"
+}
+
+func terraformSREDriftEnabled() bool {
+	return envTruthy("CLANKER_TERRAFORM_DRIFT") || viper.GetBool("terraform.sre_drift")
+}
+
+func terraformWorkspaceForSRE() string {
+	for _, value := range []string{
+		os.Getenv("CLANKER_TERRAFORM_WORKSPACE"),
+		viper.GetString("terraform.workspace"),
+		viper.GetString("terraform.default_workspace"),
+	} {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	cwd, err := os.Getwd()
+	if err == nil && directoryHasTerraformFiles(cwd) {
+		return cwd
+	}
+	return ""
+}
+
+func directoryHasTerraformFiles(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasSuffix(name, ".tf") || strings.HasSuffix(name, ".tf.json") {
+			return true
+		}
+	}
+	return false
+}
+
+func envTruthy(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "1", "true", "yes", "y", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func dedupeStrings(values []string) []string {
+	seen := map[string]bool{}
+	result := []string{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		result = append(result, value)
+	}
+	return result
 }
 
 func sreRunArgs(target string, interval time.Duration, provider string, deployID string) []string {

--- a/internal/terraform/analyzer.go
+++ b/internal/terraform/analyzer.go
@@ -1,0 +1,589 @@
+package terraform
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const (
+	defaultMaxOutputLines = 80
+	stalePlanAge          = 24 * time.Hour
+	staleLocalStateAge    = 30 * 24 * time.Hour
+)
+
+type AnalysisOptions struct {
+	Tool           string `json:"tool,omitempty"`
+	CheckDrift     bool   `json:"checkDrift,omitempty"`
+	IncludePlan    bool   `json:"includePlan,omitempty"`
+	MaxOutputLines int    `json:"maxOutputLines,omitempty"`
+}
+
+type AnalysisReport struct {
+	Workspace       string            `json:"workspace"`
+	Path            string            `json:"path"`
+	Tool            string            `json:"tool"`
+	ToolPath        string            `json:"toolPath,omitempty"`
+	Mode            string            `json:"mode"`
+	Remote          bool              `json:"remote"`
+	Files           []string          `json:"files"`
+	Backends        []string          `json:"backends,omitempty"`
+	ProviderSources []string          `json:"providerSources,omitempty"`
+	Modules         []string          `json:"modules,omitempty"`
+	State           *StateSummary     `json:"state,omitempty"`
+	Drift           *DriftReport      `json:"drift,omitempty"`
+	StaleArtifacts  []StaleArtifact   `json:"staleArtifacts,omitempty"`
+	Alternatives    []AlternativeTool `json:"alternatives"`
+	Warnings        []string          `json:"warnings,omitempty"`
+	Recommendations []string          `json:"recommendations,omitempty"`
+}
+
+type StateSummary struct {
+	ResourceCount int            `json:"resourceCount"`
+	ResourceTypes map[string]int `json:"resourceTypes,omitempty"`
+	Sample        []string       `json:"sample,omitempty"`
+}
+
+type DriftReport struct {
+	Checked    bool     `json:"checked"`
+	HasChanges bool     `json:"hasChanges"`
+	ExitCode   int      `json:"exitCode"`
+	Command    string   `json:"command"`
+	Summary    []string `json:"summary,omitempty"`
+	Output     []string `json:"output,omitempty"`
+	Error      string   `json:"error,omitempty"`
+}
+
+type StaleArtifact struct {
+	Path           string `json:"path"`
+	Kind           string `json:"kind"`
+	Age            string `json:"age"`
+	ObservedAt     string `json:"observedAt"`
+	Recommendation string `json:"recommendation"`
+}
+
+type AlternativeTool struct {
+	Name         string `json:"name"`
+	Binary       string `json:"binary,omitempty"`
+	Category     string `json:"category"`
+	Providers    string `json:"providers"`
+	DriftCommand string `json:"driftCommand,omitempty"`
+	DocsURL      string `json:"docsUrl"`
+	Detected     bool   `json:"detected"`
+}
+
+type workspaceMetadata struct {
+	files           []string
+	backends        []string
+	providerSources []string
+	modules         []string
+	resourceTypes   []string
+	remote          bool
+}
+
+var (
+	backendRe        = regexp.MustCompile(`(?m)\bbackend\s+"([^"]+)"`)
+	cloudBlockRe     = regexp.MustCompile(`(?m)\bcloud\s*\{`)
+	providerSourceRe = regexp.MustCompile(`(?m)\bsource\s*=\s*"([^"]+)"`)
+	moduleRe         = regexp.MustCompile(`(?m)\bmodule\s+"([^"]+)"`)
+	resourceRe       = regexp.MustCompile(`(?m)\b(?:resource|data)\s+"([^"]+)"\s+"([^"]+)"`)
+	ansiRe           = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+)
+
+func (c *Client) Analyze(ctx context.Context, opts AnalysisOptions) (AnalysisReport, error) {
+	if c == nil {
+		return AnalysisReport{}, fmt.Errorf("terraform client is nil")
+	}
+	binary := c.binary
+	if override := resolveTerraformBinary(opts.Tool); strings.TrimSpace(opts.Tool) != "" {
+		binary = override
+	}
+	if strings.TrimSpace(binary) == "" {
+		binary = "terraform"
+	}
+
+	maxLines := opts.MaxOutputLines
+	if maxLines <= 0 {
+		maxLines = defaultMaxOutputLines
+	}
+
+	report := AnalysisReport{
+		Workspace:    c.workspace,
+		Path:         c.path,
+		Tool:         displayToolName(binary),
+		Alternatives: DetectAlternatives(),
+	}
+	if path, err := exec.LookPath(binary); err == nil {
+		report.ToolPath = path
+	} else {
+		report.Warnings = append(report.Warnings, fmt.Sprintf("%s binary not found on PATH", binary))
+	}
+
+	info, err := os.Stat(c.path)
+	if err != nil {
+		return report, fmt.Errorf("terraform workspace path is not readable: %w", err)
+	}
+	if !info.IsDir() {
+		return report, fmt.Errorf("terraform workspace path is not a directory: %s", c.path)
+	}
+
+	metadata := scanWorkspace(c.path)
+	report.Files = metadata.files
+	report.Backends = metadata.backends
+	report.ProviderSources = metadata.providerSources
+	report.Modules = metadata.modules
+	report.Remote = metadata.remote
+	report.Mode = workspaceMode(metadata)
+	report.StaleArtifacts = detectStaleArtifacts(c.path)
+
+	if len(report.Files) == 0 {
+		report.Warnings = append(report.Warnings, "no .tf or .tf.json files found in workspace")
+	}
+	if len(report.Backends) == 0 && len(report.Files) > 0 {
+		report.Recommendations = append(report.Recommendations, "Declare an explicit backend before team or agent workflows depend on this workspace.")
+	}
+	if len(report.ProviderSources) == 0 && len(metadata.resourceTypes) > 0 {
+		report.ProviderSources = inferredProviderSources(metadata.resourceTypes)
+	}
+	if len(report.ProviderSources) > 0 {
+		report.Recommendations = append(report.Recommendations, fmt.Sprintf("Provider families detected: %s.", strings.Join(report.ProviderSources, ", ")))
+	}
+	if report.Remote {
+		report.Recommendations = append(report.Recommendations, "Remote state/backend detected; run drift checks from an environment with the matching cloud credentials and backend access.")
+	}
+
+	report.State = c.stateSummary(ctx, binary, maxLines, &report)
+	if opts.IncludePlan {
+		report.Drift = c.normalPlan(ctx, binary, maxLines)
+	} else if opts.CheckDrift {
+		report.Drift = c.refreshOnlyDrift(ctx, binary, maxLines)
+	}
+	if report.Drift != nil && report.Drift.Checked && report.Drift.HasChanges {
+		report.Recommendations = append(report.Recommendations, "Drift or pending state refresh detected; reconcile code, imports, or remote objects before applying new changes.")
+	}
+	if len(report.StaleArtifacts) > 0 {
+		report.Recommendations = append(report.Recommendations, "Review stale local state or saved plan artifacts; remove obsolete files after confirming the active backend.")
+	}
+	report.Warnings = dedupeSorted(report.Warnings)
+	report.Recommendations = dedupePreserveOrder(report.Recommendations)
+	return report, nil
+}
+
+func (c *Client) stateSummary(ctx context.Context, binary string, maxLines int, report *AnalysisReport) *StateSummary {
+	output, err := runTerraformCommand(ctx, c.path, binary, 8*time.Second, "state", "list")
+	if err != nil {
+		if report != nil {
+			report.Warnings = append(report.Warnings, fmt.Sprintf("state list unavailable: %v", err))
+		}
+		return nil
+	}
+	resources := nonEmptyLines(output)
+	if len(resources) == 0 {
+		return &StateSummary{ResourceCount: 0}
+	}
+	types := make(map[string]int)
+	for _, resource := range resources {
+		if resourceType := resourceTypeFromAddress(resource); resourceType != "" {
+			types[resourceType]++
+		}
+	}
+	return &StateSummary{
+		ResourceCount: len(resources),
+		ResourceTypes: types,
+		Sample:        limitStrings(resources, maxLines),
+	}
+}
+
+func (c *Client) refreshOnlyDrift(ctx context.Context, binary string, maxLines int) *DriftReport {
+	args := []string{"plan", "-refresh-only", "-detailed-exitcode", "-no-color", "-compact-warnings", "-input=false"}
+	return c.planReport(ctx, binary, args, maxLines)
+}
+
+func (c *Client) normalPlan(ctx context.Context, binary string, maxLines int) *DriftReport {
+	args := []string{"plan", "-detailed-exitcode", "-no-color", "-compact-warnings", "-input=false"}
+	return c.planReport(ctx, binary, args, maxLines)
+}
+
+func (c *Client) planReport(ctx context.Context, binary string, args []string, maxLines int) *DriftReport {
+	output, exitCode, err := runTerraformCommandDetailed(ctx, c.path, binary, 90*time.Second, args...)
+	report := &DriftReport{
+		Checked:  true,
+		ExitCode: exitCode,
+		Command:  binary + " " + strings.Join(args, " "),
+		Output:   limitStrings(nonEmptyLines(output), maxLines),
+		Summary:  summarizePlanOutput(output),
+	}
+	if exitCode == 2 {
+		report.HasChanges = true
+	}
+	if err != nil && exitCode != 2 {
+		report.Error = err.Error()
+	}
+	return report
+}
+
+func runTerraformCommand(ctx context.Context, dir string, binary string, timeout time.Duration, args ...string) (string, error) {
+	output, _, err := runTerraformCommandDetailed(ctx, dir, binary, timeout, args...)
+	return output, err
+}
+
+func runTerraformCommandDetailed(ctx context.Context, dir string, binary string, timeout time.Duration, args ...string) (string, int, error) {
+	runCtx := ctx
+	cancel := func() {}
+	if timeout > 0 {
+		runCtx, cancel = context.WithTimeout(ctx, timeout)
+	}
+	defer cancel()
+
+	cmd := exec.CommandContext(runCtx, binary, args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	text := stripANSI(strings.TrimSpace(string(output)))
+	exitCode := 0
+	if err != nil {
+		exitCode = 1
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+				exitCode = status.ExitStatus()
+			}
+		}
+		if runCtx.Err() != nil {
+			return text, exitCode, runCtx.Err()
+		}
+		return text, exitCode, fmt.Errorf("%s %s failed: %w%s", binary, strings.Join(args, " "), err, commandOutputSuffix(text))
+	}
+	return text, exitCode, nil
+}
+
+func commandOutputSuffix(output string) string {
+	if strings.TrimSpace(output) == "" {
+		return ""
+	}
+	return "\nOutput: " + strings.TrimSpace(output)
+}
+
+func stripANSI(value string) string {
+	return ansiRe.ReplaceAllString(value, "")
+}
+
+func scanWorkspace(root string) workspaceMetadata {
+	metadata := workspaceMetadata{}
+	seenBackends := map[string]bool{}
+	seenSources := map[string]bool{}
+	seenModules := map[string]bool{}
+	seenResourceTypes := map[string]bool{}
+	_ = filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if entry.IsDir() {
+			switch entry.Name() {
+			case ".git", ".terraform", "node_modules", "vendor":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !isTerraformFile(path) {
+			return nil
+		}
+		rel, _ := filepath.Rel(root, path)
+		metadata.files = append(metadata.files, rel)
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
+		}
+		text := string(data)
+		for _, match := range backendRe.FindAllStringSubmatch(text, -1) {
+			addSeen(match[1], seenBackends, &metadata.backends)
+		}
+		if cloudBlockRe.MatchString(text) {
+			addSeen("hcp_terraform", seenBackends, &metadata.backends)
+		}
+		for _, match := range providerSourceRe.FindAllStringSubmatch(text, -1) {
+			source := strings.TrimSpace(match[1])
+			if looksLikeProviderSource(source) {
+				addSeen(source, seenSources, &metadata.providerSources)
+			}
+		}
+		for _, match := range moduleRe.FindAllStringSubmatch(text, -1) {
+			addSeen(match[1], seenModules, &metadata.modules)
+		}
+		for _, match := range resourceRe.FindAllStringSubmatch(text, -1) {
+			addSeen(match[1], seenResourceTypes, &metadata.resourceTypes)
+		}
+		return nil
+	})
+	sort.Strings(metadata.files)
+	sort.Strings(metadata.backends)
+	sort.Strings(metadata.providerSources)
+	sort.Strings(metadata.modules)
+	sort.Strings(metadata.resourceTypes)
+	metadata.remote = hasRemoteBackend(metadata.backends)
+	return metadata
+}
+
+func isTerraformFile(path string) bool {
+	return strings.HasSuffix(path, ".tf") || strings.HasSuffix(path, ".tf.json")
+}
+
+func addSeen(value string, seen map[string]bool, values *[]string) {
+	value = strings.TrimSpace(value)
+	if value == "" || seen[value] {
+		return
+	}
+	seen[value] = true
+	*values = append(*values, value)
+}
+
+func looksLikeProviderSource(source string) bool {
+	if source == "" || strings.HasPrefix(source, ".") || strings.HasPrefix(source, "/") {
+		return false
+	}
+	if strings.Contains(source, "://") {
+		return false
+	}
+	parts := strings.Split(source, "/")
+	return len(parts) == 2 || len(parts) == 3
+}
+
+func inferredProviderSources(resourceTypes []string) []string {
+	providers := map[string]bool{}
+	for _, resourceType := range resourceTypes {
+		if idx := strings.Index(resourceType, "_"); idx > 0 {
+			providers[resourceType[:idx]] = true
+		}
+	}
+	values := make([]string, 0, len(providers))
+	for provider := range providers {
+		values = append(values, provider)
+	}
+	sort.Strings(values)
+	return values
+}
+
+func hasRemoteBackend(backends []string) bool {
+	for _, backend := range backends {
+		switch strings.ToLower(backend) {
+		case "azurerm", "consul", "cos", "gcs", "hcp_terraform", "http", "kubernetes", "oss", "pg", "remote", "s3":
+			return true
+		}
+	}
+	return false
+}
+
+func workspaceMode(metadata workspaceMetadata) string {
+	if len(metadata.files) == 0 {
+		return "unconfigured"
+	}
+	if metadata.remote {
+		return "remote-state"
+	}
+	if len(metadata.backends) > 0 {
+		return "local-or-custom-backend"
+	}
+	return "local-state"
+}
+
+func detectStaleArtifacts(root string) []StaleArtifact {
+	now := time.Now()
+	candidates := []struct {
+		path           string
+		kind           string
+		threshold      time.Duration
+		recommendation string
+	}{
+		{filepath.Join(root, "tfplan"), "saved-plan", stalePlanAge, "Regenerate saved plans before applying; plan files can become stale quickly."},
+		{filepath.Join(root, "terraform.tfstate"), "local-state", staleLocalStateAge, "Confirm whether this local state is still authoritative or move state to a remote backend."},
+	}
+	stale := []StaleArtifact{}
+	for _, candidate := range candidates {
+		info, err := os.Stat(candidate.path)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		age := now.Sub(info.ModTime())
+		if age < candidate.threshold {
+			continue
+		}
+		rel, _ := filepath.Rel(root, candidate.path)
+		stale = append(stale, StaleArtifact{
+			Path:           rel,
+			Kind:           candidate.kind,
+			Age:            age.Round(time.Second).String(),
+			ObservedAt:     info.ModTime().UTC().Format(time.RFC3339),
+			Recommendation: candidate.recommendation,
+		})
+	}
+	return stale
+}
+
+func resourceTypeFromAddress(address string) string {
+	address = strings.TrimSpace(address)
+	if address == "" {
+		return ""
+	}
+	parts := strings.Split(address, ".")
+	for i := 0; i < len(parts)-1; i++ {
+		part := parts[i]
+		if part == "data" && i+1 < len(parts) {
+			return "data." + parts[i+1]
+		}
+		if strings.Contains(part, "_") && !strings.Contains(part, "[") {
+			return part
+		}
+	}
+	return ""
+}
+
+func summarizePlanOutput(output string) []string {
+	lines := nonEmptyLines(output)
+	summary := []string{}
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.Contains(trimmed, "Plan:") ||
+			strings.Contains(trimmed, "No changes") ||
+			strings.Contains(trimmed, "No changes.") ||
+			strings.Contains(trimmed, "Objects have changed outside of Terraform") ||
+			strings.Contains(trimmed, "Objects have changed outside of OpenTofu") ||
+			strings.Contains(trimmed, "Your infrastructure matches the configuration") {
+			summary = append(summary, trimmed)
+		}
+	}
+	return dedupePreserveOrder(summary)
+}
+
+func nonEmptyLines(output string) []string {
+	raw := strings.Split(strings.TrimSpace(output), "\n")
+	lines := make([]string, 0, len(raw))
+	for _, line := range raw {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}
+
+func limitStrings(values []string, max int) []string {
+	if max <= 0 || len(values) <= max {
+		return values
+	}
+	limited := append([]string{}, values[:max]...)
+	limited = append(limited, fmt.Sprintf("... truncated %d more line(s)", len(values)-max))
+	return limited
+}
+
+func displayToolName(binary string) string {
+	switch strings.TrimSpace(binary) {
+	case "tofu":
+		return "OpenTofu"
+	default:
+		return "Terraform"
+	}
+}
+
+func DetectAlternatives() []AlternativeTool {
+	alternatives := []AlternativeTool{
+		{
+			Name:         "Terraform",
+			Binary:       "terraform",
+			Category:     "HCL infrastructure as code",
+			Providers:    "Multi-cloud via Terraform providers",
+			DriftCommand: "terraform plan -refresh-only -detailed-exitcode",
+			DocsURL:      "https://developer.hashicorp.com/terraform/cli/commands/plan",
+		},
+		{
+			Name:         "OpenTofu",
+			Binary:       "tofu",
+			Category:     "Open-source Terraform-compatible HCL",
+			Providers:    "Multi-cloud via OpenTofu/Terraform-compatible providers",
+			DriftCommand: "tofu plan -refresh-only -detailed-exitcode",
+			DocsURL:      "https://opentofu.org/docs/cli/commands/plan/",
+		},
+		{
+			Name:         "Pulumi",
+			Binary:       "pulumi",
+			Category:     "Programming-language infrastructure as code",
+			Providers:    "AWS, Azure, Google Cloud, Kubernetes, Cloudflare, and more",
+			DriftCommand: "pulumi refresh --preview-only",
+			DocsURL:      "https://www.pulumi.com/docs/iac/operations/stack-management/drift/",
+		},
+		{
+			Name:         "Crossplane",
+			Binary:       "kubectl",
+			Category:     "Kubernetes control-plane infrastructure",
+			Providers:    "External services through Crossplane providers",
+			DriftCommand: "kubectl get managed",
+			DocsURL:      "https://docs.crossplane.io/latest/packages/providers/",
+		},
+		{
+			Name:         "AWS CDK",
+			Binary:       "cdk",
+			Category:     "Code-first AWS infrastructure",
+			Providers:    "AWS via CloudFormation",
+			DriftCommand: "cdk diff",
+			DocsURL:      "https://docs.aws.amazon.com/cdk/v2/guide/ref-cli-cmd-diff.html",
+		},
+		{
+			Name:         "AWS CloudFormation",
+			Binary:       "aws",
+			Category:     "Native AWS declarative infrastructure",
+			Providers:    "AWS",
+			DriftCommand: "aws cloudformation detect-stack-drift",
+			DocsURL:      "https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift.html",
+		},
+		{
+			Name:         "Azure Bicep",
+			Binary:       "az",
+			Category:     "Native Azure declarative infrastructure",
+			Providers:    "Azure",
+			DriftCommand: "az deployment group what-if",
+			DocsURL:      "https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/deploy-what-if",
+		},
+		{
+			Name:         "Google Cloud Infrastructure Manager",
+			Binary:       "gcloud",
+			Category:     "Managed Terraform deployments on Google Cloud",
+			Providers:    "Google Cloud",
+			DriftCommand: "gcloud infra-manager deployments describe",
+			DocsURL:      "https://docs.cloud.google.com/infrastructure-manager/docs",
+		},
+	}
+	for i := range alternatives {
+		if alternatives[i].Binary == "" {
+			continue
+		}
+		_, err := exec.LookPath(alternatives[i].Binary)
+		alternatives[i].Detected = err == nil
+	}
+	return alternatives
+}
+
+func dedupeSorted(values []string) []string {
+	values = dedupePreserveOrder(values)
+	sort.Strings(values)
+	return values
+}
+
+func dedupePreserveOrder(values []string) []string {
+	seen := map[string]bool{}
+	result := []string{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		result = append(result, value)
+	}
+	return result
+}

--- a/internal/terraform/analyzer_test.go
+++ b/internal/terraform/analyzer_test.go
@@ -1,0 +1,102 @@
+package terraform
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestScanWorkspaceDetectsBackendsProvidersModules(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "main.tf"), `
+terraform {
+  backend "s3" {}
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
+module "network" {
+  source = "./modules/network"
+}
+
+resource "aws_instance" "web" {}
+data "aws_iam_policy_document" "assume" {}
+`)
+	writeFile(t, filepath.Join(dir, "modules", "network", "main.tf"), `
+resource "aws_vpc" "main" {}
+`)
+
+	metadata := scanWorkspace(dir)
+	if !metadata.remote {
+		t.Fatal("expected remote backend detection")
+	}
+	assertContains(t, metadata.backends, "s3")
+	assertContains(t, metadata.providerSources, "hashicorp/aws")
+	assertContains(t, metadata.modules, "network")
+	assertContains(t, metadata.resourceTypes, "aws_instance")
+	assertContains(t, metadata.resourceTypes, "aws_vpc")
+	if len(metadata.files) != 2 {
+		t.Fatalf("expected 2 terraform files, got %d: %#v", len(metadata.files), metadata.files)
+	}
+}
+
+func TestDetectStaleArtifactsFlagsOldPlanAndState(t *testing.T) {
+	dir := t.TempDir()
+	planPath := filepath.Join(dir, "tfplan")
+	statePath := filepath.Join(dir, "terraform.tfstate")
+	writeFile(t, planPath, "plan")
+	writeFile(t, statePath, "{}")
+	old := time.Now().Add(-45 * 24 * time.Hour)
+	if err := os.Chtimes(planPath, old, old); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(statePath, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	stale := detectStaleArtifacts(dir)
+	if len(stale) != 2 {
+		t.Fatalf("expected 2 stale artifacts, got %d: %#v", len(stale), stale)
+	}
+	if stale[0].Path == "" || stale[0].Recommendation == "" {
+		t.Fatalf("expected stale artifact path and recommendation, got %#v", stale[0])
+	}
+}
+
+func TestResourceTypeFromAddress(t *testing.T) {
+	tests := map[string]string{
+		"aws_instance.web":                                   "aws_instance",
+		"module.network.aws_vpc.main":                        "aws_vpc",
+		"module.a.module.b.aws_security_group.rule[\"api\"]": "aws_security_group",
+		"data.aws_iam_policy_document.assume":                "data.aws_iam_policy_document",
+	}
+	for address, want := range tests {
+		if got := resourceTypeFromAddress(address); got != want {
+			t.Errorf("resourceTypeFromAddress(%q) = %q, want %q", address, got, want)
+		}
+	}
+}
+
+func writeFile(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertContains(t *testing.T, values []string, want string) {
+	t.Helper()
+	for _, value := range values {
+		if value == want {
+			return
+		}
+	}
+	t.Fatalf("expected %#v to contain %q", values, want)
+}

--- a/internal/terraform/client.go
+++ b/internal/terraform/client.go
@@ -15,14 +15,21 @@ import (
 type Client struct {
 	workspace string
 	path      string
+	binary    string
 }
 
 func NewClient(workspace string) (*Client, error) {
+	return NewClientWithTool(workspace, "")
+}
+
+func NewClientWithTool(workspace string, tool string) (*Client, error) {
+	binary := resolveTerraformBinary(tool)
 	if looksLikePath(workspace) {
 		if expanded, ok := expandTerraformPath(workspace); ok {
 			return &Client{
 				workspace: "local",
 				path:      expanded,
+				binary:    binary,
 			}, nil
 		}
 	}
@@ -59,7 +66,25 @@ func NewClient(workspace string) (*Client, error) {
 	return &Client{
 		workspace: workspace,
 		path:      path,
+		binary:    binary,
 	}, nil
+}
+
+func resolveTerraformBinary(tool string) string {
+	switch strings.ToLower(strings.TrimSpace(tool)) {
+	case "tofu", "opentofu", "open-tofu":
+		return "tofu"
+	case "terraform":
+		return "terraform"
+	case "":
+		if _, err := exec.LookPath("terraform"); err == nil {
+			return "terraform"
+		}
+		if _, err := exec.LookPath("tofu"); err == nil {
+			return "tofu"
+		}
+	}
+	return "terraform"
 }
 
 func looksLikePath(value string) bool {
@@ -177,19 +202,19 @@ func mergeOutputs(primary string, secondary string) string {
 }
 
 func (c *Client) runCommand(ctx context.Context, args ...string) (string, error) {
-	cmd := exec.CommandContext(ctx, "terraform", args...)
+	cmd := exec.CommandContext(ctx, c.binary, args...)
 	cmd.Dir = c.path
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("terraform %s failed: %w\nOutput: %s", strings.Join(args, " "), err, strings.TrimSpace(string(output)))
+		return "", fmt.Errorf("%s %s failed: %w\nOutput: %s", c.binary, strings.Join(args, " "), err, strings.TrimSpace(string(output)))
 	}
 
 	return strings.TrimSpace(string(output)), nil
 }
 
 func (c *Client) getWorkspaceInfo(ctx context.Context) (string, error) {
-	cmd := exec.CommandContext(ctx, "terraform", "workspace", "show")
+	cmd := exec.CommandContext(ctx, c.binary, "workspace", "show")
 	cmd.Dir = c.path
 
 	output, err := cmd.Output()
@@ -197,11 +222,11 @@ func (c *Client) getWorkspaceInfo(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf("Current workspace: %s\nConfigured path: %s", strings.TrimSpace(string(output)), c.path), nil
+	return fmt.Sprintf("Current workspace: %s\nConfigured path: %s\nTool: %s", strings.TrimSpace(string(output)), c.path, c.binary), nil
 }
 
 func (c *Client) getStateInfo(ctx context.Context) (string, error) {
-	cmd := exec.CommandContext(ctx, "terraform", "state", "list")
+	cmd := exec.CommandContext(ctx, c.binary, "state", "list")
 	cmd.Dir = c.path
 
 	output, err := cmd.Output()
@@ -242,7 +267,7 @@ func (c *Client) getPlanInfo(ctx context.Context) (string, error) {
 	planFile := filepath.Join(c.path, "tfplan")
 	if _, err := os.Stat(planFile); os.IsNotExist(err) {
 		// Run terraform plan
-		cmd := exec.CommandContext(ctx, "terraform", "plan", "-no-color", "-compact-warnings")
+		cmd := exec.CommandContext(ctx, c.binary, "plan", "-no-color", "-compact-warnings")
 		cmd.Dir = c.path
 
 		output, err := cmd.Output()
@@ -264,7 +289,7 @@ func (c *Client) getPlanInfo(ctx context.Context) (string, error) {
 	}
 
 	// Show existing plan
-	cmd := exec.CommandContext(ctx, "terraform", "show", "-no-color", planFile)
+	cmd := exec.CommandContext(ctx, c.binary, "show", "-no-color", planFile)
 	cmd.Dir = c.path
 
 	output, err := cmd.Output()
@@ -284,13 +309,13 @@ func (c *Client) getPlanInfo(ctx context.Context) (string, error) {
 }
 
 func (c *Client) getOutputInfo(ctx context.Context) (string, error) {
-	cmd := exec.CommandContext(ctx, "terraform", "output", "-json")
+	cmd := exec.CommandContext(ctx, c.binary, "output", "-json")
 	cmd.Dir = c.path
 
 	output, err := cmd.Output()
 	if err != nil {
 		// Try non-JSON output as fallback
-		cmd = exec.CommandContext(ctx, "terraform", "output")
+		cmd = exec.CommandContext(ctx, c.binary, "output")
 		cmd.Dir = c.path
 		output, err = cmd.Output()
 		if err != nil {
@@ -307,7 +332,7 @@ func (c *Client) getOutputInfo(ctx context.Context) (string, error) {
 }
 
 func (c *Client) GetTerraformOutputs(ctx context.Context) (map[string]interface{}, error) {
-	cmd := exec.CommandContext(ctx, "terraform", "output", "-json")
+	cmd := exec.CommandContext(ctx, c.binary, "output", "-json")
 	cmd.Dir = c.path
 
 	output, err := cmd.Output()


### PR DESCRIPTION
## Summary
- add Terraform/OpenTofu analyzer for workspace metadata, state summaries, stale artifacts, optional drift/plan checks, and IaC alternatives
- add `clanker terraform analyze` with text/json output
- wire IaC tool detection and optional drift checks into SRE discovery/heartbeat context

## Verification
- `go test ./...`
- smoke: `go run . terraform analyze /Users/bog/Documents/clanker\ cloud/worktrees/clanker-cloud-terraform-adoption/terraform --format json --max-lines 5`