### PR TITLE
Expose Kubernetes cluster chat over MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ The CLI MCP currently exposes tools to:
 - return Clanker routing decisions for a prompt
 - run local `clanker` commands through MCP, including `ask`, `openclaw`, and other subcommands
 - launch and talk to the Clanker Cloud desktop app through its local backend
+- inspect and chat with Kubernetes clusters through native `clanker_k8s_*` MCP tools, including `clanker_k8s_ask_cluster`
 
 Clanker chat routing also recognizes Clanker Cloud app questions now. If you use `clanker talk` and ask about the running desktop app or its saved settings, it will try the local Clanker Cloud backend first and fall back to Hermes if the app is not running.
 
@@ -252,6 +253,23 @@ The standalone CLI MCP currently exposes these tools:
 - `clanker_cloud_launch_app`
 - `clanker_cloud_ask_app`
 - `clanker_cloud_call_backend_api`
+- `clanker_k8s_list_clusters`
+- `clanker_k8s_get_resources`
+- `clanker_k8s_ask_cluster`
+- `clanker_k8s_logs`
+- `clanker_k8s_exec`
+- `clanker_k8s_scale`
+- `clanker_k8s_restart`
+- `clanker_k8s_rollout`
+- `clanker_k8s_apply`
+- `clanker_k8s_delete_resource`
+- `clanker_k8s_helm_install`
+- `clanker_k8s_helm_upgrade`
+- `clanker_k8s_helm_list`
+- `clanker_k8s_helm_uninstall`
+- `clanker_k8s_node_cordon`
+- `clanker_k8s_node_uncordon`
+- `clanker_k8s_node_drain`
 
 Flags:
 
@@ -513,6 +531,23 @@ clanker k8s ask "now show me its logs"
 
 # Debug mode (shows LLM operations)
 clanker k8s ask --debug "how many pods are running"
+```
+
+MCP agents can use the same pipeline through `clanker_k8s_ask_cluster` after starting `clanker mcp`. The tool accepts `question`, optional `cluster`, `context`, `namespace`, `kubeconfig`, `profile`, `provider`, `gcpProject`, `gcpRegion`, `aiProfile`, and `model` fields so agents can ask any reachable EKS, GKE, or kubeconfig-backed cluster without shelling through a generic command tool.
+
+```json
+{
+  "name": "clanker_k8s_ask_cluster",
+  "arguments": {
+    "question": "which pods are unhealthy and what should I check next?",
+    "cluster": "prod-gke",
+    "provider": "gke",
+    "gcpProject": "prod-project",
+    "gcpRegion": "us-central1",
+    "namespace": "payments",
+    "model": "gpt-5.1"
+  }
+}
 ```
 
 #### K8s Ask Flags

--- a/cmd/mcp_k8s.go
+++ b/cmd/mcp_k8s.go
@@ -28,6 +28,19 @@ type k8sGetResourcesArgs struct {
 	Kubeconfig string `json:"kubeconfig,omitempty" jsonschema:"description=Path to kubeconfig file"`
 }
 
+type k8sAskClusterArgs struct {
+	k8sConnectionArgs
+	Question   string `json:"question" jsonschema:"description=Natural language question to ask about the Kubernetes cluster,required"`
+	Cluster    string `json:"cluster,omitempty" jsonschema:"description=EKS or GKE cluster name. If omitted, uses the active kubeconfig context."`
+	Provider   string `json:"provider,omitempty" jsonschema:"description=Cluster provider hint: eks, gke, kubeconfig, or current. GKE enables --gcp."`
+	Profile    string `json:"profile,omitempty" jsonschema:"description=AWS profile for EKS clusters"`
+	AIProfile  string `json:"aiProfile,omitempty" jsonschema:"description=AI profile/provider to use for the LLM pipeline"`
+	Model      string `json:"model,omitempty" jsonschema:"description=AI model override for the selected AI profile"`
+	GCPProject string `json:"gcpProject,omitempty" jsonschema:"description=GCP project ID for GKE clusters"`
+	GCPRegion  string `json:"gcpRegion,omitempty" jsonschema:"description=GCP region for GKE clusters"`
+	Debug      bool   `json:"debug,omitempty" jsonschema:"description=Enable debug output from clanker k8s ask"`
+}
+
 type k8sScaleArgs struct {
 	k8sConnectionArgs
 	Kind     string `json:"kind" jsonschema:"description=Workload kind: deployment, statefulset, or replicaset,required"`
@@ -176,6 +189,51 @@ func mcpAppendBoolIf(args []string, flag string, v bool) []string {
 	return append(args, flag)
 }
 
+func buildK8sAskCommandArgs(args k8sAskClusterArgs) ([]string, error) {
+	question := strings.TrimSpace(args.Question)
+	if question == "" {
+		return nil, fmt.Errorf("question is required")
+	}
+
+	command := []string{"k8s", "ask"}
+	command = mcpAppendIf(command, "--cluster", strings.TrimSpace(args.Cluster))
+	command = mcpAppendIf(command, "--profile", strings.TrimSpace(args.Profile))
+	command = mcpAppendIf(command, "--kubeconfig", strings.TrimSpace(args.Kubeconfig))
+	command = mcpAppendIf(command, "--context", strings.TrimSpace(args.Context))
+	command = mcpAppendIf(command, "--namespace", strings.TrimSpace(args.Namespace))
+	command = mcpAppendIf(command, "--ai-profile", strings.TrimSpace(args.AIProfile))
+	command = mcpAppendIf(command, "--model", strings.TrimSpace(args.Model))
+
+	provider := strings.ToLower(strings.TrimSpace(args.Provider))
+	switch provider {
+	case "", "eks", "aws", "kubeconfig", "current":
+	case "gke", "gcp":
+		command = append(command, "--gcp")
+	default:
+		return nil, fmt.Errorf("unsupported Kubernetes provider %q (use eks, gke, kubeconfig, or current)", args.Provider)
+	}
+
+	if provider == "gke" || provider == "gcp" || strings.TrimSpace(args.GCPProject) != "" || strings.TrimSpace(args.GCPRegion) != "" {
+		if !containsArg(command, "--gcp") {
+			command = append(command, "--gcp")
+		}
+		command = mcpAppendIf(command, "--gcp-project", strings.TrimSpace(args.GCPProject))
+		command = mcpAppendIf(command, "--gcp-region", strings.TrimSpace(args.GCPRegion))
+	}
+	command = mcpAppendBoolIf(command, "--debug", args.Debug)
+	command = append(command, question)
+	return command, nil
+}
+
+func containsArg(args []string, needle string) bool {
+	for _, arg := range args {
+		if arg == needle {
+			return true
+		}
+	}
+	return false
+}
+
 // normalizeHelmListOutput turns `helm list -o json` output into a
 // stable response shape: {"releases": [...], "raw": "..."}.
 //
@@ -256,6 +314,31 @@ func registerK8sMCPTools(server *mcptransport.MCPServer) {
 				return mcp.NewToolResultError(err.Error()), nil
 			}
 			return mcp.NewToolResultJSON(resources)
+		}),
+	)
+
+	server.AddTool(
+		mcp.NewTool(
+			"clanker_k8s_ask_cluster",
+			mcp.WithDescription("Ask a natural-language question about any reachable Kubernetes cluster. Reuses 'clanker k8s ask' so MCP agents get cluster discovery, kubeconfig/context selection, provider auth, conversation history, and model overrides."),
+			mcp.WithInputSchema[k8sAskClusterArgs](),
+			mcp.WithReadOnlyHintAnnotation(true),
+		),
+		mcp.NewTypedToolHandler(func(ctx context.Context, _ mcp.CallToolRequest, args k8sAskClusterArgs) (*mcp.CallToolResult, error) {
+			cliArgs, err := buildK8sAskCommandArgs(args)
+			if err != nil {
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			result, err := runClankerCommand(ctx, commandArgs{Args: cliArgs})
+			if err != nil {
+				if result != nil {
+					if output := strings.TrimSpace(fmt.Sprint(result["output"])); output != "" {
+						return mcp.NewToolResultError(fmt.Sprintf("%v\n%s", err, output)), nil
+					}
+				}
+				return mcp.NewToolResultError(err.Error()), nil
+			}
+			return mcp.NewToolResultJSON(result)
 		}),
 	)
 

--- a/cmd/mcp_k8s_test.go
+++ b/cmd/mcp_k8s_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -34,6 +35,7 @@ func registeredK8sToolNames(t *testing.T) []string {
 func wantedK8sToolNames() []string {
 	return []string{
 		"clanker_k8s_apply",
+		"clanker_k8s_ask_cluster",
 		"clanker_k8s_delete_resource",
 		"clanker_k8s_exec",
 		"clanker_k8s_get_resources",
@@ -64,8 +66,8 @@ func TestMCPK8sTools_ExpectedNames(t *testing.T) {
 	// smoke (running the MCP server and asking for tools/list) is the
 	// truthier check; this is the unit-level prefix sanity.
 	got := registeredK8sToolNames(t)
-	if len(got) != 16 {
-		t.Errorf("expected 16 k8s MCP tools, got %d", len(got))
+	if len(got) != 17 {
+		t.Errorf("expected 17 k8s MCP tools, got %d", len(got))
 	}
 	for _, name := range got {
 		if !strings.HasPrefix(name, "clanker_k8s_") {
@@ -91,6 +93,46 @@ func TestMCPAppendBoolIf_OnlyAppendsWhenTrue(t *testing.T) {
 	}
 	if got := mcpAppendBoolIf([]string{"helm"}, "--wait", true); len(got) != 2 || got[1] != "--wait" {
 		t.Errorf("mcpAppendBoolIf(true) = %v", got)
+	}
+}
+
+func TestBuildK8sAskCommandArgs_GKEModelOverride(t *testing.T) {
+	got, err := buildK8sAskCommandArgs(k8sAskClusterArgs{
+		k8sConnectionArgs: k8sConnectionArgs{
+			Context:   "gke-prod",
+			Namespace: "payments",
+		},
+		Question:   "why is checkout crashing?",
+		Cluster:    "prod-gke",
+		Provider:   "gke",
+		AIProfile:  "openai",
+		Model:      "gpt-5.1",
+		GCPProject: "prod-project",
+		GCPRegion:  "us-central1",
+	})
+	if err != nil {
+		t.Fatalf("buildK8sAskCommandArgs returned error: %v", err)
+	}
+	want := []string{
+		"k8s", "ask",
+		"--cluster", "prod-gke",
+		"--context", "gke-prod",
+		"--namespace", "payments",
+		"--ai-profile", "openai",
+		"--model", "gpt-5.1",
+		"--gcp",
+		"--gcp-project", "prod-project",
+		"--gcp-region", "us-central1",
+		"why is checkout crashing?",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildK8sAskCommandArgs() = %v, want %v", got, want)
+	}
+}
+
+func TestBuildK8sAskCommandArgs_RequiresQuestion(t *testing.T) {
+	if _, err := buildK8sAskCommandArgs(k8sAskClusterArgs{}); err == nil {
+		t.Fatal("expected empty question to fail")
 	}
 }
 

--- a/internal/onboarding/onboarding.go
+++ b/internal/onboarding/onboarding.go
@@ -438,7 +438,8 @@ func BuildAgentInstructions(providers []ProviderStatus, missing []ToolStatus, au
 	b.WriteString("3. If the user asked you to install or use Clanker Cloud, perform the install step instead of only reporting missing tools. In Clanker Cloud MCP, call `clanker_cloud_install_setup_dependencies` with `dependencySummary.recommendedMissingTools`; otherwise run `clanker onboarding install --yes <tool>` for selected or detected providers only.\n")
 	b.WriteString("4. After installation, run `clanker onboarding scan --format json` again. If a tool still requires browser login, SSO, sudo, or an API token, tell the user exactly what you need and use only the official docs and token URLs from `authGuides`.\n")
 	b.WriteString("5. Once auth is configured, start the Clanker Cloud infrastructure scan and wait for it before chat, Kubernetes, research, or security work. Scans can take several minutes; keep reporting that resources are still being scanned instead of failing early.\n")
-	b.WriteString("6. For infrastructure changes, generate a plan first and apply it only after explicit user approval.\n")
+	b.WriteString("6. For Kubernetes follow-up through the standalone Clanker CLI MCP, use `clanker_k8s_list_clusters` or `clanker_k8s_get_resources` for context and `clanker_k8s_ask_cluster` for natural-language cluster chat. Pass cluster/context/namespace/provider fields when the user names a specific cluster.\n")
+	b.WriteString("7. For infrastructure changes, generate a plan first and apply it only after explicit user approval.\n")
 	if len(missing) > 0 {
 		ids := make([]string, 0, len(missing))
 		for _, tool := range missing {

--- a/internal/onboarding/onboarding_test.go
+++ b/internal/onboarding/onboarding_test.go
@@ -31,6 +31,9 @@ func TestScanIncludesOfficialAuthGuides(t *testing.T) {
 	if !strings.Contains(result.AgentInstructions, "wait for it before chat") {
 		t.Fatalf("agent instructions do not require waiting for scan before app use:\n%s", result.AgentInstructions)
 	}
+	if !strings.Contains(result.AgentInstructions, "clanker_k8s_ask_cluster") {
+		t.Fatalf("agent instructions do not tell MCP agents how to chat with Kubernetes clusters:\n%s", result.AgentInstructions)
+	}
 }
 
 func TestGuidesPreferOfficialVendorDocs(t *testing.T) {


### PR DESCRIPTION
## Summary
- add clanker_k8s_ask_cluster MCP tool backed by clanker k8s ask
- support cluster/context/namespace/kubeconfig, EKS profile, GKE project/region, AI profile, and model override args
- document the K8s MCP surface and add onboarding agent instructions

## Verification
- go test ./cmd -run 'TestMCPK8s|TestBuildK8sAsk|TestMCPAppend|TestK8sNodeDrain'
- go test ./internal/onboarding
- go test ./cmd -run 'MCP|BuildK8sAsk'
- go test ./cmd ./internal/onboarding