### PR TITLE
feat: add Clanker Box runtime

### DIFF
--- a/Dockerfile.clankerbox
+++ b/Dockerfile.clankerbox
@@ -9,9 +9,15 @@ RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/clanker .
 FROM debian:bookworm-slim
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates git openssh-client python3 nodejs npm \
+    && apt-get install -y --no-install-recommends bash ca-certificates curl git gnupg openssh-client python3 python3-venv \
+    && install -d -m 0755 /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends nodejs \
     && groupadd --system clankerbox \
     && useradd --system --create-home --gid clankerbox --shell /bin/sh clankerbox \
+    && mkdir -p /home/clankerbox/.local \
     && mkdir -p /workspace \
     && chown -R clankerbox:clankerbox /workspace /home/clankerbox \
     && rm -rf /var/lib/apt/lists/*
@@ -22,8 +28,11 @@ ENV CLANKER_BOX_AGENT=clanker-cli \
     CLANKER_BOX_REGION=us-central1 \
     CLANKER_BOX_REQUIRE_AUTH=true \
     CLANKER_BOX_ENABLE_TERMINAL=true \
+    CLANKER_BOX_AUTO_INSTALL=true \
     CLANKER_BOX_WORKDIR=/workspace \
     HOME=/home/clankerbox \
+    NPM_CONFIG_PREFIX=/home/clankerbox/.local \
+    PATH=/home/clankerbox/.local/bin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin \
     PORT=8080
 
 USER clankerbox

--- a/Dockerfile.clankerbox
+++ b/Dockerfile.clankerbox
@@ -1,0 +1,23 @@
+FROM golang:1.25-bookworm AS build
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/clanker .
+
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates git openssh-client python3 nodejs npm \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /out/clanker /usr/local/bin/clanker
+
+ENV CLANKER_BOX_AGENT=clanker-cli \
+    CLANKER_BOX_REGION=us-central1 \
+    CLANKER_BOX_REQUIRE_AUTH=true \
+    PORT=8080
+
+EXPOSE 8080
+ENTRYPOINT ["clanker", "box", "serve"]

--- a/Dockerfile.clankerbox
+++ b/Dockerfile.clankerbox
@@ -10,6 +10,10 @@ FROM debian:bookworm-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates git openssh-client python3 nodejs npm \
+    && groupadd --system clankerbox \
+    && useradd --system --create-home --gid clankerbox --shell /bin/sh clankerbox \
+    && mkdir -p /workspace \
+    && chown -R clankerbox:clankerbox /workspace /home/clankerbox \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /out/clanker /usr/local/bin/clanker
@@ -17,7 +21,12 @@ COPY --from=build /out/clanker /usr/local/bin/clanker
 ENV CLANKER_BOX_AGENT=clanker-cli \
     CLANKER_BOX_REGION=us-central1 \
     CLANKER_BOX_REQUIRE_AUTH=true \
+    CLANKER_BOX_ENABLE_TERMINAL=true \
+    CLANKER_BOX_WORKDIR=/workspace \
+    HOME=/home/clankerbox \
     PORT=8080
 
+USER clankerbox
+WORKDIR /workspace
 EXPOSE 8080
 ENTRYPOINT ["clanker", "box", "serve"]

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,14 @@ INSTALL_PATH ?= $(INSTALL_BIN)/$(BINARY_NAME)
 TAG ?= v0.0.0
 DIST_DIR ?= ./dist
 RELEASE_LDFLAGS := -X github.com/bgdnvk/clanker/cmd.Version=$(TAG)
+CLANKER_BOX_PROJECT ?= $(shell gcloud config get-value project 2>/dev/null)
+CLANKER_BOX_REGION ?= us-east4
+CLANKER_BOX_REPO ?= clanker
+CLANKER_BOX_IMAGE ?= $(CLANKER_BOX_REGION)-docker.pkg.dev/$(CLANKER_BOX_PROJECT)/$(CLANKER_BOX_REPO)/clanker-box:latest
 
 .PHONY: build build-all clean test test-short run install uninstall dev deps fmt vet lint docs quick ci help \
 	release-clean release-build-macos release-tar-macos release-sha release release-create release-upload \
-	setup-hermes
+	setup-hermes clanker-box-image clanker-box-image-push
 
 # Default target
 all: build
@@ -159,11 +163,24 @@ help:
 	@echo "  release-upload         - Upload tarballs to an existing GitHub release (TAG=vX.Y.Z)"
 	@echo "  release-clean          - Remove dist/ artifacts"
 	@echo "  setup-hermes           - Install Hermes Agent into vendor/hermes-agent"
+	@echo "  clanker-box-image      - Build the Clanker Box runtime image"
+	@echo "  clanker-box-image-push - Build and push the Clanker Box runtime image"
 
 # -------------------- Hermes Agent --------------------
 
 setup-hermes:
 	@bash scripts/setup-hermes.sh
+
+# -------------------- Clanker Box Runtime Image --------------------
+
+clanker-box-image:
+	@test -n "$(CLANKER_BOX_PROJECT)" || (echo "CLANKER_BOX_PROJECT is required" && exit 1)
+	@echo "Building Clanker Box runtime image: $(CLANKER_BOX_IMAGE)"
+	@docker build -f Dockerfile.clankerbox -t $(CLANKER_BOX_IMAGE) .
+
+clanker-box-image-push: clanker-box-image
+	@echo "Pushing Clanker Box runtime image: $(CLANKER_BOX_IMAGE)"
+	@docker push $(CLANKER_BOX_IMAGE)
 
 # -------------------- Release targets (macOS tarballs for Homebrew) --------------------
 

--- a/cmd/box.go
+++ b/cmd/box.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -73,6 +74,28 @@ func newBoxCmd() *cobra.Command {
 	manifestCmd.Flags().BoolVar(&requireAuth, "require-auth", true, "Require X-API-Key or Bearer token for message endpoints")
 	manifestCmd.Flags().IntVar(&websocketTimeout, "websocket-timeout-minutes", 60, "Cloud Run WebSocket request timeout target")
 
+	installCmd := &cobra.Command{
+		Use:   "install [agent|all]",
+		Short: "Install a Clanker Box agent runtime",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			if strings.EqualFold(strings.TrimSpace(args[0]), "all") {
+				results, err := clankerbox.InstallAllAgents(context.Background())
+				if encodeErr := enc.Encode(map[string]any{"ok": err == nil, "results": results}); encodeErr != nil {
+					return encodeErr
+				}
+				return err
+			}
+			result, err := clankerbox.InstallAgent(context.Background(), args[0])
+			if encodeErr := enc.Encode(map[string]any{"ok": err == nil, "result": result}); encodeErr != nil {
+				return encodeErr
+			}
+			return err
+		},
+	}
+
 	serveCmd := &cobra.Command{
 		Use:   "serve",
 		Short: "Serve a Clanker Box agent runtime over HTTP",
@@ -100,6 +123,6 @@ func newBoxCmd() *cobra.Command {
 	serveCmd.Flags().StringVar(&agent, "agent", "", "Agent to run")
 	serveCmd.Flags().StringVar(&region, "region", "", "Cloud Run region")
 
-	boxCmd.AddCommand(catalogCmd, manifestCmd, serveCmd)
+	boxCmd.AddCommand(catalogCmd, manifestCmd, installCmd, serveCmd)
 	return boxCmd
 }

--- a/cmd/box.go
+++ b/cmd/box.go
@@ -1,0 +1,105 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/bgdnvk/clanker/internal/clankerbox"
+	"github.com/spf13/cobra"
+)
+
+func newBoxCmd() *cobra.Command {
+	var agent string
+	var region string
+	var name string
+	var image string
+	var projectID string
+	var serviceAccount string
+	var artifactRepo string
+	var stateBucket string
+	var controlPlaneURL string
+	var requireAuth bool
+	var websocketTimeout int
+
+	boxCmd := &cobra.Command{
+		Use:   "box",
+		Short: "Run and describe Clanker Box agent sandboxes",
+	}
+
+	catalogCmd := &cobra.Command{
+		Use:   "catalog",
+		Short: "Print supported Clanker Box agents and regions",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]any{
+				"agents":  clankerbox.Agents(),
+				"regions": clankerbox.Regions(),
+			})
+		},
+	}
+
+	manifestCmd := &cobra.Command{
+		Use:   "manifest",
+		Short: "Print the Cloud Run runtime manifest for a Clanker Box",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			manifest, err := clankerbox.NewManifest(name, agent, region, clankerbox.ManifestOptions{
+				ProjectID:            projectID,
+				Image:                image,
+				ServiceAccountEmail:  serviceAccount,
+				ArtifactRepository:   artifactRepo,
+				StateBucket:          stateBucket,
+				ControlPlaneBaseURL:  controlPlaneURL,
+				RequireAuth:          requireAuth,
+				WebSocketTimeoutMins: websocketTimeout,
+			})
+			if err != nil {
+				return err
+			}
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode(manifest)
+		},
+	}
+	manifestCmd.Flags().StringVar(&name, "name", "clanker-box", "Box display name")
+	manifestCmd.Flags().StringVar(&agent, "agent", "clanker-cli", "Agent to run (hermes, openclaw, codex, claude-code, clanker-cli)")
+	manifestCmd.Flags().StringVar(&region, "region", "us-central1", "Cloud Run region")
+	manifestCmd.Flags().StringVar(&image, "image", "", "Container image URI")
+	manifestCmd.Flags().StringVar(&projectID, "project", "", "GCP project ID")
+	manifestCmd.Flags().StringVar(&serviceAccount, "service-account", "", "Runtime service account email")
+	manifestCmd.Flags().StringVar(&artifactRepo, "artifact-repo", "", "Artifact Registry repository")
+	manifestCmd.Flags().StringVar(&stateBucket, "state-bucket", "", "Cloud Storage state bucket")
+	manifestCmd.Flags().StringVar(&controlPlaneURL, "control-plane-url", "", "Clanker Cloud control-plane URL")
+	manifestCmd.Flags().BoolVar(&requireAuth, "require-auth", true, "Require X-API-Key or Bearer token for message endpoints")
+	manifestCmd.Flags().IntVar(&websocketTimeout, "websocket-timeout-minutes", 60, "Cloud Run WebSocket request timeout target")
+
+	serveCmd := &cobra.Command{
+		Use:   "serve",
+		Short: "Serve a Clanker Box agent runtime over HTTP",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg := clankerbox.RuntimeConfigFromEnv(Version)
+			if strings.TrimSpace(agent) != "" {
+				cfg.Agent = agent
+			}
+			if strings.TrimSpace(region) != "" {
+				cfg.Region = region
+			}
+			if strings.TrimSpace(name) != "" {
+				cfg.Name = name
+			}
+			port := strings.TrimSpace(os.Getenv("PORT"))
+			if port == "" {
+				port = "8080"
+			}
+			addr := ":" + port
+			fmt.Fprintf(cmd.ErrOrStderr(), "[clanker-box] serving %s in %s on %s\n", cfg.Agent, cfg.Region, addr)
+			return clankerbox.NewServer(cfg, nil).ListenAndServe(addr)
+		},
+	}
+	serveCmd.Flags().StringVar(&name, "name", "", "Box display name")
+	serveCmd.Flags().StringVar(&agent, "agent", "", "Agent to run")
+	serveCmd.Flags().StringVar(&region, "region", "", "Cloud Run region")
+
+	boxCmd.AddCommand(catalogCmd, manifestCmd, serveCmd)
+	return boxCmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -166,6 +166,8 @@ func init() {
 	// (`clanker ask --tencent ...`) will land in a later phase.
 	tencentCmd := tencent.CreateTencentCommands()
 	rootCmd.AddCommand(tencentCmd)
+
+	rootCmd.AddCommand(newBoxCmd())
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/internal/clankerbox/install.go
+++ b/internal/clankerbox/install.go
@@ -1,0 +1,185 @@
+package clankerbox
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type InstallResult struct {
+	Agent     string `json:"agent"`
+	Installed bool   `json:"installed"`
+	Command   string `json:"command,omitempty"`
+	Version   string `json:"version,omitempty"`
+	Output    string `json:"output,omitempty"`
+}
+
+func InstallAgent(ctx context.Context, rawAgent string) (InstallResult, error) {
+	agent, ok := AgentByID(rawAgent)
+	if !ok {
+		return InstallResult{}, fmt.Errorf("unsupported agent %q", strings.TrimSpace(rawAgent))
+	}
+	return installAgent(ctx, agent.ID)
+}
+
+func InstallAllAgents(ctx context.Context) ([]InstallResult, error) {
+	results := make([]InstallResult, 0, len(Agents()))
+	for _, agent := range Agents() {
+		result, err := installAgent(ctx, agent.ID)
+		results = append(results, result)
+		if err != nil {
+			return results, err
+		}
+	}
+	return results, nil
+}
+
+func ensureAgentInstalled(ctx context.Context, agentID string) error {
+	if !parseBoolEnv("CLANKER_BOX_AUTO_INSTALL", true) {
+		return nil
+	}
+	_, err := installAgent(ctx, agentID)
+	return err
+}
+
+func installAgent(parent context.Context, agentID string) (InstallResult, error) {
+	ctx, cancel := context.WithTimeout(parent, installTimeout())
+	defer cancel()
+	switch normalizeID(agentID) {
+	case "clanker-cli":
+		return installClankerCLI(ctx)
+	case "codex":
+		return installCodex(ctx)
+	case "claude-code":
+		return installClaudeCode(ctx)
+	case "openclaw":
+		return installOpenClaw(ctx)
+	case "hermes":
+		return installHermes(ctx)
+	default:
+		return InstallResult{}, fmt.Errorf("unsupported agent %q", agentID)
+	}
+}
+
+func installClankerCLI(ctx context.Context) (InstallResult, error) {
+	return ensureCommand(ctx, "clanker-cli", "clanker", []string{executable(), "--version"}, "")
+}
+
+func installCodex(ctx context.Context) (InstallResult, error) {
+	return ensureCommand(ctx, "codex", "codex", []string{"codex", "--version"}, "npm install -g @openai/codex@latest")
+}
+
+func installClaudeCode(ctx context.Context) (InstallResult, error) {
+	return ensureCommand(ctx, "claude-code", "claude", []string{"claude", "--version"}, "npm install -g @anthropic-ai/claude-code@latest")
+}
+
+func installOpenClaw(ctx context.Context) (InstallResult, error) {
+	return ensureCommand(ctx, "openclaw", "openclaw", []string{"openclaw", "--version"}, "npm install -g openclaw@latest")
+}
+
+func installHermes(ctx context.Context) (InstallResult, error) {
+	if path, err := findHermesVendorPath(); err == nil && path != "" {
+		return InstallResult{Agent: "hermes", Installed: true, Command: "vendor/hermes-agent", Version: path}, nil
+	}
+	workdir := terminalWorkingDir("")
+	vendorDir := filepath.Join(workdir, "vendor", "hermes-agent")
+	cmd := fmt.Sprintf(
+		`set -e; mkdir -p %q; if [ -d %q/.git ]; then git -C %q pull --recurse-submodules; git -C %q submodule update --init --recursive; else git clone --recurse-submodules https://github.com/NousResearch/hermes-agent.git %q; fi; cd %q; python3 -m venv .venv; .venv/bin/python -m pip install --upgrade pip wheel setuptools; .venv/bin/python -m pip install -e '.[all]'; if [ -d mini-swe-agent ] && [ -f mini-swe-agent/pyproject.toml ]; then .venv/bin/python -m pip install -e ./mini-swe-agent; fi; mkdir -p "$HOME/.local/bin"; if [ -x .venv/bin/hermes ]; then ln -sf %q "$HOME/.local/bin/hermes"; fi`,
+		filepath.Dir(vendorDir),
+		vendorDir,
+		vendorDir,
+		vendorDir,
+		vendorDir,
+		vendorDir,
+		filepath.Join(vendorDir, ".venv", "bin", "hermes"),
+	)
+	output, err := runShell(ctx, cmd)
+	result := InstallResult{Agent: "hermes", Command: "git clone https://github.com/NousResearch/hermes-agent.git", Output: output}
+	if err != nil {
+		return result, err
+	}
+	result.Installed = true
+	result.Version = vendorDir
+	return result, nil
+}
+
+func ensureCommand(ctx context.Context, agentID, binary string, versionCmd []string, installCmd string) (InstallResult, error) {
+	if path, err := exec.LookPath(binary); err == nil && path != "" {
+		version := ""
+		if len(versionCmd) > 0 {
+			out, _ := exec.CommandContext(ctx, versionCmd[0], versionCmd[1:]...).CombinedOutput()
+			version = strings.TrimSpace(string(out))
+		}
+		return InstallResult{Agent: agentID, Installed: true, Command: path, Version: version}, nil
+	}
+	if strings.TrimSpace(installCmd) == "" {
+		return InstallResult{Agent: agentID, Installed: false}, fmt.Errorf("%s is not installed", binary)
+	}
+	output, err := runShell(ctx, installCmd)
+	result := InstallResult{Agent: agentID, Command: installCmd, Output: output}
+	if err != nil {
+		return result, err
+	}
+	if path, err := exec.LookPath(binary); err == nil && path != "" {
+		result.Installed = true
+		result.Command = path
+		if len(versionCmd) > 0 {
+			out, _ := exec.CommandContext(ctx, versionCmd[0], versionCmd[1:]...).CombinedOutput()
+			result.Version = strings.TrimSpace(string(out))
+		}
+		return result, nil
+	}
+	return result, fmt.Errorf("%s install completed but binary was not found in PATH", binary)
+}
+
+func runShell(ctx context.Context, command string) (string, error) {
+	var stdout, stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, "sh", "-lc", command)
+	cmd.Dir = terminalWorkingDir("")
+	cmd.Env = os.Environ()
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	output := strings.TrimSpace(stdout.String() + "\n" + stderr.String())
+	if err != nil {
+		return trimTerminalOutput(output), fmt.Errorf("install command failed: %w: %s", err, trimTerminalOutput(output))
+	}
+	return trimTerminalOutput(output), nil
+}
+
+func installTimeout() time.Duration {
+	raw := strings.TrimSpace(os.Getenv("CLANKER_BOX_INSTALL_TIMEOUT_SECONDS"))
+	if raw == "" {
+		return 15 * time.Minute
+	}
+	duration, err := time.ParseDuration(raw)
+	if err == nil && duration > 0 {
+		return duration
+	}
+	duration, err = time.ParseDuration(raw + "s")
+	if err == nil && duration > 0 {
+		return duration
+	}
+	return 15 * time.Minute
+}
+
+func findHermesVendorPath() (string, error) {
+	if p := strings.TrimSpace(os.Getenv("CLANKER_BOX_HERMES_PATH")); p != "" && isHermesDir(p) {
+		return p, nil
+	}
+	candidate := filepath.Join(terminalWorkingDir(""), "vendor", "hermes-agent")
+	if isHermesDir(candidate) {
+		return candidate, nil
+	}
+	return "", fmt.Errorf("hermes vendor install not found")
+}
+
+func isHermesDir(path string) bool {
+	info, err := os.Stat(filepath.Join(path, ".venv", "bin", "python"))
+	return err == nil && !info.IsDir()
+}

--- a/internal/clankerbox/install.go
+++ b/internal/clankerbox/install.go
@@ -51,6 +51,8 @@ func installAgent(parent context.Context, agentID string) (InstallResult, error)
 	ctx, cancel := context.WithTimeout(parent, installTimeout())
 	defer cancel()
 	switch normalizeID(agentID) {
+	case "empty":
+		return InstallResult{Agent: "empty", Installed: true, Command: "sh", Version: "base-shell"}, nil
 	case "clanker-cli":
 		return installClankerCLI(ctx)
 	case "codex":

--- a/internal/clankerbox/server.go
+++ b/internal/clankerbox/server.go
@@ -3,6 +3,7 @@ package clankerbox
 import (
 	"bytes"
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -96,7 +97,7 @@ func NewServer(cfg RuntimeConfig, runner AgentRunner) *Server {
 func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", s.handleHealth)
-	mux.HandleFunc("/v1/box/info", s.handleInfo)
+	mux.HandleFunc("/v1/box/info", s.withAuth(s.handleInfo))
 	mux.HandleFunc("/v1/box/messages", s.withAuth(s.handleMessage))
 	mux.HandleFunc("/v1/box/ws", s.withAuth(s.handleWebSocket))
 	mux.HandleFunc("/v1/box/terminal", s.withAuth(s.handleTerminal))
@@ -113,12 +114,7 @@ func (s *Server) ListenAndServe(addr string) error {
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, map[string]any{
-		"ok":     true,
-		"name":   s.cfg.Name,
-		"agent":  s.cfg.Agent,
-		"region": s.cfg.Region,
-	})
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
 }
 
 func (s *Server) handleInfo(w http.ResponseWriter, r *http.Request) {
@@ -302,7 +298,7 @@ func (s *Server) withAuth(next http.HandlerFunc) http.HandlerFunc {
 		if got == "" {
 			got = strings.TrimSpace(r.URL.Query().Get("token"))
 		}
-		if got != expected {
+		if subtle.ConstantTimeCompare([]byte(got), []byte(expected)) != 1 {
 			writeJSON(w, http.StatusUnauthorized, map[string]any{"ok": false, "error": "unauthorized"})
 			return
 		}

--- a/internal/clankerbox/server.go
+++ b/internal/clankerbox/server.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 	"time"
 
@@ -34,12 +35,13 @@ type MessageRequest struct {
 }
 
 type MessageResponse struct {
-	OK        bool      `json:"ok"`
-	SessionID string    `json:"sessionId,omitempty"`
-	Agent     string    `json:"agent"`
-	Message   string    `json:"message,omitempty"`
-	Error     string    `json:"error,omitempty"`
-	CreatedAt time.Time `json:"createdAt"`
+	OK        bool              `json:"ok"`
+	SessionID string            `json:"sessionId,omitempty"`
+	Agent     string            `json:"agent"`
+	Message   string            `json:"message,omitempty"`
+	Error     string            `json:"error,omitempty"`
+	Terminal  *TerminalResponse `json:"terminal,omitempty"`
+	CreatedAt time.Time         `json:"createdAt"`
 }
 
 type TerminalRequest struct {
@@ -148,14 +150,12 @@ func (s *Server) handleMessage(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, MessageResponse{OK: false, Agent: s.cfg.Agent, Error: "invalid json", CreatedAt: time.Now().UTC()})
 		return
 	}
-	reply, err := s.run(r.Context(), req)
-	status := http.StatusOK
-	resp := MessageResponse{OK: err == nil, SessionID: req.SessionID, Agent: s.cfg.Agent, Message: reply, CreatedAt: time.Now().UTC()}
+	reply, terminal, err := s.run(r.Context(), req)
+	resp := MessageResponse{OK: err == nil, SessionID: req.SessionID, Agent: s.cfg.Agent, Message: reply, Terminal: terminal, CreatedAt: time.Now().UTC()}
 	if err != nil {
-		status = http.StatusBadGateway
 		resp.Error = err.Error()
 	}
-	writeJSON(w, status, resp)
+	writeJSON(w, http.StatusOK, resp)
 }
 
 func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
@@ -171,9 +171,9 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		ctx, cancel := context.WithTimeout(r.Context(), 10*time.Minute)
-		reply, runErr := s.run(ctx, req)
+		reply, terminal, runErr := s.run(ctx, req)
 		cancel()
-		resp := MessageResponse{OK: runErr == nil, SessionID: req.SessionID, Agent: s.cfg.Agent, Message: reply, CreatedAt: time.Now().UTC()}
+		resp := MessageResponse{OK: runErr == nil, SessionID: req.SessionID, Agent: s.cfg.Agent, Message: reply, Terminal: terminal, CreatedAt: time.Now().UTC()}
 		if runErr != nil {
 			resp.Error = runErr.Error()
 		}
@@ -195,11 +195,7 @@ func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		resp := s.runTerminal(r.Context(), req)
-		status := http.StatusOK
-		if !resp.OK {
-			status = http.StatusBadGateway
-		}
-		writeJSON(w, status, resp)
+		writeJSON(w, http.StatusOK, resp)
 		return
 	}
 	if r.Method != http.MethodGet {
@@ -244,7 +240,7 @@ func (s *Server) runTerminal(parent context.Context, req TerminalRequest) Termin
 	ctx, cancel := context.WithTimeout(parent, time.Duration(timeout)*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "sh", "-lc", req.Command)
+	cmd := exec.CommandContext(ctx, "sh", "-c", req.Command)
 	cmd.Dir = terminalWorkingDir(req.WorkingDir)
 	cmd.Env = append(os.Environ(),
 		"CLANKER_BOX_NAME="+s.cfg.Name,
@@ -269,15 +265,43 @@ func (s *Server) runTerminal(parent context.Context, req TerminalRequest) Termin
 	return resp
 }
 
-func (s *Server) run(ctx context.Context, req MessageRequest) (string, error) {
+func (s *Server) run(ctx context.Context, req MessageRequest) (string, *TerminalResponse, error) {
 	req.Message = strings.TrimSpace(req.Message)
 	if req.Message == "" {
-		return "", fmt.Errorf("message is required")
+		return "", nil, fmt.Errorf("message is required")
 	}
 	if _, ok := AgentByID(s.cfg.Agent); !ok {
-		return "", fmt.Errorf("unsupported agent %q", s.cfg.Agent)
+		return "", nil, fmt.Errorf("unsupported agent %q", s.cfg.Agent)
 	}
-	return s.runner.RunAgentMessage(ctx, s.cfg, req)
+	if terminalReq, ok := s.terminalRequestFromMessage(req); ok {
+		resp := s.runTerminal(ctx, terminalReq)
+		message := formatTerminalMessage(resp)
+		if resp.OK {
+			return message, &resp, nil
+		}
+		errMessage := resp.Error
+		if errMessage == "" {
+			errMessage = "terminal command failed"
+		}
+		return message, &resp, fmt.Errorf("%s", errMessage)
+	}
+	reply, err := s.runner.RunAgentMessage(ctx, s.cfg, req)
+	return reply, nil, err
+}
+
+func (s *Server) terminalRequestFromMessage(req MessageRequest) (TerminalRequest, bool) {
+	if !s.cfg.EnableTerminal {
+		return TerminalRequest{}, false
+	}
+	command, ok := terminalCommandFromMessage(req.Message, s.cfg.Agent)
+	if !ok {
+		return TerminalRequest{}, false
+	}
+	return TerminalRequest{
+		SessionID:      req.SessionID,
+		Command:        command,
+		TimeoutSeconds: 120,
+	}, true
 }
 
 func (s *Server) withAuth(next http.HandlerFunc) http.HandlerFunc {
@@ -331,6 +355,94 @@ func (DefaultRunner) RunAgentMessage(ctx context.Context, cfg RuntimeConfig, req
 	default:
 		return "", fmt.Errorf("unsupported agent %q", cfg.Agent)
 	}
+}
+
+func terminalCommandFromMessage(message string, agent string) (string, bool) {
+	text := strings.TrimSpace(message)
+	lower := strings.ToLower(text)
+	switch {
+	case strings.HasPrefix(text, "$ "):
+		return strings.TrimSpace(strings.TrimPrefix(text, "$ ")), true
+	case strings.HasPrefix(lower, "run "):
+		return strings.TrimSpace(text[4:]), true
+	case strings.HasPrefix(lower, "exec "):
+		return strings.TrimSpace(text[5:]), true
+	case strings.HasPrefix(lower, "execute "):
+		return strings.TrimSpace(text[8:]), true
+	case strings.HasPrefix(lower, "shell "):
+		return strings.TrimSpace(text[6:]), true
+	case strings.HasPrefix(lower, "terminal "):
+		return strings.TrimSpace(text[9:]), true
+	case lower == "doctor" || strings.Contains(lower, "cloud doctor"):
+		return "clanker cloud doctor", true
+	case strings.HasPrefix(lower, "install "):
+		target := strings.TrimSpace(text[len("install "):])
+		return installCommandFromChat(target, agent), true
+	default:
+		return "", false
+	}
+}
+
+func installCommandFromChat(target string, agent string) string {
+	normalized := normalizeID(target)
+	normalized = strings.TrimPrefix(normalized, "the-")
+	normalized = strings.TrimSuffix(normalized, "-agent")
+	switch normalized {
+	case "codex", "openai-codex":
+		return "clanker box install codex"
+	case "claude", "claude-code", "anthropic-claude-code":
+		return "clanker box install claude-code"
+	case "hermes", "nous-hermes":
+		return "clanker box install hermes"
+	case "openclaw", "open-claw":
+		return "clanker box install openclaw"
+	case "clanker", "clanker-cli", "cli":
+		return "clanker box install clanker-cli && clanker --version"
+	case "docker", "docker-cli":
+		return dockerCLIInstallCommand()
+	case "":
+		if normalizeID(agent) == "empty" {
+			return "pwd && ls -la"
+		}
+		return "clanker box install " + normalizeID(agent)
+	default:
+		return fmt.Sprintf("if command -v %s >/dev/null 2>&1; then %s --version || true; else printf 'No built-in installer for %s. Use the terminal to run the official installer.\\n'; exit 1; fi", shellQuoteWord(normalized), shellQuoteWord(normalized), shellQuoteWord(target))
+	}
+}
+
+func dockerCLIInstallCommand() string {
+	return `set -e; export PATH="$HOME/.local/bin:$PATH"; arch="$(uname -m)"; case "$arch" in x86_64|amd64) docker_arch=x86_64 ;; aarch64|arm64) docker_arch=aarch64 ;; *) echo "unsupported docker static binary arch: $arch"; exit 1 ;; esac; mkdir -p "$HOME/.local/bin" "$HOME/.cache/clanker-box/docker"; cd "$HOME/.cache/clanker-box/docker"; curl -fsSL "https://download.docker.com/linux/static/stable/${docker_arch}/docker-27.5.1.tgz" -o docker.tgz; tar -xzf docker.tgz; cp docker/docker "$HOME/.local/bin/docker"; chmod +x "$HOME/.local/bin/docker"; "$HOME/.local/bin/docker" --version; printf '\nDocker CLI installed in $HOME/.local/bin. Cloud Run does not provide a Docker daemon, so docker build/run needs a remote daemon or Cloud Build.\n'`
+}
+
+func formatTerminalMessage(resp TerminalResponse) string {
+	var b strings.Builder
+	if resp.Command != "" {
+		b.WriteString("Executed in Clanker Box terminal:\n$ ")
+		b.WriteString(resp.Command)
+		b.WriteString("\n")
+	}
+	if strings.TrimSpace(resp.Output) != "" {
+		b.WriteString(resp.Output)
+		b.WriteString("\n")
+	}
+	if resp.Error != "" {
+		b.WriteString("exit ")
+		b.WriteString(fmt.Sprint(resp.ExitCode))
+		b.WriteString(": ")
+		b.WriteString(resp.Error)
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func shellQuoteWord(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "''"
+	}
+	if regexp.MustCompile(`^[a-zA-Z0-9._/-]+$`).MatchString(value) {
+		return value
+	}
+	return "'" + strings.ReplaceAll(value, "'", `'"'"'`) + "'"
 }
 
 func runHermes(ctx context.Context, message string) (string, error) {

--- a/internal/clankerbox/server.go
+++ b/internal/clankerbox/server.go
@@ -192,6 +192,20 @@ func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusForbidden, map[string]any{"ok": false, "error": "terminal access is disabled"})
 		return
 	}
+	if r.Method == http.MethodPost {
+		var req TerminalRequest
+		if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, TerminalResponse{OK: false, Error: "invalid json", ExitCode: 1, CreatedAt: time.Now().UTC()})
+			return
+		}
+		resp := s.runTerminal(r.Context(), req)
+		status := http.StatusOK
+		if !resp.OK {
+			status = http.StatusBadGateway
+		}
+		writeJSON(w, status, resp)
+		return
+	}
 	if r.Method != http.MethodGet {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
@@ -299,6 +313,9 @@ func (s *Server) withAuth(next http.HandlerFunc) http.HandlerFunc {
 type DefaultRunner struct{}
 
 func (DefaultRunner) RunAgentMessage(ctx context.Context, cfg RuntimeConfig, req MessageRequest) (string, error) {
+	if err := ensureAgentInstalled(ctx, cfg.Agent); err != nil {
+		return "", err
+	}
 	switch normalizeID(cfg.Agent) {
 	case "hermes":
 		return runHermes(ctx, req.Message)

--- a/internal/clankerbox/server.go
+++ b/internal/clankerbox/server.go
@@ -17,12 +17,13 @@ import (
 )
 
 type RuntimeConfig struct {
-	Name        string `json:"name"`
-	Agent       string `json:"agent"`
-	Region      string `json:"region"`
-	RequireAuth bool   `json:"requireAuth"`
-	APIToken    string `json:"-"`
-	Version     string `json:"version,omitempty"`
+	Name           string `json:"name"`
+	Agent          string `json:"agent"`
+	Region         string `json:"region"`
+	RequireAuth    bool   `json:"requireAuth"`
+	EnableTerminal bool   `json:"enableTerminal"`
+	APIToken       string `json:"-"`
+	Version        string `json:"version,omitempty"`
 }
 
 type MessageRequest struct {
@@ -40,6 +41,23 @@ type MessageResponse struct {
 	CreatedAt time.Time `json:"createdAt"`
 }
 
+type TerminalRequest struct {
+	SessionID      string `json:"sessionId,omitempty"`
+	Command        string `json:"command"`
+	WorkingDir     string `json:"workingDir,omitempty"`
+	TimeoutSeconds int    `json:"timeoutSeconds,omitempty"`
+}
+
+type TerminalResponse struct {
+	OK        bool      `json:"ok"`
+	SessionID string    `json:"sessionId,omitempty"`
+	Command   string    `json:"command,omitempty"`
+	Output    string    `json:"output,omitempty"`
+	Error     string    `json:"error,omitempty"`
+	ExitCode  int       `json:"exitCode"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
 type AgentRunner interface {
 	RunAgentMessage(ctx context.Context, cfg RuntimeConfig, req MessageRequest) (string, error)
 }
@@ -52,12 +70,13 @@ type Server struct {
 
 func RuntimeConfigFromEnv(version string) RuntimeConfig {
 	return RuntimeConfig{
-		Name:        envOr("CLANKER_BOX_NAME", "clanker-box"),
-		Agent:       envOr("CLANKER_BOX_AGENT", "clanker-cli"),
-		Region:      envOr("CLANKER_BOX_REGION", "us-central1"),
-		RequireAuth: parseBoolEnv("CLANKER_BOX_REQUIRE_AUTH", true),
-		APIToken:    strings.TrimSpace(os.Getenv("CLANKER_BOX_API_TOKEN")),
-		Version:     version,
+		Name:           envOr("CLANKER_BOX_NAME", "clanker-box"),
+		Agent:          envOr("CLANKER_BOX_AGENT", "clanker-cli"),
+		Region:         envOr("CLANKER_BOX_REGION", "us-central1"),
+		RequireAuth:    parseBoolEnv("CLANKER_BOX_REQUIRE_AUTH", true),
+		EnableTerminal: parseBoolEnv("CLANKER_BOX_ENABLE_TERMINAL", true),
+		APIToken:       strings.TrimSpace(os.Getenv("CLANKER_BOX_API_TOKEN")),
+		Version:        version,
 	}
 }
 
@@ -80,6 +99,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/v1/box/info", s.handleInfo)
 	mux.HandleFunc("/v1/box/messages", s.withAuth(s.handleMessage))
 	mux.HandleFunc("/v1/box/ws", s.withAuth(s.handleWebSocket))
+	mux.HandleFunc("/v1/box/terminal", s.withAuth(s.handleTerminal))
 	return mux
 }
 
@@ -110,12 +130,14 @@ func (s *Server) handleInfo(w http.ResponseWriter, r *http.Request) {
 		"agent":       agent,
 		"region":      region,
 		"requireAuth": s.cfg.RequireAuth,
+		"terminal":    s.cfg.EnableTerminal,
 		"version":     s.cfg.Version,
 		"endpoints": []EndpointSpec{
 			{Kind: "health", Path: "/healthz", Description: "Liveness check."},
 			{Kind: "info", Path: "/v1/box/info", Description: "Runtime metadata."},
 			{Kind: "message", Path: "/v1/box/messages", Description: "JSON message endpoint."},
 			{Kind: "websocket", Path: "/v1/box/ws", Description: "Bidirectional message endpoint."},
+			{Kind: "terminal", Path: "/v1/box/terminal", Description: "Authenticated WebSocket shell endpoint for box access."},
 		},
 	})
 }
@@ -163,6 +185,78 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+}
+
+func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request) {
+	if !s.cfg.EnableTerminal {
+		writeJSON(w, http.StatusForbidden, map[string]any{"ok": false, "error": "terminal access is disabled"})
+		return
+	}
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	conn, err := s.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+
+	for {
+		var req TerminalRequest
+		if err := conn.ReadJSON(&req); err != nil {
+			return
+		}
+		resp := s.runTerminal(r.Context(), req)
+		if err := conn.WriteJSON(resp); err != nil {
+			return
+		}
+	}
+}
+
+func (s *Server) runTerminal(parent context.Context, req TerminalRequest) TerminalResponse {
+	req.Command = strings.TrimSpace(req.Command)
+	resp := TerminalResponse{
+		OK:        false,
+		SessionID: req.SessionID,
+		Command:   req.Command,
+		ExitCode:  1,
+		CreatedAt: time.Now().UTC(),
+	}
+	if req.Command == "" {
+		resp.Error = "command is required"
+		return resp
+	}
+	timeout := req.TimeoutSeconds
+	if timeout <= 0 || timeout > 120 {
+		timeout = 120
+	}
+	ctx, cancel := context.WithTimeout(parent, time.Duration(timeout)*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "sh", "-lc", req.Command)
+	cmd.Dir = terminalWorkingDir(req.WorkingDir)
+	cmd.Env = append(os.Environ(),
+		"CLANKER_BOX_NAME="+s.cfg.Name,
+		"CLANKER_BOX_AGENT="+s.cfg.Agent,
+		"CLANKER_BOX_REGION="+s.cfg.Region,
+	)
+	output, err := cmd.CombinedOutput()
+	resp.Output = trimTerminalOutput(string(output))
+	if ctx.Err() == context.DeadlineExceeded {
+		resp.Error = "command timed out"
+		return resp
+	}
+	if err != nil {
+		resp.Error = err.Error()
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			resp.ExitCode = exitErr.ExitCode()
+		}
+		return resp
+	}
+	resp.OK = true
+	resp.ExitCode = 0
+	return resp
 }
 
 func (s *Server) run(ctx context.Context, req MessageRequest) (string, error) {
@@ -273,6 +367,27 @@ func executable() string {
 		return path
 	}
 	return "clanker"
+}
+
+func terminalWorkingDir(requested string) string {
+	if requested = strings.TrimSpace(requested); requested != "" {
+		return requested
+	}
+	if workdir := strings.TrimSpace(os.Getenv("CLANKER_BOX_WORKDIR")); workdir != "" {
+		return workdir
+	}
+	if workdir, err := os.Getwd(); err == nil && strings.TrimSpace(workdir) != "" {
+		return workdir
+	}
+	return "/workspace"
+}
+
+func trimTerminalOutput(output string) string {
+	const maxTerminalOutputBytes = 64 * 1024
+	if len(output) <= maxTerminalOutputBytes {
+		return output
+	}
+	return "[output truncated]\n" + output[len(output)-maxTerminalOutputBytes:]
 }
 
 func writeJSON(w http.ResponseWriter, status int, payload any) {

--- a/internal/clankerbox/server.go
+++ b/internal/clankerbox/server.go
@@ -313,6 +313,8 @@ func (DefaultRunner) RunAgentMessage(ctx context.Context, cfg RuntimeConfig, req
 		return "", err
 	}
 	switch normalizeID(cfg.Agent) {
+	case "empty":
+		return "Empty sandbox is running. Use the terminal endpoint to run shell commands.", nil
 	case "hermes":
 		return runHermes(ctx, req.Message)
 	case "claude-code":

--- a/internal/clankerbox/server.go
+++ b/internal/clankerbox/server.go
@@ -1,0 +1,301 @@
+package clankerbox
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/bgdnvk/clanker/internal/claudecode"
+	"github.com/bgdnvk/clanker/internal/hermes"
+	"github.com/gorilla/websocket"
+)
+
+type RuntimeConfig struct {
+	Name        string `json:"name"`
+	Agent       string `json:"agent"`
+	Region      string `json:"region"`
+	RequireAuth bool   `json:"requireAuth"`
+	APIToken    string `json:"-"`
+	Version     string `json:"version,omitempty"`
+}
+
+type MessageRequest struct {
+	SessionID string         `json:"sessionId,omitempty"`
+	Message   string         `json:"message"`
+	Context   map[string]any `json:"context,omitempty"`
+}
+
+type MessageResponse struct {
+	OK        bool      `json:"ok"`
+	SessionID string    `json:"sessionId,omitempty"`
+	Agent     string    `json:"agent"`
+	Message   string    `json:"message,omitempty"`
+	Error     string    `json:"error,omitempty"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+type AgentRunner interface {
+	RunAgentMessage(ctx context.Context, cfg RuntimeConfig, req MessageRequest) (string, error)
+}
+
+type Server struct {
+	cfg      RuntimeConfig
+	runner   AgentRunner
+	upgrader websocket.Upgrader
+}
+
+func RuntimeConfigFromEnv(version string) RuntimeConfig {
+	return RuntimeConfig{
+		Name:        envOr("CLANKER_BOX_NAME", "clanker-box"),
+		Agent:       envOr("CLANKER_BOX_AGENT", "clanker-cli"),
+		Region:      envOr("CLANKER_BOX_REGION", "us-central1"),
+		RequireAuth: parseBoolEnv("CLANKER_BOX_REQUIRE_AUTH", true),
+		APIToken:    strings.TrimSpace(os.Getenv("CLANKER_BOX_API_TOKEN")),
+		Version:     version,
+	}
+}
+
+func NewServer(cfg RuntimeConfig, runner AgentRunner) *Server {
+	if runner == nil {
+		runner = DefaultRunner{}
+	}
+	return &Server{
+		cfg:    cfg,
+		runner: runner,
+		upgrader: websocket.Upgrader{
+			CheckOrigin: func(r *http.Request) bool { return true },
+		},
+	}
+}
+
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", s.handleHealth)
+	mux.HandleFunc("/v1/box/info", s.handleInfo)
+	mux.HandleFunc("/v1/box/messages", s.withAuth(s.handleMessage))
+	mux.HandleFunc("/v1/box/ws", s.withAuth(s.handleWebSocket))
+	return mux
+}
+
+func (s *Server) ListenAndServe(addr string) error {
+	server := &http.Server{
+		Addr:              addr,
+		Handler:           s.Handler(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	return server.ListenAndServe()
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok":     true,
+		"name":   s.cfg.Name,
+		"agent":  s.cfg.Agent,
+		"region": s.cfg.Region,
+	})
+}
+
+func (s *Server) handleInfo(w http.ResponseWriter, r *http.Request) {
+	agent, _ := AgentByID(s.cfg.Agent)
+	region, _ := RegionByID(s.cfg.Region)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok":          true,
+		"name":        s.cfg.Name,
+		"agent":       agent,
+		"region":      region,
+		"requireAuth": s.cfg.RequireAuth,
+		"version":     s.cfg.Version,
+		"endpoints": []EndpointSpec{
+			{Kind: "health", Path: "/healthz", Description: "Liveness check."},
+			{Kind: "info", Path: "/v1/box/info", Description: "Runtime metadata."},
+			{Kind: "message", Path: "/v1/box/messages", Description: "JSON message endpoint."},
+			{Kind: "websocket", Path: "/v1/box/ws", Description: "Bidirectional message endpoint."},
+		},
+	})
+}
+
+func (s *Server) handleMessage(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	var req MessageRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, MessageResponse{OK: false, Agent: s.cfg.Agent, Error: "invalid json", CreatedAt: time.Now().UTC()})
+		return
+	}
+	reply, err := s.run(r.Context(), req)
+	status := http.StatusOK
+	resp := MessageResponse{OK: err == nil, SessionID: req.SessionID, Agent: s.cfg.Agent, Message: reply, CreatedAt: time.Now().UTC()}
+	if err != nil {
+		status = http.StatusBadGateway
+		resp.Error = err.Error()
+	}
+	writeJSON(w, status, resp)
+}
+
+func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
+	conn, err := s.upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+
+	for {
+		var req MessageRequest
+		if err := conn.ReadJSON(&req); err != nil {
+			return
+		}
+		ctx, cancel := context.WithTimeout(r.Context(), 10*time.Minute)
+		reply, runErr := s.run(ctx, req)
+		cancel()
+		resp := MessageResponse{OK: runErr == nil, SessionID: req.SessionID, Agent: s.cfg.Agent, Message: reply, CreatedAt: time.Now().UTC()}
+		if runErr != nil {
+			resp.Error = runErr.Error()
+		}
+		if err := conn.WriteJSON(resp); err != nil {
+			return
+		}
+	}
+}
+
+func (s *Server) run(ctx context.Context, req MessageRequest) (string, error) {
+	req.Message = strings.TrimSpace(req.Message)
+	if req.Message == "" {
+		return "", fmt.Errorf("message is required")
+	}
+	if _, ok := AgentByID(s.cfg.Agent); !ok {
+		return "", fmt.Errorf("unsupported agent %q", s.cfg.Agent)
+	}
+	return s.runner.RunAgentMessage(ctx, s.cfg, req)
+}
+
+func (s *Server) withAuth(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !s.cfg.RequireAuth {
+			next(w, r)
+			return
+		}
+		expected := strings.TrimSpace(s.cfg.APIToken)
+		if expected == "" {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]any{"ok": false, "error": "box auth token is not configured"})
+			return
+		}
+		got := strings.TrimSpace(r.Header.Get("X-API-Key"))
+		if got == "" {
+			got = strings.TrimSpace(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
+		}
+		if got == "" {
+			got = strings.TrimSpace(r.URL.Query().Get("token"))
+		}
+		if got != expected {
+			writeJSON(w, http.StatusUnauthorized, map[string]any{"ok": false, "error": "unauthorized"})
+			return
+		}
+		next(w, r)
+	}
+}
+
+type DefaultRunner struct{}
+
+func (DefaultRunner) RunAgentMessage(ctx context.Context, cfg RuntimeConfig, req MessageRequest) (string, error) {
+	switch normalizeID(cfg.Agent) {
+	case "hermes":
+		return runHermes(ctx, req.Message)
+	case "claude-code":
+		return runClaudeCode(ctx, req.Message)
+	case "clanker-cli":
+		return runCommand(ctx, "CLANKER_BOX_CLANKER_COMMAND", []string{executable(), "ask", req.Message}, req.Message)
+	case "codex":
+		return runCommand(ctx, "CLANKER_BOX_CODEX_COMMAND", []string{"codex", "exec", "--skip-git-repo-check", req.Message}, req.Message)
+	case "openclaw":
+		if url := strings.TrimSpace(os.Getenv("CLANKER_BOX_OPENCLAW_URL")); url != "" {
+			return "OpenClaw gateway is attached at " + url, nil
+		}
+		return runCommand(ctx, "CLANKER_BOX_OPENCLAW_COMMAND", []string{"openclaw", "agent", req.Message}, req.Message)
+	default:
+		return "", fmt.Errorf("unsupported agent %q", cfg.Agent)
+	}
+}
+
+func runHermes(ctx context.Context, message string) (string, error) {
+	path, err := hermes.FindHermesPath()
+	if err != nil {
+		return "", err
+	}
+	runner := hermes.NewRunner(path, parseBoolEnv("CLANKER_BOX_DEBUG", false))
+	if err := runner.Start(ctx); err != nil {
+		return "", err
+	}
+	defer runner.Stop()
+	return runner.PromptSync(ctx, message)
+}
+
+func runClaudeCode(ctx context.Context, message string) (string, error) {
+	runner := claudecode.NewRunner(parseBoolEnv("CLANKER_BOX_DEBUG", false))
+	return runner.AskSync(ctx, message)
+}
+
+func runCommand(ctx context.Context, envKey string, fallback []string, prompt string) (string, error) {
+	if custom := strings.TrimSpace(os.Getenv(envKey)); custom != "" {
+		cmd := exec.CommandContext(ctx, "sh", "-lc", custom)
+		cmd.Env = append(os.Environ(), "CLANKER_BOX_PROMPT="+prompt)
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			return "", fmt.Errorf("%s failed: %w: %s", envKey, err, strings.TrimSpace(stderr.String()))
+		}
+		return strings.TrimSpace(stdout.String()), nil
+	}
+	if len(fallback) == 0 {
+		return "", fmt.Errorf("no command configured")
+	}
+	cmd := exec.CommandContext(ctx, fallback[0], fallback[1:]...)
+	cmd.Env = os.Environ()
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%s failed: %w: %s", fallback[0], err, strings.TrimSpace(stderr.String()))
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+func executable() string {
+	if path, err := os.Executable(); err == nil && strings.TrimSpace(path) != "" {
+		return path
+	}
+	return "clanker"
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func envOr(key, fallback string) string {
+	if val := strings.TrimSpace(os.Getenv(key)); val != "" {
+		return val
+	}
+	return fallback
+}
+
+func parseBoolEnv(key string, fallback bool) bool {
+	value := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
+	switch value {
+	case "1", "true", "yes", "on":
+		return true
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return fallback
+	}
+}

--- a/internal/clankerbox/spec.go
+++ b/internal/clankerbox/spec.go
@@ -227,6 +227,7 @@ func NewManifest(name, agentID, regionID string, opts ManifestOptions) (Manifest
 		"CLANKER_BOX_REGION":          region.ID,
 		"CLANKER_BOX_REQUIRE_AUTH":    fmt.Sprintf("%t", opts.RequireAuth),
 		"CLANKER_BOX_ENABLE_TERMINAL": "true",
+		"CLANKER_BOX_AUTO_INSTALL":    "true",
 		"CLANKER_BOX_WORKDIR":         "/workspace",
 	}
 	if opts.ControlPlaneBaseURL != "" {

--- a/internal/clankerbox/spec.go
+++ b/internal/clankerbox/spec.go
@@ -89,6 +89,14 @@ var serviceNameRE = regexp.MustCompile(`[^a-z0-9-]+`)
 func Agents() []AgentSpec {
 	return []AgentSpec{
 		{
+			ID:             "empty",
+			Name:           "Empty Sandbox",
+			Summary:        "Basic shell environment with terminal access and no preselected agent.",
+			Runtime:        "base-shell",
+			Status:         "ready",
+			DefaultCommand: []string{"clanker", "box", "serve", "--agent", "empty"},
+		},
+		{
 			ID:              "hermes",
 			Name:            "Hermes",
 			Summary:         "Hermes agent bridge for autonomous infrastructure and code tasks.",
@@ -231,6 +239,9 @@ func NewManifest(name, agentID, regionID string, opts ManifestOptions) (Manifest
 		"CLANKER_BOX_AUTO_INSTALL":    "true",
 		"CLANKER_BOX_WORKDIR":         "/workspace",
 	}
+	if agent.ID == "empty" {
+		env["CLANKER_BOX_AUTO_INSTALL"] = "false"
+	}
 	if opts.ControlPlaneBaseURL != "" {
 		env["CLANKER_BOX_CONTROL_PLANE_URL"] = strings.TrimRight(opts.ControlPlaneBaseURL, "/")
 	}
@@ -333,6 +344,8 @@ func normalizeID(raw string) string {
 		return "clanker-cli"
 	case "openai-codex":
 		return "codex"
+	case "base", "blank", "empty-sandbox", "shell":
+		return "empty"
 	default:
 		return id
 	}

--- a/internal/clankerbox/spec.go
+++ b/internal/clankerbox/spec.go
@@ -1,0 +1,290 @@
+package clankerbox
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+type AgentSpec struct {
+	ID              string   `json:"id"`
+	Name            string   `json:"name"`
+	Summary         string   `json:"summary"`
+	Runtime         string   `json:"runtime"`
+	Status          string   `json:"status"`
+	DefaultCommand  []string `json:"defaultCommand,omitempty"`
+	RequiredSecrets []string `json:"requiredSecrets,omitempty"`
+}
+
+type RegionSpec struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Tier   string `json:"tier"`
+	LowCO2 bool   `json:"lowCo2,omitempty"`
+}
+
+type EndpointSpec struct {
+	Kind        string `json:"kind"`
+	Path        string `json:"path"`
+	Description string `json:"description"`
+}
+
+type ManifestOptions struct {
+	ProjectID            string
+	Image                string
+	ServiceAccountEmail  string
+	ArtifactRepository   string
+	StateBucket          string
+	ControlPlaneBaseURL  string
+	RequireAuth          bool
+	WebSocketTimeoutMins int
+}
+
+type Manifest struct {
+	Name                 string            `json:"name"`
+	ServiceName          string            `json:"serviceName"`
+	Agent                AgentSpec         `json:"agent"`
+	Region               RegionSpec        `json:"region"`
+	Image                string            `json:"image,omitempty"`
+	ProjectID            string            `json:"projectId,omitempty"`
+	ServiceAccountEmail  string            `json:"serviceAccountEmail,omitempty"`
+	ArtifactRepository   string            `json:"artifactRepository,omitempty"`
+	StateBucket          string            `json:"stateBucket,omitempty"`
+	RequireAuth          bool              `json:"requireAuth"`
+	WebSocketTimeoutMins int               `json:"webSocketTimeoutMins"`
+	Environment          map[string]string `json:"environment"`
+	Endpoints            []EndpointSpec    `json:"endpoints"`
+	IAMRoles             []string          `json:"iamRoles"`
+	Labels               map[string]string `json:"labels"`
+}
+
+var serviceNameRE = regexp.MustCompile(`[^a-z0-9-]+`)
+
+func Agents() []AgentSpec {
+	return []AgentSpec{
+		{
+			ID:              "hermes",
+			Name:            "Hermes",
+			Summary:         "Hermes agent bridge for autonomous infrastructure and code tasks.",
+			Runtime:         "python-bridge",
+			Status:          "adapter",
+			DefaultCommand:  []string{"clanker", "box", "serve", "--agent", "hermes"},
+			RequiredSecrets: []string{"OPENAI_API_KEY or ANTHROPIC_API_KEY"},
+		},
+		{
+			ID:              "openclaw",
+			Name:            "OpenClaw",
+			Summary:         "OpenClaw gateway adapter for browser/control-plane agent sessions.",
+			Runtime:         "gateway-adapter",
+			Status:          "adapter",
+			DefaultCommand:  []string{"clanker", "box", "serve", "--agent", "openclaw"},
+			RequiredSecrets: []string{"OPENCLAW_GATEWAY_TOKEN"},
+		},
+		{
+			ID:              "codex",
+			Name:            "Codex",
+			Summary:         "OpenAI Codex CLI adapter for sandboxed coding tasks.",
+			Runtime:         "cli-adapter",
+			Status:          "adapter",
+			DefaultCommand:  []string{"clanker", "box", "serve", "--agent", "codex"},
+			RequiredSecrets: []string{"CODEX_AUTH or OPENAI_API_KEY"},
+		},
+		{
+			ID:              "claude-code",
+			Name:            "Claude Code",
+			Summary:         "Anthropic Claude Code CLI adapter for code and shell workflows.",
+			Runtime:         "cli-adapter",
+			Status:          "adapter",
+			DefaultCommand:  []string{"clanker", "box", "serve", "--agent", "claude-code"},
+			RequiredSecrets: []string{"ANTHROPIC_API_KEY or Claude Code login"},
+		},
+		{
+			ID:             "clanker-cli",
+			Name:           "Clanker CLI",
+			Summary:        "Native Clanker CLI runtime for cloud operations and MCP-compatible workflows.",
+			Runtime:        "native-cli",
+			Status:         "ready",
+			DefaultCommand: []string{"clanker", "box", "serve", "--agent", "clanker-cli"},
+		},
+	}
+}
+
+func Regions() []RegionSpec {
+	return []RegionSpec{
+		{ID: "us-central1", Name: "Iowa", Tier: "1", LowCO2: true},
+		{ID: "us-east1", Name: "South Carolina", Tier: "1"},
+		{ID: "us-east4", Name: "Northern Virginia", Tier: "1"},
+		{ID: "us-east5", Name: "Columbus", Tier: "1"},
+		{ID: "us-south1", Name: "Dallas", Tier: "1", LowCO2: true},
+		{ID: "us-west1", Name: "Oregon", Tier: "1", LowCO2: true},
+		{ID: "us-west2", Name: "Los Angeles", Tier: "2"},
+		{ID: "us-west3", Name: "Salt Lake City", Tier: "2"},
+		{ID: "us-west4", Name: "Las Vegas", Tier: "2"},
+		{ID: "northamerica-northeast1", Name: "Montreal", Tier: "2", LowCO2: true},
+		{ID: "northamerica-northeast2", Name: "Toronto", Tier: "2", LowCO2: true},
+		{ID: "northamerica-south1", Name: "Mexico", Tier: "1"},
+		{ID: "southamerica-east1", Name: "Sao Paulo", Tier: "2", LowCO2: true},
+		{ID: "southamerica-west1", Name: "Santiago", Tier: "2", LowCO2: true},
+		{ID: "europe-west1", Name: "Belgium", Tier: "1", LowCO2: true},
+		{ID: "europe-west2", Name: "London", Tier: "2", LowCO2: true},
+		{ID: "europe-west3", Name: "Frankfurt", Tier: "2"},
+		{ID: "europe-west4", Name: "Netherlands", Tier: "1", LowCO2: true},
+		{ID: "europe-west6", Name: "Zurich", Tier: "2", LowCO2: true},
+		{ID: "europe-west8", Name: "Milan", Tier: "1"},
+		{ID: "europe-west9", Name: "Paris", Tier: "1", LowCO2: true},
+		{ID: "europe-west10", Name: "Berlin", Tier: "2"},
+		{ID: "europe-west12", Name: "Turin", Tier: "2"},
+		{ID: "europe-north1", Name: "Finland", Tier: "1", LowCO2: true},
+		{ID: "europe-north2", Name: "Stockholm", Tier: "1", LowCO2: true},
+		{ID: "europe-southwest1", Name: "Madrid", Tier: "1", LowCO2: true},
+		{ID: "europe-central2", Name: "Warsaw", Tier: "2"},
+		{ID: "asia-east1", Name: "Taiwan", Tier: "1"},
+		{ID: "asia-east2", Name: "Hong Kong", Tier: "2"},
+		{ID: "asia-northeast1", Name: "Tokyo", Tier: "1"},
+		{ID: "asia-northeast2", Name: "Osaka", Tier: "1"},
+		{ID: "asia-northeast3", Name: "Seoul", Tier: "2"},
+		{ID: "asia-south1", Name: "Mumbai", Tier: "1"},
+		{ID: "asia-south2", Name: "Delhi", Tier: "2"},
+		{ID: "asia-southeast1", Name: "Singapore", Tier: "2"},
+		{ID: "asia-southeast2", Name: "Jakarta", Tier: "2"},
+		{ID: "asia-southeast3", Name: "Bangkok", Tier: "1"},
+		{ID: "australia-southeast1", Name: "Sydney", Tier: "2"},
+		{ID: "australia-southeast2", Name: "Melbourne", Tier: "2"},
+		{ID: "africa-south1", Name: "Johannesburg", Tier: "2"},
+		{ID: "me-west1", Name: "Tel Aviv", Tier: "1"},
+		{ID: "me-central1", Name: "Doha", Tier: "2"},
+		{ID: "me-central2", Name: "Dammam", Tier: "2"},
+	}
+}
+
+func AgentByID(raw string) (AgentSpec, bool) {
+	id := normalizeID(raw)
+	for _, agent := range Agents() {
+		if agent.ID == id {
+			return agent, true
+		}
+	}
+	return AgentSpec{}, false
+}
+
+func RegionByID(raw string) (RegionSpec, bool) {
+	id := strings.ToLower(strings.TrimSpace(raw))
+	for _, region := range Regions() {
+		if region.ID == id {
+			return region, true
+		}
+	}
+	return RegionSpec{}, false
+}
+
+func NewManifest(name, agentID, regionID string, opts ManifestOptions) (Manifest, error) {
+	displayName := strings.TrimSpace(name)
+	if displayName == "" {
+		return Manifest{}, fmt.Errorf("box name is required")
+	}
+	agent, ok := AgentByID(agentID)
+	if !ok {
+		return Manifest{}, fmt.Errorf("unsupported agent %q", strings.TrimSpace(agentID))
+	}
+	region, ok := RegionByID(regionID)
+	if !ok {
+		return Manifest{}, fmt.Errorf("unsupported Cloud Run region %q", strings.TrimSpace(regionID))
+	}
+	timeout := opts.WebSocketTimeoutMins
+	if timeout <= 0 {
+		timeout = 60
+	}
+	serviceName := ServiceName(displayName, agent.ID)
+	env := map[string]string{
+		"CLANKER_BOX_NAME":         displayName,
+		"CLANKER_BOX_AGENT":        agent.ID,
+		"CLANKER_BOX_REGION":       region.ID,
+		"CLANKER_BOX_REQUIRE_AUTH": fmt.Sprintf("%t", opts.RequireAuth),
+	}
+	if opts.ControlPlaneBaseURL != "" {
+		env["CLANKER_BOX_CONTROL_PLANE_URL"] = strings.TrimRight(opts.ControlPlaneBaseURL, "/")
+	}
+	if opts.StateBucket != "" {
+		env["CLANKER_BOX_STATE_BUCKET"] = opts.StateBucket
+	}
+
+	return Manifest{
+		Name:                 displayName,
+		ServiceName:          serviceName,
+		Agent:                agent,
+		Region:               region,
+		Image:                strings.TrimSpace(opts.Image),
+		ProjectID:            strings.TrimSpace(opts.ProjectID),
+		ServiceAccountEmail:  strings.TrimSpace(opts.ServiceAccountEmail),
+		ArtifactRepository:   strings.TrimSpace(opts.ArtifactRepository),
+		StateBucket:          strings.TrimSpace(opts.StateBucket),
+		RequireAuth:          opts.RequireAuth,
+		WebSocketTimeoutMins: timeout,
+		Environment:          env,
+		Endpoints: []EndpointSpec{
+			{Kind: "health", Path: "/healthz", Description: "Cloud Run startup and liveness check."},
+			{Kind: "info", Path: "/v1/box/info", Description: "Box metadata, agent adapter, and endpoint contract."},
+			{Kind: "message", Path: "/v1/box/messages", Description: "Authenticated request/response agent messages."},
+			{Kind: "websocket", Path: "/v1/box/ws", Description: "Authenticated bidirectional agent session stream."},
+		},
+		IAMRoles: []string{
+			"roles/logging.logWriter",
+			"roles/monitoring.metricWriter",
+			"roles/artifactregistry.reader",
+			"roles/secretmanager.secretAccessor",
+			"roles/storage.objectAdmin",
+		},
+		Labels: map[string]string{
+			"app":    "clanker-box",
+			"agent":  agent.ID,
+			"region": region.ID,
+		},
+	}, nil
+}
+
+func ServiceName(name, agentID string) string {
+	base := strings.ToLower(strings.TrimSpace(name))
+	base = serviceNameRE.ReplaceAllString(base, "-")
+	base = strings.Trim(base, "-")
+	if base == "" {
+		base = "agent"
+	}
+	agentID = normalizeID(agentID)
+	prefix := "clanker-box-" + agentID + "-"
+	maxBaseLen := 63 - len(prefix) - 7
+	if maxBaseLen < 8 {
+		maxBaseLen = 8
+	}
+	if len(base) > maxBaseLen {
+		base = strings.Trim(base[:maxBaseLen], "-")
+	}
+	sum := sha1.Sum([]byte(name + ":" + agentID))
+	return prefix + base + "-" + hex.EncodeToString(sum[:])[:6]
+}
+
+func normalizeID(raw string) string {
+	id := strings.ToLower(strings.TrimSpace(raw))
+	id = strings.ReplaceAll(id, "_", "-")
+	switch id {
+	case "claude", "claudecode":
+		return "claude-code"
+	case "clanker", "cli":
+		return "clanker-cli"
+	case "openai-codex":
+		return "codex"
+	default:
+		return id
+	}
+}
+
+func SortedAgentIDs() []string {
+	ids := make([]string, 0, len(Agents()))
+	for _, agent := range Agents() {
+		ids = append(ids, agent.ID)
+	}
+	sort.Strings(ids)
+	return ids
+}

--- a/internal/clankerbox/spec.go
+++ b/internal/clankerbox/spec.go
@@ -80,6 +80,7 @@ type Manifest struct {
 	Environment          map[string]string `json:"environment"`
 	Endpoints            []EndpointSpec    `json:"endpoints"`
 	IAMRoles             []string          `json:"iamRoles"`
+	IAMConditions        []string          `json:"iamConditions,omitempty"`
 	Labels               map[string]string `json:"labels"`
 }
 
@@ -262,7 +263,7 @@ func NewManifest(name, agentID, regionID string, opts ManifestOptions) (Manifest
 				"One Clanker Box per account during beta.",
 				"Cloud Run max instances is capped at 1 with concurrency 1.",
 				"Runtime must use a unique per-box service account.",
-				"Do not attach Cloud SQL roles, database credentials, or a private VPC connector.",
+				"Do not attach Cloud SQL roles, Secret Manager roles, database credentials, or a private VPC connector.",
 				"Grant Cloud Run invoker only to the Clanker Cloud control plane.",
 			},
 		},
@@ -278,8 +279,10 @@ func NewManifest(name, agentID, regionID string, opts ManifestOptions) (Manifest
 			"roles/logging.logWriter",
 			"roles/monitoring.metricWriter",
 			"roles/artifactregistry.reader",
-			"roles/secretmanager.secretAccessor",
 			"roles/storage.objectAdmin",
+		},
+		IAMConditions: []string{
+			"Grant roles/storage.objectAdmin only with an IAM condition limited to CLANKER_BOX_STATE_PREFIX.",
 		},
 		Labels: map[string]string{
 			"app":    "clanker-box",

--- a/internal/clankerbox/spec.go
+++ b/internal/clankerbox/spec.go
@@ -32,6 +32,26 @@ type EndpointSpec struct {
 	Description string `json:"description"`
 }
 
+type SizeSpec struct {
+	CPU                  string `json:"cpu"`
+	Memory               string `json:"memory"`
+	MinInstances         int    `json:"minInstances"`
+	MaxInstances         int    `json:"maxInstances"`
+	Concurrency          int    `json:"concurrency"`
+	RequestTimeoutSecond int    `json:"requestTimeoutSeconds"`
+}
+
+type SecuritySpec struct {
+	Ingress              string   `json:"ingress"`
+	AllowUnauthenticated bool     `json:"allowUnauthenticated"`
+	RuntimeUser          string   `json:"runtimeUser"`
+	PerBoxServiceAccount bool     `json:"perBoxServiceAccount"`
+	NoCloudSQL           bool     `json:"noCloudSql"`
+	NoVPCConnector       bool     `json:"noVpcConnector"`
+	TerminalMode         string   `json:"terminalMode"`
+	Controls             []string `json:"controls"`
+}
+
 type ManifestOptions struct {
 	ProjectID            string
 	Image                string
@@ -55,6 +75,8 @@ type Manifest struct {
 	StateBucket          string            `json:"stateBucket,omitempty"`
 	RequireAuth          bool              `json:"requireAuth"`
 	WebSocketTimeoutMins int               `json:"webSocketTimeoutMins"`
+	Size                 SizeSpec          `json:"size"`
+	Security             SecuritySpec      `json:"security"`
 	Environment          map[string]string `json:"environment"`
 	Endpoints            []EndpointSpec    `json:"endpoints"`
 	IAMRoles             []string          `json:"iamRoles"`
@@ -197,12 +219,15 @@ func NewManifest(name, agentID, regionID string, opts ManifestOptions) (Manifest
 	if timeout <= 0 {
 		timeout = 60
 	}
+	size := DefaultSize()
 	serviceName := ServiceName(displayName, agent.ID)
 	env := map[string]string{
-		"CLANKER_BOX_NAME":         displayName,
-		"CLANKER_BOX_AGENT":        agent.ID,
-		"CLANKER_BOX_REGION":       region.ID,
-		"CLANKER_BOX_REQUIRE_AUTH": fmt.Sprintf("%t", opts.RequireAuth),
+		"CLANKER_BOX_NAME":            displayName,
+		"CLANKER_BOX_AGENT":           agent.ID,
+		"CLANKER_BOX_REGION":          region.ID,
+		"CLANKER_BOX_REQUIRE_AUTH":    fmt.Sprintf("%t", opts.RequireAuth),
+		"CLANKER_BOX_ENABLE_TERMINAL": "true",
+		"CLANKER_BOX_WORKDIR":         "/workspace",
 	}
 	if opts.ControlPlaneBaseURL != "" {
 		env["CLANKER_BOX_CONTROL_PLANE_URL"] = strings.TrimRight(opts.ControlPlaneBaseURL, "/")
@@ -223,12 +248,30 @@ func NewManifest(name, agentID, regionID string, opts ManifestOptions) (Manifest
 		StateBucket:          strings.TrimSpace(opts.StateBucket),
 		RequireAuth:          opts.RequireAuth,
 		WebSocketTimeoutMins: timeout,
-		Environment:          env,
+		Size:                 size,
+		Security: SecuritySpec{
+			Ingress:              "internal-and-cloud-load-balancing",
+			AllowUnauthenticated: false,
+			RuntimeUser:          "clankerbox",
+			PerBoxServiceAccount: true,
+			NoCloudSQL:           true,
+			NoVPCConnector:       true,
+			TerminalMode:         "authenticated-websocket-terminal",
+			Controls: []string{
+				"One Clanker Box per account during beta.",
+				"Cloud Run max instances is capped at 1 with concurrency 1.",
+				"Runtime must use a unique per-box service account.",
+				"Do not attach Cloud SQL roles, database credentials, or a private VPC connector.",
+				"Grant Cloud Run invoker only to the Clanker Cloud control plane.",
+			},
+		},
+		Environment: env,
 		Endpoints: []EndpointSpec{
 			{Kind: "health", Path: "/healthz", Description: "Cloud Run startup and liveness check."},
 			{Kind: "info", Path: "/v1/box/info", Description: "Box metadata, agent adapter, and endpoint contract."},
 			{Kind: "message", Path: "/v1/box/messages", Description: "Authenticated request/response agent messages."},
 			{Kind: "websocket", Path: "/v1/box/ws", Description: "Authenticated bidirectional agent session stream."},
+			{Kind: "terminal", Path: "/v1/box/terminal", Description: "Authenticated WebSocket terminal for SSH-style box access."},
 		},
 		IAMRoles: []string{
 			"roles/logging.logWriter",
@@ -243,6 +286,17 @@ func NewManifest(name, agentID, regionID string, opts ManifestOptions) (Manifest
 			"region": region.ID,
 		},
 	}, nil
+}
+
+func DefaultSize() SizeSpec {
+	return SizeSpec{
+		CPU:                  "1",
+		Memory:               "2Gi",
+		MinInstances:         0,
+		MaxInstances:         1,
+		Concurrency:          1,
+		RequestTimeoutSecond: 3600,
+	}
 }
 
 func ServiceName(name, agentID string) string {

--- a/internal/clankerbox/spec_test.go
+++ b/internal/clankerbox/spec_test.go
@@ -1,0 +1,82 @@
+package clankerbox
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNewManifestValidatesAgentAndRegion(t *testing.T) {
+	manifest, err := NewManifest("Prod Agent", "claude", "us-east4", ManifestOptions{
+		ProjectID:            "clanker-prod",
+		Image:                "us-east4-docker.pkg.dev/clanker-prod/clanker/box:latest",
+		ServiceAccountEmail:  "box@clanker-prod.iam.gserviceaccount.com",
+		ArtifactRepository:   "clanker",
+		StateBucket:          "clanker-box-state",
+		RequireAuth:          true,
+		WebSocketTimeoutMins: 45,
+	})
+	if err != nil {
+		t.Fatalf("NewManifest returned error: %v", err)
+	}
+	if manifest.Agent.ID != "claude-code" {
+		t.Fatalf("expected claude-code alias, got %q", manifest.Agent.ID)
+	}
+	if manifest.Region.ID != "us-east4" {
+		t.Fatalf("expected region us-east4, got %q", manifest.Region.ID)
+	}
+	if !strings.HasPrefix(manifest.ServiceName, "clanker-box-claude-code-prod-agent-") {
+		t.Fatalf("unexpected service name %q", manifest.ServiceName)
+	}
+	if manifest.Environment["CLANKER_BOX_REQUIRE_AUTH"] != "true" {
+		t.Fatalf("expected auth env true, got %#v", manifest.Environment)
+	}
+}
+
+func TestNewManifestRejectsUnknownRegion(t *testing.T) {
+	_, err := NewManifest("Prod Agent", "hermes", "moon-1", ManifestOptions{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "unsupported Cloud Run region") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+type fakeRunner struct{}
+
+func (fakeRunner) RunAgentMessage(ctx context.Context, cfg RuntimeConfig, req MessageRequest) (string, error) {
+	return "reply:" + req.Message, nil
+}
+
+func TestServerMessageRequiresToken(t *testing.T) {
+	server := NewServer(RuntimeConfig{Name: "test", Agent: "clanker-cli", Region: "us-central1", RequireAuth: true, APIToken: "secret"}, fakeRunner{})
+	req := httptest.NewRequest(http.MethodPost, "/v1/box/messages", bytes.NewBufferString(`{"message":"hello"}`))
+	rec := httptest.NewRecorder()
+	server.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestServerMessageRunsAgent(t *testing.T) {
+	server := NewServer(RuntimeConfig{Name: "test", Agent: "clanker-cli", Region: "us-central1", RequireAuth: true, APIToken: "secret"}, fakeRunner{})
+	req := httptest.NewRequest(http.MethodPost, "/v1/box/messages", bytes.NewBufferString(`{"sessionId":"s1","message":"hello"}`))
+	req.Header.Set("X-API-Key", "secret")
+	rec := httptest.NewRecorder()
+	server.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp MessageResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !resp.OK || resp.Message != "reply:hello" || resp.SessionID != "s1" {
+		t.Fatalf("unexpected response %#v", resp)
+	}
+}

--- a/internal/clankerbox/spec_test.go
+++ b/internal/clankerbox/spec_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/gorilla/websocket"
 )
 
 func TestNewManifestValidatesAgentAndRegion(t *testing.T) {
@@ -34,6 +36,12 @@ func TestNewManifestValidatesAgentAndRegion(t *testing.T) {
 	}
 	if manifest.Environment["CLANKER_BOX_REQUIRE_AUTH"] != "true" {
 		t.Fatalf("expected auth env true, got %#v", manifest.Environment)
+	}
+	if manifest.Size.MaxInstances != 1 || manifest.Size.Concurrency != 1 {
+		t.Fatalf("unexpected beta size: %#v", manifest.Size)
+	}
+	if !manifest.Security.PerBoxServiceAccount || !manifest.Security.NoCloudSQL || manifest.Security.AllowUnauthenticated {
+		t.Fatalf("unexpected security defaults: %#v", manifest.Security)
 	}
 }
 
@@ -78,5 +86,28 @@ func TestServerMessageRunsAgent(t *testing.T) {
 	}
 	if !resp.OK || resp.Message != "reply:hello" || resp.SessionID != "s1" {
 		t.Fatalf("unexpected response %#v", resp)
+	}
+}
+
+func TestServerTerminalRunsCommand(t *testing.T) {
+	server := httptest.NewServer(NewServer(RuntimeConfig{Name: "test", Agent: "clanker-cli", Region: "us-central1", RequireAuth: true, EnableTerminal: true, APIToken: "secret"}, fakeRunner{}).Handler())
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/box/terminal?token=secret"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial terminal: %v", err)
+	}
+	defer conn.Close()
+
+	if err := conn.WriteJSON(TerminalRequest{SessionID: "term-1", Command: "printf terminal-ok", TimeoutSeconds: 5}); err != nil {
+		t.Fatalf("write terminal request: %v", err)
+	}
+	var resp TerminalResponse
+	if err := conn.ReadJSON(&resp); err != nil {
+		t.Fatalf("read terminal response: %v", err)
+	}
+	if !resp.OK || resp.SessionID != "term-1" || resp.ExitCode != 0 || resp.Output != "terminal-ok" {
+		t.Fatalf("unexpected terminal response %#v", resp)
 	}
 }

--- a/internal/clankerbox/spec_test.go
+++ b/internal/clankerbox/spec_test.go
@@ -54,6 +54,22 @@ func TestNewManifestValidatesAgentAndRegion(t *testing.T) {
 	}
 }
 
+func TestNewManifestSupportsEmptySandbox(t *testing.T) {
+	manifest, err := NewManifest("Shell Box", "blank", "us-central1", ManifestOptions{RequireAuth: true})
+	if err != nil {
+		t.Fatalf("NewManifest returned error: %v", err)
+	}
+	if manifest.Agent.ID != "empty" {
+		t.Fatalf("expected empty alias, got %q", manifest.Agent.ID)
+	}
+	if manifest.Environment["CLANKER_BOX_AUTO_INSTALL"] != "false" {
+		t.Fatalf("empty sandbox should disable auto-install: %#v", manifest.Environment)
+	}
+	if manifest.Environment["CLANKER_BOX_ENABLE_TERMINAL"] != "true" {
+		t.Fatalf("empty sandbox should keep terminal enabled: %#v", manifest.Environment)
+	}
+}
+
 func TestNewManifestRejectsUnknownRegion(t *testing.T) {
 	_, err := NewManifest("Prod Agent", "hermes", "moon-1", ManifestOptions{})
 	if err == nil {
@@ -168,6 +184,26 @@ func TestServerTerminalPostRunsCommand(t *testing.T) {
 func TestInstallAgentRejectsUnknownAgent(t *testing.T) {
 	if _, err := InstallAgent(context.Background(), "unknown"); err == nil {
 		t.Fatal("expected unsupported agent error")
+	}
+}
+
+func TestInstallAgentAcceptsEmptySandbox(t *testing.T) {
+	result, err := InstallAgent(context.Background(), "empty")
+	if err != nil {
+		t.Fatalf("InstallAgent returned error: %v", err)
+	}
+	if !result.Installed || result.Agent != "empty" {
+		t.Fatalf("unexpected install result: %#v", result)
+	}
+}
+
+func TestDefaultRunnerSupportsEmptySandboxMessage(t *testing.T) {
+	reply, err := DefaultRunner{}.RunAgentMessage(context.Background(), RuntimeConfig{Agent: "empty"}, MessageRequest{Message: "hello"})
+	if err != nil {
+		t.Fatalf("RunAgentMessage returned error: %v", err)
+	}
+	if !strings.Contains(reply, "terminal") {
+		t.Fatalf("expected terminal guidance, got %q", reply)
 	}
 }
 

--- a/internal/clankerbox/spec_test.go
+++ b/internal/clankerbox/spec_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gorilla/websocket"
 )
@@ -109,5 +110,42 @@ func TestServerTerminalRunsCommand(t *testing.T) {
 	}
 	if !resp.OK || resp.SessionID != "term-1" || resp.ExitCode != 0 || resp.Output != "terminal-ok" {
 		t.Fatalf("unexpected terminal response %#v", resp)
+	}
+}
+
+func TestServerTerminalPostRunsCommand(t *testing.T) {
+	server := NewServer(RuntimeConfig{Name: "test", Agent: "clanker-cli", Region: "us-central1", RequireAuth: true, EnableTerminal: true, APIToken: "secret"}, fakeRunner{})
+	req := httptest.NewRequest(http.MethodPost, "/v1/box/terminal", bytes.NewBufferString(`{"sessionId":"term-1","command":"printf terminal-ok","timeoutSeconds":5}`))
+	req.Header.Set("X-API-Key", "secret")
+	rec := httptest.NewRecorder()
+
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp TerminalResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode terminal response: %v", err)
+	}
+	if !resp.OK || resp.SessionID != "term-1" || resp.Output != "terminal-ok" {
+		t.Fatalf("unexpected terminal response %#v", resp)
+	}
+}
+
+func TestInstallAgentRejectsUnknownAgent(t *testing.T) {
+	if _, err := InstallAgent(context.Background(), "unknown"); err == nil {
+		t.Fatal("expected unsupported agent error")
+	}
+}
+
+func TestInstallTimeoutSupportsDurationsAndSeconds(t *testing.T) {
+	t.Setenv("CLANKER_BOX_INSTALL_TIMEOUT_SECONDS", "2m")
+	if got := installTimeout(); got != 2*time.Minute {
+		t.Fatalf("duration timeout = %s, want 2m", got)
+	}
+	t.Setenv("CLANKER_BOX_INSTALL_TIMEOUT_SECONDS", "30")
+	if got := installTimeout(); got != 30*time.Second {
+		t.Fatalf("seconds timeout = %s, want 30s", got)
 	}
 }

--- a/internal/clankerbox/spec_test.go
+++ b/internal/clankerbox/spec_test.go
@@ -181,6 +181,57 @@ func TestServerTerminalPostRunsCommand(t *testing.T) {
 	}
 }
 
+func TestServerTerminalPostReturnsCommandExitAsJSON(t *testing.T) {
+	server := NewServer(RuntimeConfig{Name: "test", Agent: "empty", Region: "us-central1", RequireAuth: true, EnableTerminal: true, APIToken: "secret"}, fakeRunner{})
+	req := httptest.NewRequest(http.MethodPost, "/v1/box/terminal", bytes.NewBufferString(`{"sessionId":"term-1","command":"printf nope; exit 7","timeoutSeconds":5}`))
+	req.Header.Set("X-API-Key", "secret")
+	rec := httptest.NewRecorder()
+
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp TerminalResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode terminal response: %v", err)
+	}
+	if resp.OK || resp.ExitCode != 7 || resp.Output != "nope" {
+		t.Fatalf("unexpected failed terminal response %#v", resp)
+	}
+}
+
+func TestServerMessageCanExecuteTerminalCommand(t *testing.T) {
+	server := NewServer(RuntimeConfig{Name: "test", Agent: "empty", Region: "us-central1", RequireAuth: true, EnableTerminal: true, APIToken: "secret"}, fakeRunner{})
+	req := httptest.NewRequest(http.MethodPost, "/v1/box/messages", bytes.NewBufferString(`{"sessionId":"chat-1","message":"run printf chat-ok"}`))
+	req.Header.Set("X-API-Key", "secret")
+	rec := httptest.NewRecorder()
+
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp MessageResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode message response: %v", err)
+	}
+	if !resp.OK || resp.Terminal == nil || resp.Terminal.Output != "chat-ok" {
+		t.Fatalf("expected terminal response in chat, got %#v", resp)
+	}
+}
+
+func TestTerminalCommandFromMessageMapsAgentInstall(t *testing.T) {
+	cmd, ok := terminalCommandFromMessage("install codex", "empty")
+	if !ok || cmd != "clanker box install codex" {
+		t.Fatalf("install codex command = %q ok=%v", cmd, ok)
+	}
+	cmd, ok = terminalCommandFromMessage("install docker", "empty")
+	if !ok || !strings.Contains(cmd, "download.docker.com") {
+		t.Fatalf("install docker command = %q ok=%v", cmd, ok)
+	}
+}
+
 func TestInstallAgentRejectsUnknownAgent(t *testing.T) {
 	if _, err := InstallAgent(context.Background(), "unknown"); err == nil {
 		t.Fatal("expected unsupported agent error")

--- a/internal/clankerbox/spec_test.go
+++ b/internal/clankerbox/spec_test.go
@@ -44,6 +44,14 @@ func TestNewManifestValidatesAgentAndRegion(t *testing.T) {
 	if !manifest.Security.PerBoxServiceAccount || !manifest.Security.NoCloudSQL || manifest.Security.AllowUnauthenticated {
 		t.Fatalf("unexpected security defaults: %#v", manifest.Security)
 	}
+	for _, role := range manifest.IAMRoles {
+		if strings.Contains(role, "secretmanager") {
+			t.Fatalf("box manifest should not include broad Secret Manager access: %#v", manifest.IAMRoles)
+		}
+	}
+	if len(manifest.IAMConditions) == 0 || !strings.Contains(strings.Join(manifest.IAMConditions, "\n"), "CLANKER_BOX_STATE_PREFIX") {
+		t.Fatalf("box manifest should require state-prefix IAM conditions: %#v", manifest.IAMConditions)
+	}
 }
 
 func TestNewManifestRejectsUnknownRegion(t *testing.T) {
@@ -65,6 +73,30 @@ func (fakeRunner) RunAgentMessage(ctx context.Context, cfg RuntimeConfig, req Me
 func TestServerMessageRequiresToken(t *testing.T) {
 	server := NewServer(RuntimeConfig{Name: "test", Agent: "clanker-cli", Region: "us-central1", RequireAuth: true, APIToken: "secret"}, fakeRunner{})
 	req := httptest.NewRequest(http.MethodPost, "/v1/box/messages", bytes.NewBufferString(`{"message":"hello"}`))
+	rec := httptest.NewRecorder()
+	server.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestServerHealthDoesNotExposeBoxMetadata(t *testing.T) {
+	server := NewServer(RuntimeConfig{Name: "private-name", Agent: "claude-code", Region: "us-east4", RequireAuth: true, APIToken: "secret"}, fakeRunner{})
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	server.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "private-name") || strings.Contains(body, "claude-code") || strings.Contains(body, "us-east4") {
+		t.Fatalf("health response leaked box metadata: %s", body)
+	}
+}
+
+func TestServerInfoRequiresToken(t *testing.T) {
+	server := NewServer(RuntimeConfig{Name: "test", Agent: "clanker-cli", Region: "us-central1", RequireAuth: true, APIToken: "secret"}, fakeRunner{})
+	req := httptest.NewRequest(http.MethodGet, "/v1/box/info", nil)
 	rec := httptest.NewRecorder()
 	server.Handler().ServeHTTP(rec, req)
 	if rec.Code != http.StatusUnauthorized {


### PR DESCRIPTION
Summary
- Adds `clanker box catalog`, `clanker box manifest`, and `clanker box serve` for account-scoped Cloud Run agent runtimes.
- Adds HTTP and WebSocket message endpoints with API-key/Bearer auth for Hermes, OpenClaw, Codex, Claude Code, and Clanker CLI adapters.
- Adds a `Dockerfile.clankerbox` for building the sandbox runtime image.

Tests
- `go test ./internal/clankerbox ./cmd`

Deploy
- Not deployed; PR only.