### PR TITLE
Add Terraform infrastructure view

### DIFF
--- a/cmd/terraform.go
+++ b/cmd/terraform.go
@@ -113,15 +113,67 @@ a refresh-only drift check, or --plan to run a normal detailed-exitcode plan.`,
 	},
 }
 
+var terraformViewCmd = &cobra.Command{
+	Use:   "view [workspace-or-path]",
+	Short: "Show Terraform/OpenTofu infrastructure, state, and alternatives",
+	Long: `Show a Terraform/OpenTofu infrastructure view.
+
+The view groups local configuration, state source, remote backend/drift status,
+stale local artifacts, and adjacent IaC alternatives into one operator-readable
+report. Drift checks are opt-in because they can contact remote backends and
+cloud APIs.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		workspace, _ := cmd.Flags().GetString("workspace")
+		if len(args) > 0 {
+			workspace = args[0]
+		}
+		tool, _ := cmd.Flags().GetString("tool")
+		format, _ := cmd.Flags().GetString("format")
+		checkDrift, _ := cmd.Flags().GetBool("drift")
+		includePlan, _ := cmd.Flags().GetBool("plan")
+		maxLines, _ := cmd.Flags().GetInt("max-lines")
+
+		client, err := tfclient.NewClientWithTool(workspace, tool)
+		if err != nil {
+			return err
+		}
+		report, err := client.Analyze(cmd.Context(), tfclient.AnalysisOptions{
+			Tool:           tool,
+			CheckDrift:     checkDrift,
+			IncludePlan:    includePlan,
+			MaxOutputLines: maxLines,
+		})
+		if err != nil {
+			return err
+		}
+
+		view := tfclient.BuildViewReport(report.Workspace, report)
+		if strings.EqualFold(format, "json") {
+			encoder := json.NewEncoder(os.Stdout)
+			encoder.SetIndent("", "  ")
+			return encoder.Encode(view)
+		}
+		fmt.Print(formatTerraformView(view))
+		return nil
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(terraformCmd)
-	terraformCmd.AddCommand(terraformListCmd, terraformAnalyzeCmd)
+	terraformCmd.AddCommand(terraformListCmd, terraformAnalyzeCmd, terraformViewCmd)
 	terraformAnalyzeCmd.Flags().String("workspace", "", "Configured workspace name or local path")
 	terraformAnalyzeCmd.Flags().String("tool", "", "IaC binary to use: terraform or tofu (default auto-detect)")
 	terraformAnalyzeCmd.Flags().Bool("drift", false, "Run refresh-only drift detection with detailed exit codes")
 	terraformAnalyzeCmd.Flags().Bool("plan", false, "Run a normal speculative plan with detailed exit codes")
 	terraformAnalyzeCmd.Flags().Int("max-lines", 80, "Maximum command output lines to include")
 	terraformAnalyzeCmd.Flags().String("format", "text", "Output format: text or json")
+	terraformViewCmd.Flags().String("workspace", "", "Configured workspace name or local path")
+	terraformViewCmd.Flags().String("tool", "", "IaC binary to use: terraform or tofu (default auto-detect)")
+	terraformViewCmd.Flags().Bool("drift", false, "Run refresh-only drift detection with detailed exit codes")
+	terraformViewCmd.Flags().Bool("plan", false, "Run a normal speculative plan with detailed exit codes")
+	terraformViewCmd.Flags().Int("max-lines", 80, "Maximum command output lines to include")
+	terraformViewCmd.Flags().String("format", "text", "Output format: text or json")
 }
 
 func formatTerraformAnalysis(report tfclient.AnalysisReport) string {
@@ -206,6 +258,93 @@ func sortedCountLines(values map[string]int) []string {
 	}
 	sort.Strings(lines)
 	return lines
+}
+
+func formatTerraformView(view tfclient.ViewReport) string {
+	var out strings.Builder
+	out.WriteString("Terraform view\n")
+	out.WriteString(fmt.Sprintf("Workspace: %s\n", fallbackText(view.Workspace, "local")))
+	out.WriteString(fmt.Sprintf("Path: %s\n", view.Path))
+	out.WriteString(fmt.Sprintf("Status: %s\n", view.Status))
+	out.WriteString(fmt.Sprintf("Tool: %s", fallbackText(view.Tool, "Terraform")))
+	if view.ToolPath != "" {
+		out.WriteString(fmt.Sprintf(" (%s)", view.ToolPath))
+	}
+	out.WriteString("\n")
+
+	if len(view.Summary) > 0 {
+		out.WriteString("\nSummary:\n")
+		for _, line := range view.Summary {
+			out.WriteString("- " + line + "\n")
+		}
+	}
+
+	out.WriteString("\nLocal configuration:\n")
+	out.WriteString(fmt.Sprintf("Mode: %s\n", fallbackText(view.Local.Mode, "unknown")))
+	out.WriteString(fmt.Sprintf("Files: %d\n", view.Local.FileCount))
+	if len(view.Local.ProviderSources) > 0 {
+		out.WriteString(fmt.Sprintf("Providers: %s\n", strings.Join(view.Local.ProviderSources, ", ")))
+	}
+	if len(view.Local.Modules) > 0 {
+		out.WriteString(fmt.Sprintf("Modules: %s\n", strings.Join(view.Local.Modules, ", ")))
+	}
+	if len(view.Local.StaleArtifacts) > 0 {
+		out.WriteString("Stale artifacts:\n")
+		for _, artifact := range view.Local.StaleArtifacts {
+			out.WriteString(fmt.Sprintf("  - %s (%s, age %s): %s\n", artifact.Path, artifact.Kind, artifact.Age, artifact.Recommendation))
+		}
+	}
+
+	out.WriteString("\nState:\n")
+	out.WriteString(fmt.Sprintf("Source: %s\n", fallbackText(view.State.Source, "unknown")))
+	out.WriteString(fmt.Sprintf("Backend: %s\n", fallbackText(view.State.Backend, "none")))
+	out.WriteString(fmt.Sprintf("Availability: %s\n", view.State.Availability))
+	out.WriteString(fmt.Sprintf("Resources: %d\n", view.State.ResourceCount))
+	if len(view.State.ResourceTypes) > 0 {
+		out.WriteString("Resource types:\n")
+		for _, line := range tfclient.SortedResourceTypeLines(view.State.ResourceTypes) {
+			out.WriteString("  " + line + "\n")
+		}
+	}
+	if len(view.State.Sample) > 0 {
+		out.WriteString("Sample state addresses:\n")
+		for _, address := range view.State.Sample {
+			out.WriteString("  - " + address + "\n")
+		}
+	}
+
+	out.WriteString("\nRemote/drift:\n")
+	out.WriteString(fmt.Sprintf("Remote backend: %v\n", view.Remote.Enabled))
+	out.WriteString(fmt.Sprintf("Drift status: %s\n", view.Remote.DriftStatus))
+	if view.Remote.Command != "" {
+		out.WriteString(fmt.Sprintf("Command: %s\n", view.Remote.Command))
+	}
+	for _, line := range view.Remote.Summary {
+		out.WriteString("  " + line + "\n")
+	}
+	if view.Remote.Error != "" {
+		out.WriteString("Error: " + view.Remote.Error + "\n")
+	}
+
+	if len(view.Alternatives) > 0 {
+		out.WriteString("\nIaC alternatives:\n")
+		for _, alt := range view.Alternatives {
+			out.WriteString(fmt.Sprintf("- %s: %s; %s; drift/diff: %s (%s)\n", alt.Name, alt.Status, alt.Category, fallbackText(alt.DriftCommand, "n/a"), alt.DocsURL))
+		}
+	}
+	if len(view.Warnings) > 0 {
+		out.WriteString("\nWarnings:\n")
+		for _, warning := range view.Warnings {
+			out.WriteString("- " + warning + "\n")
+		}
+	}
+	if len(view.Recommendations) > 0 {
+		out.WriteString("\nRecommendations:\n")
+		for _, recommendation := range view.Recommendations {
+			out.WriteString("- " + recommendation + "\n")
+		}
+	}
+	return out.String()
 }
 
 func fallbackText(value string, fallback string) string {

--- a/internal/terraform/analyzer_test.go
+++ b/internal/terraform/analyzer_test.go
@@ -81,6 +81,61 @@ func TestResourceTypeFromAddress(t *testing.T) {
 	}
 }
 
+func TestBuildViewReportDescribesLocalRemoteAndAlternatives(t *testing.T) {
+	report := AnalysisReport{
+		Path:            "/infra/prod",
+		Tool:            "Terraform",
+		Mode:            "remote-state",
+		Remote:          true,
+		Files:           []string{"main.tf", "network/vpc.tf"},
+		Backends:        []string{"s3"},
+		ProviderSources: []string{"hashicorp/aws"},
+		Modules:         []string{"network"},
+		State: &StateSummary{
+			ResourceCount: 2,
+			ResourceTypes: map[string]int{
+				"aws_instance": 1,
+				"aws_vpc":      1,
+			},
+			Sample: []string{"aws_instance.web", "aws_vpc.main"},
+		},
+		Drift: &DriftReport{
+			Checked:    true,
+			HasChanges: true,
+			ExitCode:   2,
+			Command:    "terraform plan -refresh-only -detailed-exitcode",
+			Summary:    []string{"Plan: 0 to add, 1 to change, 0 to destroy."},
+		},
+		Alternatives: []AlternativeTool{
+			{Name: "Terraform", Binary: "terraform", Detected: true},
+			{Name: "OpenTofu", Binary: "tofu", Detected: false},
+		},
+	}
+
+	view := BuildViewReport("prod", report)
+	if view.Workspace != "prod" {
+		t.Fatalf("workspace = %q, want prod", view.Workspace)
+	}
+	if view.Status != "attention" {
+		t.Fatalf("status = %q, want attention", view.Status)
+	}
+	if view.Local.FileCount != 2 || view.State.Source != "remote" || view.State.Backend != "s3" {
+		t.Fatalf("unexpected local/state view: %#v %#v", view.Local, view.State)
+	}
+	if view.Remote.DriftStatus != "changed" || !view.Remote.HasChanges {
+		t.Fatalf("unexpected remote drift view: %#v", view.Remote)
+	}
+	if view.Drift == nil || view.Drift.Status != "changed" {
+		t.Fatalf("unexpected drift view: %#v", view.Drift)
+	}
+	if len(view.Alternatives) != 2 || view.Alternatives[0].Status != "available" || view.Alternatives[1].Status != "missing" {
+		t.Fatalf("unexpected alternatives: %#v", view.Alternatives)
+	}
+	if len(view.Summary) == 0 {
+		t.Fatal("expected generated summary")
+	}
+}
+
 func writeFile(t *testing.T, path string, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/terraform/view.go
+++ b/internal/terraform/view.go
@@ -1,0 +1,303 @@
+package terraform
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+type ViewReport struct {
+	GeneratedAt     string            `json:"generatedAt"`
+	Workspace       string            `json:"workspace"`
+	Path            string            `json:"path"`
+	Tool            string            `json:"tool"`
+	ToolPath        string            `json:"toolPath,omitempty"`
+	Status          string            `json:"status"`
+	Summary         []string          `json:"summary"`
+	Local           LocalView         `json:"local"`
+	State           StateView         `json:"state"`
+	Remote          RemoteView        `json:"remote"`
+	Drift           *DriftView        `json:"drift,omitempty"`
+	Alternatives    []AlternativeView `json:"alternatives"`
+	Warnings        []string          `json:"warnings,omitempty"`
+	Recommendations []string          `json:"recommendations,omitempty"`
+}
+
+type LocalView struct {
+	Mode            string          `json:"mode"`
+	FileCount       int             `json:"fileCount"`
+	Files           []string        `json:"files,omitempty"`
+	ProviderSources []string        `json:"providerSources,omitempty"`
+	Modules         []string        `json:"modules,omitempty"`
+	StaleArtifacts  []StaleArtifact `json:"staleArtifacts,omitempty"`
+}
+
+type StateView struct {
+	Source           string         `json:"source"`
+	Backend          string         `json:"backend"`
+	Backends         []string       `json:"backends,omitempty"`
+	HasRemoteBackend bool           `json:"hasRemoteBackend"`
+	Availability     string         `json:"availability"`
+	ResourceCount    int            `json:"resourceCount"`
+	ResourceTypes    map[string]int `json:"resourceTypes,omitempty"`
+	Sample           []string       `json:"sample,omitempty"`
+}
+
+type RemoteView struct {
+	Enabled     bool     `json:"enabled"`
+	Backends    []string `json:"backends,omitempty"`
+	DriftStatus string   `json:"driftStatus"`
+	HasChanges  bool     `json:"hasChanges"`
+	Command     string   `json:"command,omitempty"`
+	Summary     []string `json:"summary,omitempty"`
+	Error       string   `json:"error,omitempty"`
+}
+
+type DriftView struct {
+	Checked    bool     `json:"checked"`
+	Status     string   `json:"status"`
+	HasChanges bool     `json:"hasChanges"`
+	ExitCode   int      `json:"exitCode"`
+	Command    string   `json:"command"`
+	Summary    []string `json:"summary,omitempty"`
+	Output     []string `json:"output,omitempty"`
+	Error      string   `json:"error,omitempty"`
+}
+
+type AlternativeView struct {
+	Name         string `json:"name"`
+	Binary       string `json:"binary,omitempty"`
+	Category     string `json:"category"`
+	Providers    string `json:"providers"`
+	DriftCommand string `json:"driftCommand,omitempty"`
+	DocsURL      string `json:"docsUrl"`
+	Detected     bool   `json:"detected"`
+	Status       string `json:"status"`
+}
+
+func BuildViewReport(workspace string, report AnalysisReport) ViewReport {
+	workspace = strings.TrimSpace(workspace)
+	if workspace == "" {
+		workspace = "local"
+	}
+
+	state := buildStateView(report)
+	remote := buildRemoteView(report)
+	drift := buildDriftView(report.Drift)
+	alternatives := buildAlternativeViews(report.Alternatives)
+	status := viewStatus(report, state, drift)
+
+	view := ViewReport{
+		GeneratedAt:     time.Now().UTC().Format(time.RFC3339),
+		Workspace:       workspace,
+		Path:            report.Path,
+		Tool:            report.Tool,
+		ToolPath:        report.ToolPath,
+		Status:          status,
+		Local:           buildLocalView(report),
+		State:           state,
+		Remote:          remote,
+		Drift:           drift,
+		Alternatives:    alternatives,
+		Warnings:        append([]string{}, report.Warnings...),
+		Recommendations: append([]string{}, report.Recommendations...),
+	}
+	view.Summary = buildViewSummary(view)
+	return view
+}
+
+func buildLocalView(report AnalysisReport) LocalView {
+	return LocalView{
+		Mode:            report.Mode,
+		FileCount:       len(report.Files),
+		Files:           append([]string{}, report.Files...),
+		ProviderSources: append([]string{}, report.ProviderSources...),
+		Modules:         append([]string{}, report.Modules...),
+		StaleArtifacts:  append([]StaleArtifact{}, report.StaleArtifacts...),
+	}
+}
+
+func buildStateView(report AnalysisReport) StateView {
+	source := "none"
+	backend := "none"
+	if len(report.Files) > 0 {
+		switch {
+		case report.Remote:
+			source = "remote"
+		case len(report.Backends) > 0:
+			source = "custom"
+		default:
+			source = "local"
+		}
+	}
+	if len(report.Backends) > 0 {
+		backend = strings.Join(report.Backends, ", ")
+	}
+
+	view := StateView{
+		Source:           source,
+		Backend:          backend,
+		Backends:         append([]string{}, report.Backends...),
+		HasRemoteBackend: report.Remote,
+		Availability:     "unavailable",
+	}
+	if report.State != nil {
+		view.Availability = "available"
+		if report.State.ResourceCount == 0 {
+			view.Availability = "empty"
+		}
+		view.ResourceCount = report.State.ResourceCount
+		view.ResourceTypes = copyStringIntMap(report.State.ResourceTypes)
+		view.Sample = append([]string{}, report.State.Sample...)
+	}
+	return view
+}
+
+func buildRemoteView(report AnalysisReport) RemoteView {
+	view := RemoteView{
+		Enabled:     report.Remote,
+		Backends:    append([]string{}, report.Backends...),
+		DriftStatus: "not-checked",
+	}
+	if report.Drift == nil {
+		return view
+	}
+	view.HasChanges = report.Drift.HasChanges
+	view.Command = report.Drift.Command
+	view.Summary = append([]string{}, report.Drift.Summary...)
+	view.Error = report.Drift.Error
+	view.DriftStatus = driftStatus(report.Drift)
+	return view
+}
+
+func buildDriftView(report *DriftReport) *DriftView {
+	if report == nil {
+		return nil
+	}
+	return &DriftView{
+		Checked:    report.Checked,
+		Status:     driftStatus(report),
+		HasChanges: report.HasChanges,
+		ExitCode:   report.ExitCode,
+		Command:    report.Command,
+		Summary:    append([]string{}, report.Summary...),
+		Output:     append([]string{}, report.Output...),
+		Error:      report.Error,
+	}
+}
+
+func buildAlternativeViews(alternatives []AlternativeTool) []AlternativeView {
+	views := make([]AlternativeView, 0, len(alternatives))
+	for _, alternative := range alternatives {
+		status := "missing"
+		if alternative.Detected {
+			status = "available"
+		}
+		views = append(views, AlternativeView{
+			Name:         alternative.Name,
+			Binary:       alternative.Binary,
+			Category:     alternative.Category,
+			Providers:    alternative.Providers,
+			DriftCommand: alternative.DriftCommand,
+			DocsURL:      alternative.DocsURL,
+			Detected:     alternative.Detected,
+			Status:       status,
+		})
+	}
+	return views
+}
+
+func viewStatus(report AnalysisReport, state StateView, drift *DriftView) string {
+	if drift != nil && drift.Status == "error" {
+		return "error"
+	}
+	if drift != nil && drift.HasChanges {
+		return "attention"
+	}
+	if len(report.StaleArtifacts) > 0 {
+		return "attention"
+	}
+	if len(report.Files) > 0 && state.Availability == "unavailable" {
+		return "warning"
+	}
+	if len(report.Warnings) > 0 {
+		return "warning"
+	}
+	if len(report.Files) == 0 {
+		return "warning"
+	}
+	return "ok"
+}
+
+func driftStatus(report *DriftReport) string {
+	if report == nil || !report.Checked {
+		return "not-checked"
+	}
+	if strings.TrimSpace(report.Error) != "" {
+		return "error"
+	}
+	if report.HasChanges {
+		return "changed"
+	}
+	return "in-sync"
+}
+
+func buildViewSummary(view ViewReport) []string {
+	summary := []string{
+		fmt.Sprintf("%d Terraform/OpenTofu file(s) in %s mode.", view.Local.FileCount, fallbackViewText(view.Local.Mode, "unknown")),
+		fmt.Sprintf("State source is %s via %s backend.", fallbackViewText(view.State.Source, "unknown"), fallbackViewText(view.State.Backend, "none")),
+	}
+	if view.State.Availability == "available" || view.State.Availability == "empty" {
+		summary = append(summary, fmt.Sprintf("%d resource(s) currently listed in state.", view.State.ResourceCount))
+	} else {
+		summary = append(summary, "State resources are unavailable from the selected environment.")
+	}
+	if view.Remote.Enabled {
+		summary = append(summary, fmt.Sprintf("Remote backend detected; drift status is %s.", view.Remote.DriftStatus))
+	} else {
+		summary = append(summary, fmt.Sprintf("Local/custom state mode; drift status is %s.", view.Remote.DriftStatus))
+	}
+	if detected := detectedAlternativeCount(view.Alternatives); detected > 0 {
+		summary = append(summary, fmt.Sprintf("%d IaC alternative tool(s) detected on PATH.", detected))
+	}
+	return summary
+}
+
+func detectedAlternativeCount(alternatives []AlternativeView) int {
+	count := 0
+	for _, alternative := range alternatives {
+		if alternative.Detected {
+			count++
+		}
+	}
+	return count
+}
+
+func fallbackViewText(value string, fallback string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func copyStringIntMap(values map[string]int) map[string]int {
+	if len(values) == 0 {
+		return nil
+	}
+	copied := make(map[string]int, len(values))
+	for key, value := range values {
+		copied[key] = value
+	}
+	return copied
+}
+
+func SortedResourceTypeLines(values map[string]int) []string {
+	lines := make([]string, 0, len(values))
+	for key, count := range values {
+		lines = append(lines, fmt.Sprintf("%s: %d", key, count))
+	}
+	sort.Strings(lines)
+	return lines
+}


### PR DESCRIPTION
## Summary
- add `clanker terraform view` for local config, state, remote backend, drift status, stale artifacts, and IaC alternatives
- expose text and JSON output built from the Terraform analyzer report
- add coverage for local/remote state and alternatives summaries

## Verification
- `go test ./...`
- `git diff --check`
- `go run . terraform view . --format json`