### PR TITLE
Add model override for k8s ask

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ If you run without `~/.clanker.yaml`:
 - OpenAI key order: `--openai-key` → `OPENAI_API_KEY` (also supports `ai.providers.openai.api_key` and `ai.providers.openai.api_key_env` if config exists).
 - Gemini API key order (when using `--ai-profile gemini-api`): `--gemini-key` → `GEMINI_API_KEY` (also supports `ai.providers.gemini-api.api_key` and `ai.providers.gemini-api.api_key_env` if config exists).
 - Cohere API key order (when using `--ai-profile cohere`): `--cohere-key` → `COHERE_API_KEY` (also supports `ai.providers.cohere.api_key` and `ai.providers.cohere.api_key_env` if config exists).
-- Model: `openai` defaults to `gpt-5`; `gemini`/`gemini-api` defaults to `gemini-3-pro-preview`; `cohere` defaults to `command-a-03-2025`.
+- Model: `openai` defaults to `gpt-5`; `gemini`/`gemini-api` defaults to `gemini-2.5-flash`; `cohere` defaults to `command-a-03-2025`.
 
 ### AWS
 
@@ -525,6 +525,7 @@ clanker k8s ask --debug "how many pods are running"
 | `--context`       | kubectl context to use (overrides --cluster)        |
 | `-n, --namespace` | Default namespace for queries                       |
 | `--ai-profile`    | AI profile to use for LLM queries                   |
+| `--model`         | AI model for the selected AI profile                |
 | `--debug`         | Show detailed debug output including LLM operations |
 
 ### Legacy Natural Language Queries (via `clanker ask`)

--- a/cmd/ask_test.go
+++ b/cmd/ask_test.go
@@ -57,6 +57,26 @@ func TestApplyCommandAIOverrides_RespectsConfiguredProvider(t *testing.T) {
 	}
 }
 
+func TestCreateAIClient_AppliesK8sModelOverride(t *testing.T) {
+	previousProfile := k8sAskAIProfile
+	previousModel := k8sAskModel
+	previousConfiguredModel := viper.GetString("ai.providers.openai.model")
+	k8sAskAIProfile = "openai"
+	k8sAskModel = "gpt-k8s-selected"
+	t.Cleanup(func() {
+		k8sAskAIProfile = previousProfile
+		k8sAskModel = previousModel
+		viper.Set("ai.providers.openai.model", previousConfiguredModel)
+	})
+
+	if _, err := createAIClient(false); err != nil {
+		t.Fatalf("createAIClient returned error: %v", err)
+	}
+	if got := viper.GetString("ai.providers.openai.model"); got != "gpt-k8s-selected" {
+		t.Fatalf("expected k8s --model override to set selected provider model, got %q", got)
+	}
+}
+
 func TestApplyDiscoveryContextDefaults_UsesConfiguredHetzner(t *testing.T) {
 	useDefaultInfraProvider(t, "hetzner")
 

--- a/cmd/k8s.go
+++ b/cmd/k8s.go
@@ -281,6 +281,7 @@ var (
 	k8sAskKubeconfig string
 	k8sAskContext    string
 	k8sAskAIProfile  string
+	k8sAskModel      string
 	k8sAskDebug      bool
 	// GKE flags
 	k8sGCPMode        bool
@@ -405,6 +406,7 @@ func init() {
 	k8sAskCmd.Flags().StringVar(&k8sAskContext, "context", "", "kubectl context to use (overrides --cluster)")
 	k8sAskCmd.Flags().StringVarP(&k8sNamespace, "namespace", "n", "", "Default namespace for queries (default: all namespaces)")
 	k8sAskCmd.Flags().StringVar(&k8sAskAIProfile, "ai-profile", "", "AI profile to use for LLM queries")
+	k8sAskCmd.Flags().StringVar(&k8sAskModel, "model", "", "AI model to use for LLM queries (overrides selected AI profile config)")
 	k8sAskCmd.Flags().BoolVar(&k8sAskDebug, "debug", false, "Enable debug output")
 	k8sAskCmd.Flags().BoolVar(&k8sGCPMode, "gcp", false, "Use GKE cluster instead of EKS")
 	k8sAskCmd.Flags().StringVar(&k8sGCPProject, "gcp-project", "", "GCP project ID for GKE clusters")
@@ -2715,5 +2717,10 @@ func createAIClient(debug bool) (*ai.Client, error) {
 		fmt.Printf("[k8s ask] Using AI provider: %s\n", provider)
 	}
 
-	return ai.NewClient(provider, apiKey, debug, k8sAskAIProfile), nil
+	if model := strings.TrimSpace(k8sAskModel); model != "" {
+		configKey := fmt.Sprintf("ai.providers.%s.model", provider)
+		viper.Set(configKey, model)
+	}
+
+	return ai.NewClient(provider, apiKey, debug, provider), nil
 }


### PR DESCRIPTION
## Summary
- add a provider-neutral --model flag to clanker k8s ask
- apply the override to the selected AI profile before constructing the LLM client
- document the new K8s ask flag and cover it with a unit test

## Verification
- go test ./cmd