### PR TITLE
Simplify Clanker CLI help copy

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,11 +30,16 @@ var Version = "dev"
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:     "clanker",
-	Short:   "AI-powered terminal for Cloud queries",
+	Short:   "Cloud operations from your terminal",
 	Version: Version,
-	Long: `Clanker is an AI-powered CLI tool that helps you query your cloud infrastructure
-using natural language. Ask questions about your systems,
-get insights, and perform operations through an intelligent interface.`,
+	Long: `Clanker is the command-line companion to Clanker Cloud.
+
+Use it to inspect cloud resources, ask operational questions, scan for waste,
+and run reviewed infrastructure workflows from the terminal.`,
+	Example: `  clanker ask "what changed in prod?"
+  clanker scan --quick
+  clanker cost summary
+  clanker k8s health`,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -30,8 +30,8 @@ var (
 	scanLocal      bool
 )
 
-// scanCmd is the new top-level "scan everything for cost waste"
-// command. By design it is *richer* than `clanker cost savings`:
+// scanCmd is the top-level "scan everything for cost waste" command.
+// By design it is richer than `clanker cost savings`:
 //
 //   - When the clanker-cloud desktop backend is running on
 //     localhost:8080..8084, the CLI calls /api/cost/scan and gets the
@@ -42,14 +42,14 @@ var (
 //     AWS Cost Explorer commitment-recommendation surface — a degraded
 //     but still useful receipt focused on Savings Plans + RIs.
 //
-// The output is a coloured terminal "receipt" with category rollup,
+// The output is a terminal summary with category rollup,
 // sorted findings, and per-row actions. --export and --fix turn the
-// receipt into a Markdown/JSON file or a maker plan JSON respectively.
+// summary into a Markdown/JSON file or a maker plan JSON respectively.
 var scanCmd = &cobra.Command{
 	Use:   "scan",
-	Short: "Scan every configured cloud for cost waste, produce a receipt",
+	Short: "Scan configured clouds for cost waste",
 	Long: `Scan every configured cloud account for actionable cost-savings opportunities
-and print a colour-coded receipt summarising the waste found.
+and print a clear summary of the waste found.
 
 Sources composed (when available):
 
@@ -69,7 +69,7 @@ Modes:
 
 Output formats:
 
-  --format terminal   Coloured receipt (default).
+  --format terminal   Terminal summary (default).
   --format json       Machine-readable JSON.
   --format markdown   Markdown export.
 
@@ -81,7 +81,7 @@ Actions:
 
 Examples:
 
-  clanker scan                                    # full scan, coloured terminal
+  clanker scan                                    # full scan, terminal summary
   clanker scan --quick                            # fast scan, detectors only
   clanker scan --format json                      # JSON to stdout
   clanker scan --export receipt.md --format markdown


### PR DESCRIPTION
## Summary
- simplify the root command description around cloud operations from the terminal
- replace internal receipt wording in scan help with user-facing summary/report copy

## Tests
- go test ./...
- git diff --check