### PR TITLE
Fix Clanker Cloud LLM auth header

### DIFF
--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -1357,7 +1357,7 @@ func (c *Client) askClankerCloudMessages(ctx context.Context, messages []Message
 			return "", fmt.Errorf("failed to create request: %w", reqErr)
 		}
 		httpReq.Header.Set("Content-Type", "application/json")
-		applyModelProviderAuthHeader(httpReq, token)
+		httpReq.Header.Set("X-API-Key", strings.TrimSpace(token))
 		if strings.EqualFold(strings.TrimSpace(os.Getenv("CLANKER_CLOUD_CLIENT")), "desktop-app") {
 			httpReq.Header.Set("X-Clanker-Cloud-Client", "desktop-app")
 		}

--- a/internal/ai/codex_client_test.go
+++ b/internal/ai/codex_client_test.go
@@ -178,6 +178,41 @@ func TestAskCodexWithHistorySendsStoreFalseAndStreams(t *testing.T) {
 	}
 }
 
+func TestAskClankerCloudMessagesUsesAppTokenHeaders(t *testing.T) {
+	t.Setenv("CLANKER_CLOUD_CLIENT", "desktop-app")
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/llm/chat/completions" {
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
+		}
+		if auth := r.Header.Get("Authorization"); auth != "" {
+			t.Errorf("Clanker Cloud should not send app token through Authorization, got %q", auth)
+		}
+		if apiKey := r.Header.Get("X-API-Key"); apiKey != "cloud-token-xyz" {
+			t.Errorf("unexpected X-API-Key header: %q", apiKey)
+		}
+		if client := r.Header.Get("X-Clanker-Cloud-Client"); client != "desktop-app" {
+			t.Errorf("unexpected X-Clanker-Cloud-Client header: %q", client)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"cloud hello"}}]}`))
+	}))
+	defer mockServer.Close()
+
+	client := &Client{
+		provider: "clanker-cloud",
+		apiKey:   "cloud-token-xyz",
+		baseURL:  mockServer.URL + "/v1/llm",
+	}
+	result, err := client.askClankerCloudMessages(context.Background(), []Message{{Role: "user", Content: "say hello"}})
+	if err != nil {
+		t.Fatalf("askClankerCloudMessages failed: %v", err)
+	}
+	if result != "cloud hello" {
+		t.Fatalf("expected cloud hello, got %q", result)
+	}
+}
+
 func TestCodexInstructionsUsesSystemPrompt(t *testing.T) {
 	got := codexInstructions("  Be precise.  ")
 	if got != "Be precise." {


### PR DESCRIPTION
## Summary
- send Clanker Cloud LLM account tokens through X-API-Key instead of Authorization
- keep the desktop app client marker for app-launched CLI requests
- add regression coverage for the Clanker Cloud client headers

## Tests
- go test ./internal/ai -run 'TestAskClankerCloudMessagesUsesAppTokenHeaders|TestAskCodexWithHistorySendsStoreFalseAndStreams'
- go test ./internal/ai ./cmd