### PR TITLE
Unified multi-provider logs command (query/tail/chat)

### DIFF
--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -1,0 +1,252 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/bgdnvk/clanker/internal/logs"
+	"github.com/spf13/cobra"
+)
+
+// newLogsCmd builds `clanker logs`, the provider-agnostic log surface the cloud
+// app drives. `query`/`tail` stream normalized JSON-lines on stdout (progress
+// on stderr); `chat` runs the agentic talk-to-logs flow; `sources` discovers
+// available log sources.
+func newLogsCmd() *cobra.Command {
+	var (
+		provider  string
+		resource  string
+		service   string
+		region    string
+		since     string
+		until     string
+		level     string
+		grep      string
+		limit     int
+		format    string
+		profile   string
+		aiProfile string
+	)
+
+	buildOpts := func() (logs.Options, error) {
+		now := time.Now()
+		sinceT, err := logs.ParseSince(since, now)
+		if err != nil {
+			return logs.Options{}, err
+		}
+		opts := logs.Options{
+			Provider: provider,
+			Resource: resource,
+			Service:  service,
+			Region:   region,
+			Since:    sinceT,
+			Level:    level,
+			Grep:     grep,
+			Limit:    limit,
+			Profile:  profile,
+		}
+		if strings.TrimSpace(until) != "" {
+			if t, err := time.Parse(time.RFC3339, until); err == nil {
+				opts.Until = t
+			}
+		}
+		return opts, nil
+	}
+
+	logsCmd := &cobra.Command{
+		Use:   "logs",
+		Short: "Unified multi-provider logs: query, tail, and chat across clouds",
+		Long: `Query, stream, and chat with logs across providers (aws, k8s, flyio, vercel,
+railway) through one normalized interface. query/tail emit JSON-lines; chat runs
+the talk-to-logs agent.`,
+	}
+
+	persistent := logsCmd.PersistentFlags()
+	persistent.StringVar(&provider, "provider", "", "log provider: "+strings.Join(logs.Providers(), ", "))
+	persistent.StringVar(&resource, "resource", "", "resource to read (log group / pod / app / deployment)")
+	persistent.StringVar(&service, "service", "", "logical service (also namespace for k8s)")
+	persistent.StringVar(&region, "region", "", "region (also kube context for k8s)")
+	persistent.StringVar(&since, "since", "15m", "window start: 15m, 2h, 3d, or RFC3339")
+	persistent.StringVar(&until, "until", "", "window end (RFC3339, default now)")
+	persistent.StringVar(&level, "level", "", "minimum level: debug|info|warn|error")
+	persistent.StringVar(&grep, "grep", "", "message filter (substring, or /regex/)")
+	persistent.IntVar(&limit, "limit", 1000, "max entries for bounded queries")
+	persistent.StringVar(&format, "format", "jsonl", "output format: jsonl (json for sources)")
+	persistent.StringVar(&profile, "profile", "", "AWS profile")
+
+	// sources
+	sourcesCmd := &cobra.Command{
+		Use:   "sources",
+		Short: "Discover available log sources for a provider",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts, err := buildOpts()
+			if err != nil {
+				return err
+			}
+			collector, err := logs.Get(provider)
+			if err != nil {
+				return err
+			}
+			sources, err := collector.Sources(cmd.Context(), opts)
+			if err != nil {
+				return err
+			}
+			out, _ := json.Marshal(map[string]any{"provider": provider, "sources": sources})
+			fmt.Fprintln(os.Stdout, string(out))
+			return nil
+		},
+	}
+
+	emitJSONL := func(e logs.Entry) error {
+		b, err := json.Marshal(e)
+		if err != nil {
+			return nil // skip an unmarshalable entry rather than abort the stream
+		}
+		_, werr := os.Stdout.Write(append(b, '\n'))
+		return werr
+	}
+
+	// query
+	queryCmd := &cobra.Command{
+		Use:   "query",
+		Short: "Fetch a bounded window of logs (JSON-lines on stdout)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts, err := buildOpts()
+			if err != nil {
+				return err
+			}
+			collector, err := logs.Get(provider)
+			if err != nil {
+				return err
+			}
+			logs.EmitProgress("collect", fmt.Sprintf("querying %s %s", provider, resource))
+			return collector.Query(cmd.Context(), opts, emitJSONL)
+		},
+	}
+
+	// tail
+	tailCmd := &cobra.Command{
+		Use:   "tail",
+		Short: "Follow logs live (JSON-lines on stdout until interrupted)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts, err := buildOpts()
+			if err != nil {
+				return err
+			}
+			opts.Follow = true
+			collector, err := logs.Get(provider)
+			if err != nil {
+				return err
+			}
+			ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+			logs.EmitProgress("collect", fmt.Sprintf("tailing %s %s", provider, resource))
+			return collector.Tail(ctx, opts, emitJSONL)
+		},
+	}
+
+	// chat
+	chatCmd := &cobra.Command{
+		Use:   "chat [question]",
+		Short: "Ask questions about logs (agentic talk-to-logs)",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			question := strings.Join(args, " ")
+			opts, err := buildOpts()
+			if err != nil {
+				return err
+			}
+			if limit <= 0 || limit > 5000 {
+				opts.Limit = 2000
+			}
+			return runLogsChat(cmd.Context(), opts, question)
+		},
+	}
+	chatCmd.Flags().StringVar(&aiProfile, "ai-profile", "", "AI provider profile override")
+
+	logsCmd.AddCommand(sourcesCmd, queryCmd, tailCmd, chatCmd)
+	return logsCmd
+}
+
+// runLogsChat collects the scoped logs, compresses them, and streams an
+// LLM answer grounded in citable lines.
+func runLogsChat(ctx context.Context, opts logs.Options, question string) error {
+	collector, err := logs.Get(opts.Provider)
+	if err != nil {
+		return err
+	}
+
+	logs.EmitProgress("collect", fmt.Sprintf("collecting %s logs for analysis", opts.Provider))
+	var entries []logs.Entry
+	cap := opts.Limit
+	if cap <= 0 {
+		cap = 2000
+	}
+	collectErr := collector.Query(ctx, opts, func(e logs.Entry) error {
+		entries = append(entries, e)
+		if len(entries) >= cap {
+			return context.Canceled // stop once we hit the cap
+		}
+		return nil
+	})
+	if collectErr != nil && collectErr != context.Canceled {
+		return collectErr
+	}
+
+	logs.EmitProgress("analyze", fmt.Sprintf("summarizing %d log lines", len(entries)))
+	contextBlock, truncated := logs.BuildChatContext(entries, 60)
+	patterns := logs.ErrorPatterns(entries)
+
+	prompt := buildLogsChatPrompt(opts, question, contextBlock, patterns, truncated, len(entries))
+
+	logs.EmitProgress("synthesize", "analyzing logs with the model")
+	aiClient, err := createAIClient(false)
+	if err != nil {
+		return err
+	}
+	answer, err := aiClient.AskPrompt(ctx, prompt)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(os.Stdout, strings.TrimSpace(answer))
+	return nil
+}
+
+func buildLogsChatPrompt(opts logs.Options, question, contextBlock string, patterns map[string]int, truncated bool, total int) string {
+	var b strings.Builder
+	b.WriteString("You are a log analysis assistant. Answer the user's question using ONLY the log lines provided below.\n")
+	b.WriteString("Rules:\n")
+	b.WriteString("- Cite specific evidence with its [ref:...] marker for every factual claim.\n")
+	b.WriteString("- If the answer is not present in these logs, say so plainly and name what was searched; do not invent details.\n")
+	b.WriteString("- For deduplicated patterns, cite the pattern and its count (e.g. 'x42'), not invented per-line values.\n")
+	b.WriteString("- Label any root-cause statement as a hypothesis with the evidence supporting it.\n\n")
+
+	fmt.Fprintf(&b, "Scope: provider=%s resource=%s", opts.Provider, opts.Resource)
+	if opts.Service != "" {
+		fmt.Fprintf(&b, " service=%s", opts.Service)
+	}
+	if opts.Level != "" {
+		fmt.Fprintf(&b, " level>=%s", opts.Level)
+	}
+	if opts.Grep != "" {
+		fmt.Fprintf(&b, " grep=%q", opts.Grep)
+	}
+	fmt.Fprintf(&b, " window-from=%s\n", opts.Since.UTC().Format(time.RFC3339))
+	fmt.Fprintf(&b, "Signal counts: %d errors, %d timeouts, %d connection failures across %d lines.\n",
+		patterns["errors"], patterns["timeouts"], patterns["connection_failures"], total)
+	if truncated {
+		b.WriteString("(Note: the window was large; only the top patterns by severity/frequency are shown.)\n")
+	}
+	b.WriteString("\n--- LOGS ---\n")
+	b.WriteString(contextBlock)
+	b.WriteString("\n--- QUESTION ---\n")
+	b.WriteString(question)
+	b.WriteString("\n")
+	return b.String()
+}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -58,9 +58,11 @@ func newLogsCmd() *cobra.Command {
 			Profile:  profile,
 		}
 		if strings.TrimSpace(until) != "" {
-			if t, err := time.Parse(time.RFC3339, until); err == nil {
-				opts.Until = t
+			t, err := time.Parse(time.RFC3339, until)
+			if err != nil {
+				return logs.Options{}, fmt.Errorf("invalid --until %q: use an RFC3339 timestamp", until)
 			}
+			opts.Until = t
 		}
 		return opts, nil
 	}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -12,7 +13,12 @@ import (
 
 	"github.com/bgdnvk/clanker/internal/logs"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
+
+// errCollectLimit stops collection once the chat cap is reached (a deliberate
+// early exit, distinct from a cancelled context).
+var errCollectLimit = errors.New("collect limit reached")
 
 // newLogsCmd builds `clanker logs`, the provider-agnostic log surface the cloud
 // app drives. `query`/`tail` stream normalized JSON-lines on stdout (progress
@@ -165,7 +171,7 @@ the talk-to-logs agent.`,
 			if limit <= 0 || limit > 5000 {
 				opts.Limit = 2000
 			}
-			return runLogsChat(cmd.Context(), opts, question)
+			return runLogsChat(cmd.Context(), opts, question, aiProfile)
 		},
 	}
 	chatCmd.Flags().StringVar(&aiProfile, "ai-profile", "", "AI provider profile override")
@@ -176,10 +182,15 @@ the talk-to-logs agent.`,
 
 // runLogsChat collects the scoped logs, compresses them, and streams an
 // LLM answer grounded in citable lines.
-func runLogsChat(ctx context.Context, opts logs.Options, question string) error {
+func runLogsChat(ctx context.Context, opts logs.Options, question, aiProfile string) error {
 	collector, err := logs.Get(opts.Provider)
 	if err != nil {
 		return err
+	}
+	// Override the AI provider for this run if requested (createAIClient reads
+	// ai.default_provider when no per-command profile is set).
+	if strings.TrimSpace(aiProfile) != "" {
+		viper.Set("ai.default_provider", strings.TrimSpace(aiProfile))
 	}
 
 	logs.EmitProgress("collect", fmt.Sprintf("collecting %s logs for analysis", opts.Provider))
@@ -191,11 +202,11 @@ func runLogsChat(ctx context.Context, opts logs.Options, question string) error 
 	collectErr := collector.Query(ctx, opts, func(e logs.Entry) error {
 		entries = append(entries, e)
 		if len(entries) >= cap {
-			return context.Canceled // stop once we hit the cap
+			return errCollectLimit // stop once we hit the cap
 		}
 		return nil
 	})
-	if collectErr != nil && collectErr != context.Canceled {
+	if collectErr != nil && !errors.Is(collectErr, errCollectLimit) {
 		return collectErr
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -168,6 +168,10 @@ func init() {
 	rootCmd.AddCommand(tencentCmd)
 
 	rootCmd.AddCommand(newBoxCmd())
+
+	// Unified multi-provider logs (query/tail/chat) — drives the cloud app's
+	// logs viewer + talk-to-logs agent.
+	rootCmd.AddCommand(newLogsCmd())
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/internal/logs/aws.go
+++ b/internal/logs/aws.go
@@ -65,7 +65,12 @@ func (c *awsCollector) fetch(ctx context.Context, opts Options, startMs, endMs i
 		"--log-group-name", opts.Resource,
 		"--start-time", fmt.Sprintf("%d", startMs),
 		"--end-time", fmt.Sprintf("%d", endMs),
+		// --limit bounds the single API page; --no-paginate stops the CLI from
+		// auto-following nextToken, so the result is a hard cap of `limit`
+		// events instead of the whole window. (--max-items can't be used: it
+		// conflicts with --no-paginate, which some AWS CLI configs set.)
 		"--limit", fmt.Sprintf("%d", limit),
+		"--no-paginate",
 	}
 	out, err := runJSON(ctx, "aws", c.awsArgs(opts, base...), opts.Env)
 	if err != nil {
@@ -149,6 +154,7 @@ func (c *awsCollector) Tail(ctx context.Context, opts Options, emit Emit) error 
 
 	ticker := time.NewTicker(5 * time.Second) // poll floor for the billed FilterLogEvents API
 	defer ticker.Stop()
+	fails := 0
 	for {
 		select {
 		case <-ctx.Done():
@@ -157,8 +163,14 @@ func (c *awsCollector) Tail(ctx context.Context, opts Options, emit Emit) error 
 			// 1s overlap so boundary-straddling events aren't missed; dedup by ref.
 			events, err := c.fetch(ctx, opts, lastMs-1000, time.Now().UnixMilli(), 1000)
 			if err != nil {
-				return err
+				// Tolerate transient API blips; only give up after a streak.
+				if fails++; fails >= maxConsecutivePollErrors {
+					return err
+				}
+				EmitProgress("tail", fmt.Sprintf("aws poll error (%d/%d), retrying: %v", fails, maxConsecutivePollErrors, err))
+				continue
 			}
+			fails = 0
 			if err := flush(events); err != nil {
 				return err
 			}

--- a/internal/logs/aws.go
+++ b/internal/logs/aws.go
@@ -1,0 +1,171 @@
+package logs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+func init() { register("aws", func() Collector { return &awsCollector{} }) }
+
+// awsCollector pulls CloudWatch Logs by shelling out to the `aws` CLI, which
+// resolves credentials from AWS_PROFILE/env the same way the rest of the CLI
+// does. Tail is poll-based (FilterLogEvents on an interval); StartLiveTail is a
+// future enhancement.
+type awsCollector struct{}
+
+func (c *awsCollector) Provider() string { return "aws" }
+
+func (c *awsCollector) awsArgs(opts Options, base ...string) []string {
+	args := append([]string{}, base...)
+	args = append(args, "--output", "json")
+	if opts.Region != "" {
+		args = append(args, "--region", opts.Region)
+	}
+	if opts.Profile != "" {
+		args = append(args, "--profile", opts.Profile)
+	}
+	return args
+}
+
+func (c *awsCollector) Sources(ctx context.Context, opts Options) ([]Source, error) {
+	out, err := runJSON(ctx, "aws", c.awsArgs(opts, "logs", "describe-log-groups", "--max-items", "200"), opts.Env)
+	if err != nil {
+		return nil, err
+	}
+	var data struct {
+		LogGroups []struct {
+			LogGroupName string `json:"logGroupName"`
+		} `json:"logGroups"`
+	}
+	if err := json.Unmarshal(out, &data); err != nil {
+		return nil, fmt.Errorf("parse log groups: %w", err)
+	}
+	sources := make([]Source, 0, len(data.LogGroups))
+	for _, g := range data.LogGroups {
+		sources = append(sources, Source{ID: g.LogGroupName, Kind: "log-group", Region: opts.Region})
+	}
+	return sources, nil
+}
+
+type awsEvent struct {
+	Timestamp     int64  `json:"timestamp"`
+	Message       string `json:"message"`
+	LogStreamName string `json:"logStreamName"`
+}
+
+// fetch one bounded page of events in (start, end].
+func (c *awsCollector) fetch(ctx context.Context, opts Options, startMs, endMs int64, limit int) ([]awsEvent, error) {
+	if opts.Resource == "" {
+		return nil, fmt.Errorf("aws logs require --resource <log-group-name>")
+	}
+	base := []string{
+		"logs", "filter-log-events",
+		"--log-group-name", opts.Resource,
+		"--start-time", fmt.Sprintf("%d", startMs),
+		"--end-time", fmt.Sprintf("%d", endMs),
+		"--limit", fmt.Sprintf("%d", limit),
+	}
+	out, err := runJSON(ctx, "aws", c.awsArgs(opts, base...), opts.Env)
+	if err != nil {
+		return nil, err
+	}
+	var data struct {
+		Events []awsEvent `json:"events"`
+	}
+	if err := json.Unmarshal(out, &data); err != nil {
+		return nil, fmt.Errorf("parse log events: %w", err)
+	}
+	return data.Events, nil
+}
+
+func (c *awsCollector) toEntry(opts Options, ev awsEvent) Entry {
+	ts := time.UnixMilli(ev.Timestamp)
+	e := NewEntry("aws", opts.Resource, ev.LogStreamName, ev.Message, ts)
+	e.Service = opts.Service
+	if opts.Region != "" {
+		e.AddLabel("region", opts.Region)
+	}
+	return e
+}
+
+func (c *awsCollector) Query(ctx context.Context, opts Options, emit Emit) error {
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 1000
+	}
+	endMs := opts.Until.UnixMilli()
+	if opts.Until.IsZero() {
+		endMs = time.Now().UnixMilli()
+	}
+	events, err := c.fetch(ctx, opts, opts.Since.UnixMilli(), endMs, limit)
+	if err != nil {
+		return err
+	}
+	matcher := newMatcher(opts)
+	for _, ev := range events {
+		e := c.toEntry(opts, ev)
+		if !matcher.Match(e) {
+			continue
+		}
+		if err := emit(e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *awsCollector) Tail(ctx context.Context, opts Options, emit Emit) error {
+	matcher := newMatcher(opts)
+	// Backfill the requested window, then poll for new events.
+	lastMs := opts.Since.UnixMilli()
+	backfill, err := c.fetch(ctx, opts, lastMs, time.Now().UnixMilli(), 1000)
+	if err != nil {
+		return err
+	}
+	seen := map[string]struct{}{}
+	flush := func(events []awsEvent) error {
+		for _, ev := range events {
+			if ev.Timestamp > lastMs {
+				lastMs = ev.Timestamp
+			}
+			e := c.toEntry(opts, ev)
+			if _, dup := seen[e.Ref]; dup {
+				continue
+			}
+			seen[e.Ref] = struct{}{}
+			if !matcher.Match(e) {
+				continue
+			}
+			if err := emit(e); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if err := flush(backfill); err != nil {
+		return err
+	}
+
+	ticker := time.NewTicker(5 * time.Second) // poll floor for the billed FilterLogEvents API
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			// 1s overlap so boundary-straddling events aren't missed; dedup by ref.
+			events, err := c.fetch(ctx, opts, lastMs-1000, time.Now().UnixMilli(), 1000)
+			if err != nil {
+				return err
+			}
+			if err := flush(events); err != nil {
+				return err
+			}
+			if len(seen) > 20000 { // bound the dedup set on long-lived tails
+				seen = map[string]struct{}{}
+			}
+		}
+	}
+}

--- a/internal/logs/aws.go
+++ b/internal/logs/aws.go
@@ -124,17 +124,16 @@ func (c *awsCollector) Tail(ctx context.Context, opts Options, emit Emit) error 
 	if err != nil {
 		return err
 	}
-	seen := map[string]struct{}{}
+	seen := newRefDedup(2 * time.Minute)
 	flush := func(events []awsEvent) error {
 		for _, ev := range events {
 			if ev.Timestamp > lastMs {
 				lastMs = ev.Timestamp
 			}
 			e := c.toEntry(opts, ev)
-			if _, dup := seen[e.Ref]; dup {
+			if !seen.add(e.Ref, ev.Timestamp) {
 				continue
 			}
-			seen[e.Ref] = struct{}{}
 			if !matcher.Match(e) {
 				continue
 			}
@@ -162,9 +161,6 @@ func (c *awsCollector) Tail(ctx context.Context, opts Options, emit Emit) error 
 			}
 			if err := flush(events); err != nil {
 				return err
-			}
-			if len(seen) > 20000 { // bound the dedup set on long-lived tails
-				seen = map[string]struct{}{}
 			}
 		}
 	}

--- a/internal/logs/collector.go
+++ b/internal/logs/collector.go
@@ -116,6 +116,36 @@ func (m compiledMatcher) Match(e Entry) bool {
 	return true
 }
 
+// refDedup tracks recently-emitted entry refs for poll-based tails, keyed by
+// epoch ms so it can be pruned by a sliding time window instead of cleared
+// wholesale (a full clear re-emits the next poll's overlap as duplicates).
+type refDedup struct {
+	seen     map[string]int64
+	windowMs int64
+}
+
+func newRefDedup(window time.Duration) *refDedup {
+	return &refDedup{seen: map[string]int64{}, windowMs: window.Milliseconds()}
+}
+
+// add reports whether ref is new (not seen within the window) and records it.
+func (d *refDedup) add(ref string, epochMs int64) bool {
+	if _, ok := d.seen[ref]; ok {
+		return false
+	}
+	d.seen[ref] = epochMs
+	// Prune entries older than the retention window relative to this one.
+	if len(d.seen) > 4096 {
+		cutoff := epochMs - d.windowMs
+		for k, ts := range d.seen {
+			if ts < cutoff {
+				delete(d.seen, k)
+			}
+		}
+	}
+	return true
+}
+
 // ParseSince resolves a relative ("15m", "2h", "3d") or absolute (RFC3339)
 // window-start string against now. Empty defaults to 15m ago (the cost-safe
 // default). now is passed in so callers/tests control the clock.

--- a/internal/logs/collector.go
+++ b/internal/logs/collector.go
@@ -1,0 +1,145 @@
+package logs
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Options are the normalized filters every collector understands. Collectors
+// push down what the provider API supports (time window, grep) and the caller
+// applies the rest client-side via Match.
+type Options struct {
+	Provider string
+	Resource string // log group / app / deployment / cluster context
+	Service  string // logical service selector when Resource is unknown
+	Region   string
+	Since    time.Time
+	Until    time.Time
+	Level    string // minimum level filter (e.g. "warn")
+	Grep     string // substring (or /regex/) message filter
+	Limit    int    // hard cap for bounded queries
+	Follow   bool   // tail mode
+	Profile  string // AWS profile (also set via Env AWS_PROFILE)
+	// Env carries per-provider credentials/config to inject into any CLI the
+	// collector shells out to (AWS_PROFILE, GOOGLE_CLOUD_PROJECT, fly/vercel
+	// tokens, etc.). Populated by the caller from request headers.
+	Env map[string]string
+}
+
+// Source is a discoverable log source for a provider (a log group, app, etc.).
+type Source struct {
+	ID      string `json:"id"`
+	Kind    string `json:"kind"`
+	Service string `json:"service,omitempty"`
+	Region  string `json:"region,omitempty"`
+}
+
+// Emit is the callback collectors push normalized entries to. Returning an
+// error stops collection (e.g. the consumer disconnected).
+type Emit func(Entry) error
+
+// Collector pulls logs for one provider. Query is bounded backfill; Tail
+// follows until ctx is cancelled. Both stream via Emit so neither buffers an
+// unbounded result set.
+type Collector interface {
+	Provider() string
+	Sources(ctx context.Context, opts Options) ([]Source, error)
+	Query(ctx context.Context, opts Options, emit Emit) error
+	Tail(ctx context.Context, opts Options, emit Emit) error
+}
+
+// registry maps provider id -> collector factory. Adding a new provider is a
+// single Register call from its file's init() — the extension point for
+// GCP/Azure/Cloudflare.
+var registry = map[string]func() Collector{}
+
+func register(provider string, factory func() Collector) {
+	registry[provider] = factory
+}
+
+// Get returns the collector for a provider id, or an error if unsupported.
+func Get(provider string) (Collector, error) {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	factory, ok := registry[provider]
+	if !ok {
+		return nil, fmt.Errorf("unsupported log provider %q (supported: %s)", provider, strings.Join(Providers(), ", "))
+	}
+	return factory(), nil
+}
+
+// Providers lists registered provider ids, sorted.
+func Providers() []string {
+	out := make([]string, 0, len(registry))
+	for p := range registry {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// compiledMatcher precompiles the grep filter once per collection.
+type compiledMatcher struct {
+	level string
+	sub   string
+	re    *regexp.Regexp
+}
+
+func newMatcher(opts Options) compiledMatcher {
+	m := compiledMatcher{level: strings.ToLower(strings.TrimSpace(opts.Level))}
+	grep := strings.TrimSpace(opts.Grep)
+	if len(grep) >= 2 && strings.HasPrefix(grep, "/") && strings.HasSuffix(grep, "/") {
+		if re, err := regexp.Compile("(?i)" + grep[1:len(grep)-1]); err == nil {
+			m.re = re
+			return m
+		}
+	}
+	m.sub = strings.ToLower(grep)
+	return m
+}
+
+// Match applies the client-side level + grep filter to an entry.
+func (m compiledMatcher) Match(e Entry) bool {
+	if !e.AtLeast(m.level) {
+		return false
+	}
+	if m.re != nil {
+		return m.re.MatchString(e.Message) || m.re.MatchString(e.Raw)
+	}
+	if m.sub != "" {
+		return strings.Contains(strings.ToLower(e.Message), m.sub) ||
+			strings.Contains(strings.ToLower(e.Raw), m.sub)
+	}
+	return true
+}
+
+// ParseSince resolves a relative ("15m", "2h", "3d") or absolute (RFC3339)
+// window-start string against now. Empty defaults to 15m ago (the cost-safe
+// default). now is passed in so callers/tests control the clock.
+func ParseSince(s string, now time.Time) (time.Time, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return now.Add(-15 * time.Minute), nil
+	}
+	if d, err := parseDuration(s); err == nil {
+		return now.Add(-d), nil
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, nil
+	}
+	return time.Time{}, fmt.Errorf("invalid --since %q: use 15m, 2h, 3d, or an RFC3339 timestamp", s)
+}
+
+// parseDuration extends time.ParseDuration with a "d" (day) suffix.
+func parseDuration(s string) (time.Duration, error) {
+	if strings.HasSuffix(s, "d") {
+		var days float64
+		if _, err := fmt.Sscanf(s, "%fd", &days); err == nil {
+			return time.Duration(days * 24 * float64(time.Hour)), nil
+		}
+	}
+	return time.ParseDuration(s)
+}

--- a/internal/logs/collector.go
+++ b/internal/logs/collector.go
@@ -81,15 +81,23 @@ func Providers() []string {
 	return out
 }
 
-// compiledMatcher precompiles the grep filter once per collection.
+// compiledMatcher precompiles the level/grep/time filter once per collection.
 type compiledMatcher struct {
-	level string
-	sub   string
-	re    *regexp.Regexp
+	level   string
+	sub     string
+	re      *regexp.Regexp
+	sinceMs int64
+	untilMs int64
 }
 
 func newMatcher(opts Options) compiledMatcher {
 	m := compiledMatcher{level: strings.ToLower(strings.TrimSpace(opts.Level))}
+	if !opts.Since.IsZero() {
+		m.sinceMs = opts.Since.UnixMilli()
+	}
+	if !opts.Until.IsZero() {
+		m.untilMs = opts.Until.UnixMilli()
+	}
 	grep := strings.TrimSpace(opts.Grep)
 	if len(grep) >= 2 && strings.HasPrefix(grep, "/") && strings.HasSuffix(grep, "/") {
 		if re, err := regexp.Compile("(?i)" + grep[1:len(grep)-1]); err == nil {
@@ -101,8 +109,16 @@ func newMatcher(opts Options) compiledMatcher {
 	return m
 }
 
-// Match applies the client-side level + grep filter to an entry.
+// Match applies the client-side time + level + grep filter to an entry. The
+// time bound makes the requested window honest for providers whose APIs don't
+// (or can't) push it down (Fly/Vercel/Railway return latest-N regardless).
 func (m compiledMatcher) Match(e Entry) bool {
+	if m.sinceMs > 0 && e.EpochMs > 0 && e.EpochMs < m.sinceMs {
+		return false
+	}
+	if m.untilMs > 0 && e.EpochMs > 0 && e.EpochMs > m.untilMs {
+		return false
+	}
 	if !e.AtLeast(m.level) {
 		return false
 	}
@@ -115,6 +131,10 @@ func (m compiledMatcher) Match(e Entry) bool {
 	}
 	return true
 }
+
+// maxConsecutivePollErrors bounds transient failures before a poll-tail gives
+// up, so a momentary 429/5xx/network blip doesn't end a long-running tail.
+const maxConsecutivePollErrors = 5
 
 // refDedup tracks recently-emitted entry refs for poll-based tails, keyed by
 // epoch ms so it can be pruned by a sliding time window instead of cleared

--- a/internal/logs/compress.go
+++ b/internal/logs/compress.go
@@ -1,0 +1,134 @@
+package logs
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var (
+	reTimestamp = regexp.MustCompile(`\b\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?\b`)
+	reUUID      = regexp.MustCompile(`\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b`)
+	reHex       = regexp.MustCompile(`\b0x[0-9a-fA-F]+\b|\b[0-9a-fA-F]{16,}\b`)
+	reNum       = regexp.MustCompile(`\b\d+\b`)
+)
+
+// templatize collapses volatile tokens (timestamps, ids, numbers) so repeated
+// log lines that differ only in those fields share one template.
+func templatize(msg string) string {
+	t := reTimestamp.ReplaceAllString(msg, "<ts>")
+	t = reUUID.ReplaceAllString(t, "<uuid>")
+	t = reHex.ReplaceAllString(t, "<hex>")
+	t = reNum.ReplaceAllString(t, "<n>")
+	t = strings.Join(strings.Fields(t), " ")
+	if len(t) > 200 {
+		t = t[:200]
+	}
+	return t
+}
+
+// Cluster is a group of near-identical log lines.
+type Cluster struct {
+	Template  string
+	Level     string
+	Count     int
+	FirstTs   string
+	LastTs    string
+	SampleRef string
+	Sample    string
+}
+
+// Cluster groups entries by templated message, preserving per-cluster counts,
+// time span, and one citable sample. Clusters are ordered by severity then
+// frequency so the most important patterns survive truncation.
+func ClusterEntries(entries []Entry) []Cluster {
+	idx := map[string]*Cluster{}
+	order := []string{}
+	for _, e := range entries {
+		key := e.Level + "|" + templatize(e.Message)
+		cl, ok := idx[key]
+		if !ok {
+			cl = &Cluster{
+				Template:  templatize(e.Message),
+				Level:     e.Level,
+				FirstTs:   e.Ts,
+				LastTs:    e.Ts,
+				SampleRef: e.Ref,
+				Sample:    e.Message,
+			}
+			idx[key] = cl
+			order = append(order, key)
+		}
+		cl.Count++
+		if e.Ts < cl.FirstTs {
+			cl.FirstTs = e.Ts
+		}
+		if e.Ts > cl.LastTs {
+			cl.LastTs = e.Ts
+		}
+	}
+	out := make([]Cluster, 0, len(order))
+	for _, k := range order {
+		out = append(out, *idx[k])
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		ri, rj := levelRank[out[i].Level], levelRank[out[j].Level]
+		if ri != rj {
+			return ri > rj // errors first
+		}
+		return out[i].Count > out[j].Count
+	})
+	return out
+}
+
+// BuildChatContext produces a compact, citable text block for the LLM from a
+// (possibly huge) set of entries. It dedups into clusters and caps the output
+// at maxClusters, keeping the highest-severity / most-frequent patterns. Each
+// line carries its [ref] so the model can cite real log lines. Returns the
+// block and whether the input was truncated.
+func BuildChatContext(entries []Entry, maxClusters int) (string, bool) {
+	if maxClusters <= 0 {
+		maxClusters = 60
+	}
+	clusters := ClusterEntries(entries)
+	truncated := len(clusters) > maxClusters
+	if truncated {
+		clusters = clusters[:maxClusters]
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d log lines summarized into %d distinct patterns", len(entries), len(clusters))
+	if truncated {
+		b.WriteString(" (showing the top patterns by severity/frequency)")
+	}
+	b.WriteString(":\n")
+	for _, cl := range clusters {
+		span := cl.FirstTs
+		if cl.LastTs != cl.FirstTs {
+			span = cl.FirstTs + "→" + cl.LastTs
+		}
+		fmt.Fprintf(&b, "- [%s] x%d %s [ref:%s] %s\n",
+			strings.ToUpper(cl.Level), cl.Count, span, cl.SampleRef, truncate(cl.Sample, 240))
+	}
+	return b.String(), truncated
+}
+
+// ErrorPatterns counts common failure keywords across entries (cheap signal for
+// the chat agent's root-cause hints).
+func ErrorPatterns(entries []Entry) map[string]int {
+	p := map[string]int{"errors": 0, "timeouts": 0, "connection_failures": 0, "total": len(entries)}
+	for _, e := range entries {
+		low := strings.ToLower(e.Message)
+		if e.Level == LevelError || e.Level == LevelFatal || strings.Contains(low, "error") {
+			p["errors"]++
+		}
+		if strings.Contains(low, "timeout") || strings.Contains(low, "timed out") {
+			p["timeouts"]++
+		}
+		if strings.Contains(low, "connection") && (strings.Contains(low, "refused") || strings.Contains(low, "failed") || strings.Contains(low, "reset")) {
+			p["connection_failures"]++
+		}
+	}
+	return p
+}

--- a/internal/logs/compress.go
+++ b/internal/logs/compress.go
@@ -35,6 +35,8 @@ type Cluster struct {
 	Count     int
 	FirstTs   string
 	LastTs    string
+	firstMs   int64
+	lastMs    int64
 	SampleRef string
 	Sample    string
 }
@@ -54,6 +56,8 @@ func ClusterEntries(entries []Entry) []Cluster {
 				Level:     e.Level,
 				FirstTs:   e.Ts,
 				LastTs:    e.Ts,
+				firstMs:   e.EpochMs,
+				lastMs:    e.EpochMs,
 				SampleRef: e.Ref,
 				Sample:    e.Message,
 			}
@@ -61,10 +65,14 @@ func ClusterEntries(entries []Entry) []Cluster {
 			order = append(order, key)
 		}
 		cl.Count++
-		if e.Ts < cl.FirstTs {
+		// Compare numeric epochs, not RFC3339Nano strings (whole-second
+		// timestamps drop the fractional part and would sort incorrectly).
+		if e.EpochMs < cl.firstMs {
+			cl.firstMs = e.EpochMs
 			cl.FirstTs = e.Ts
 		}
-		if e.Ts > cl.LastTs {
+		if e.EpochMs > cl.lastMs {
+			cl.lastMs = e.EpochMs
 			cl.LastTs = e.Ts
 		}
 	}

--- a/internal/logs/entry.go
+++ b/internal/logs/entry.go
@@ -1,0 +1,222 @@
+// Package logs provides a provider-agnostic model and collectors for the
+// unified multi-provider log viewer + "talk to logs" agent. Every provider
+// normalizes its native records into a single Entry so the backend can merge,
+// sort, filter, and stream them as one time-ordered view, and so the chat agent
+// can ground answers in real, citable lines.
+package logs
+
+import (
+	"crypto/sha1"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Levels, normalized across providers. Unknown is used rather than guessing
+// "info" so a missing/unparseable severity is never silently treated as benign.
+const (
+	LevelTrace   = "trace"
+	LevelDebug   = "debug"
+	LevelInfo    = "info"
+	LevelWarn    = "warn"
+	LevelError   = "error"
+	LevelFatal   = "fatal"
+	LevelUnknown = "unknown"
+)
+
+// levelRank orders severities for "minimum level" filtering. Unknown sorts
+// below info so a level>=warn filter doesn't accidentally hide unknown lines
+// that might be errors — unknown is only dropped by an explicit info+ filter.
+var levelRank = map[string]int{
+	LevelTrace:   0,
+	LevelDebug:   1,
+	LevelUnknown: 1,
+	LevelInfo:    2,
+	LevelWarn:    3,
+	LevelError:   4,
+	LevelFatal:   5,
+}
+
+// Entry is the normalized log record shared CLI -> backend -> frontend.
+type Entry struct {
+	Ts         string            `json:"ts"`                   // RFC3339Nano UTC
+	EpochMs    int64             `json:"epochMs"`              // sort key without reparsing
+	Provider   string            `json:"provider"`             // aws|k8s|flyio|vercel|railway
+	Source     string            `json:"source"`               // log group / app / deployment / cluster
+	Service    string            `json:"service,omitempty"`    // logical service/resource
+	Stream     string            `json:"stream,omitempty"`     // log stream / pod-container / region
+	Level      string            `json:"level"`                // normalized enum
+	RawLevel   string            `json:"rawLevel,omitempty"`   // provider's original severity (auditable)
+	Message    string            `json:"message"`              // extracted if JSON, else == Raw
+	Structured map[string]any    `json:"structured,omitempty"` // parsed JSON fields when present
+	Labels     map[string]string `json:"labels,omitempty"`     // region, traceId, requestId, ...
+	Raw        string            `json:"raw,omitempty"`        // original line verbatim
+	Ref        string            `json:"ref"`                  // stable citation id
+	Cursor     string            `json:"cursor,omitempty"`     // opaque per-source position token
+}
+
+// NewEntry builds a normalized Entry from a provider's raw line + timestamp,
+// auto-detecting structured JSON and normalizing severity. provider/source are
+// required; message defaults to the raw line.
+func NewEntry(provider, source, stream, raw string, ts time.Time) Entry {
+	ts = ts.UTC()
+	e := Entry{
+		Ts:       ts.Format(time.RFC3339Nano),
+		EpochMs:  ts.UnixMilli(),
+		Provider: provider,
+		Source:   source,
+		Stream:   stream,
+		Raw:      raw,
+		Message:  raw,
+		Level:    LevelUnknown,
+	}
+	e.applyStructured(raw)
+	if e.Level == LevelUnknown {
+		if lvl := levelFromText(e.Message); lvl != "" {
+			e.Level = lvl
+		}
+	}
+	e.Ref = makeRef(provider, stream, ts, e.Message)
+	return e
+}
+
+// applyStructured tries to parse the raw line as a JSON object and lift common
+// fields (message, level, trace/request ids) into the normalized shape.
+func (e *Entry) applyStructured(raw string) {
+	trimmed := strings.TrimSpace(raw)
+	if len(trimmed) < 2 || trimmed[0] != '{' {
+		return
+	}
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(trimmed), &obj); err != nil {
+		return
+	}
+	e.Structured = obj
+
+	for _, k := range []string{"message", "msg", "text", "log", "event"} {
+		if v, ok := obj[k]; ok {
+			if s := asString(v); s != "" {
+				e.Message = s
+				break
+			}
+		}
+	}
+	for _, k := range []string{"level", "severity", "lvl", "loglevel", "log_level"} {
+		if v, ok := obj[k]; ok {
+			if s := asString(v); s != "" {
+				e.RawLevel = s
+				e.Level = normalizeLevel(s)
+				break
+			}
+		}
+	}
+	for _, k := range []string{"trace_id", "traceId", "traceID", "request_id", "requestId", "span_id", "spanId"} {
+		if v, ok := obj[k]; ok {
+			if s := asString(v); s != "" {
+				if e.Labels == nil {
+					e.Labels = map[string]string{}
+				}
+				e.Labels[k] = s
+			}
+		}
+	}
+}
+
+// SetLevel applies a provider-native severity string, recording both the raw
+// value and the normalized enum.
+func (e *Entry) SetLevel(raw string) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return
+	}
+	e.RawLevel = raw
+	e.Level = normalizeLevel(raw)
+}
+
+// AddLabel attaches a provider dimension (region, account, env, ...).
+func (e *Entry) AddLabel(k, v string) {
+	if k == "" || v == "" {
+		return
+	}
+	if e.Labels == nil {
+		e.Labels = map[string]string{}
+	}
+	e.Labels[k] = v
+}
+
+// AtLeast reports whether the entry's level is >= the given minimum level.
+// An empty or unrecognized minimum passes everything.
+func (e Entry) AtLeast(min string) bool {
+	min = strings.ToLower(strings.TrimSpace(min))
+	minRank, ok := levelRank[min]
+	if !ok {
+		return true
+	}
+	return levelRank[e.Level] >= minRank
+}
+
+func normalizeLevel(s string) string {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "trace":
+		return LevelTrace
+	case "debug", "dbg", "fine", "finer", "finest", "verbose", "default":
+		return LevelDebug
+	case "info", "information", "informational", "notice", "i":
+		return LevelInfo
+	case "warn", "warning", "w":
+		return LevelWarn
+	case "error", "err", "e", "severe":
+		return LevelError
+	case "fatal", "critical", "crit", "panic", "alert", "emergency", "emerg":
+		return LevelFatal
+	default:
+		return LevelUnknown
+	}
+}
+
+// levelFromText is a cheap heuristic for unstructured lines with no explicit
+// severity field. Returns "" when nothing matches so the caller keeps Unknown.
+func levelFromText(msg string) string {
+	up := strings.ToUpper(msg)
+	switch {
+	case strings.Contains(up, "FATAL"), strings.Contains(up, "PANIC"), strings.Contains(up, "CRITICAL"):
+		return LevelFatal
+	case strings.Contains(up, "ERROR"), strings.Contains(up, "ERR "), strings.Contains(up, "EXCEPTION"), strings.Contains(up, "TRACEBACK"):
+		return LevelError
+	case strings.Contains(up, "WARN"):
+		return LevelWarn
+	case strings.Contains(up, "INFO"):
+		return LevelInfo
+	case strings.Contains(up, "DEBUG"), strings.Contains(up, "TRACE"):
+		return LevelDebug
+	default:
+		return ""
+	}
+}
+
+func asString(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case float64:
+		return strconv.FormatFloat(t, 'f', -1, 64)
+	case bool:
+		return strconv.FormatBool(t)
+	case nil:
+		return ""
+	default:
+		b, err := json.Marshal(t)
+		if err != nil {
+			return ""
+		}
+		return string(b)
+	}
+}
+
+// makeRef builds a stable citation id the UI can resolve back to a row.
+func makeRef(provider, stream string, ts time.Time, message string) string {
+	h := sha1.Sum([]byte(message))
+	return fmt.Sprintf("%s:%s:%d:%x", provider, stream, ts.UnixMilli(), h[:4])
+}

--- a/internal/logs/exec.go
+++ b/internal/logs/exec.go
@@ -66,6 +66,12 @@ func streamLines(ctx context.Context, name string, args []string, env map[string
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		if err := fn(scanner.Text()); err != nil {
+			// Consumer gave up (e.g. broken pipe): kill the whole process group
+			// and reap, so kubectl/flyctl don't outlive us as orphans.
+			if cmd.Process != nil {
+				_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+			}
+			_ = cmd.Wait()
 			return err
 		}
 	}

--- a/internal/logs/exec.go
+++ b/internal/logs/exec.go
@@ -1,0 +1,108 @@
+package logs
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+)
+
+// runJSON runs a CLI to completion and returns stdout. Extra env vars are
+// appended to the inherited environment (used to inject per-provider creds).
+func runJSON(ctx context.Context, name string, args []string, env map[string]string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = mergedEnv(env)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, fmt.Errorf("%s %s: %s", name, strings.Join(args, " "), truncate(msg, 500))
+	}
+	return stdout.Bytes(), nil
+}
+
+// streamLines runs a long-lived CLI (e.g. `kubectl logs -f`, `flyctl logs`),
+// invoking fn for each stdout line until the process exits or ctx is cancelled.
+// The child is started in its own process group so cancellation kills any
+// descendants (kubectl/flyctl spawn helpers) rather than orphaning them.
+func streamLines(ctx context.Context, name string, args []string, env map[string]string, fn func(line string) error) error {
+	cmd := exec.Command(name, args...)
+	cmd.Env = mergedEnv(env)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	// Kill the whole process group when ctx is cancelled.
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			if cmd.Process != nil {
+				_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+			}
+		case <-done:
+		}
+	}()
+
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		if err := fn(scanner.Text()); err != nil {
+			return err
+		}
+	}
+	scanErr := scanner.Err()
+	waitErr := cmd.Wait()
+
+	// A ctx-cancelled tail (SIGKILL) is an expected stop, not a failure.
+	if ctx.Err() != nil {
+		return nil
+	}
+	if scanErr != nil {
+		return scanErr
+	}
+	if waitErr != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = waitErr.Error()
+		}
+		return fmt.Errorf("%s: %s", name, truncate(msg, 500))
+	}
+	return nil
+}
+
+func mergedEnv(env map[string]string) []string {
+	out := os.Environ()
+	for k, v := range env {
+		if k == "" {
+			continue
+		}
+		out = append(out, k+"="+v)
+	}
+	return out
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/internal/logs/flyio.go
+++ b/internal/logs/flyio.go
@@ -1,0 +1,104 @@
+package logs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+func init() {
+	register("flyio", func() Collector { return &flyCollector{} })
+	register("fly", func() Collector { return &flyCollector{} }) // alias
+}
+
+// flyCollector reads Fly.io logs via the `flyctl` CLI. Resource is the app name.
+// Fly supports a live tail (default) and `--no-tail` for a bounded recent dump,
+// so Query uses --no-tail and Tail follows.
+type flyCollector struct{}
+
+func (c *flyCollector) Provider() string { return "flyio" }
+
+func (c *flyCollector) args(opts Options, follow bool) []string {
+	args := []string{"logs", "--app", opts.Resource}
+	if opts.Region != "" {
+		args = append(args, "--region", opts.Region)
+	}
+	if !follow {
+		args = append(args, "--no-tail")
+	}
+	return args
+}
+
+// parseLine handles flyctl's text format: "<rfc3339> app[instance] region msg".
+func (c *flyCollector) parseLine(opts Options, line string) Entry {
+	ts := time.Now()
+	msg := line
+	if idx := strings.IndexByte(line, ' '); idx > 0 {
+		if t, err := time.Parse(time.RFC3339Nano, line[:idx]); err == nil {
+			ts = t
+			msg = strings.TrimSpace(line[idx+1:])
+		} else if t, err := time.Parse(time.RFC3339, line[:idx]); err == nil {
+			ts = t
+			msg = strings.TrimSpace(line[idx+1:])
+		}
+	}
+	e := NewEntry("flyio", opts.Resource, opts.Region, msg, ts)
+	e.Service = opts.Service
+	if opts.Region != "" {
+		e.AddLabel("region", opts.Region)
+	}
+	return e
+}
+
+func (c *flyCollector) Query(ctx context.Context, opts Options, emit Emit) error {
+	if opts.Resource == "" {
+		return fmt.Errorf("flyio logs require --resource <app-name>")
+	}
+	out, err := runJSON(ctx, "flyctl", c.args(opts, false), opts.Env)
+	if err != nil {
+		return err
+	}
+	matcher := newMatcher(opts)
+	lines := strings.Split(string(out), "\n")
+	if opts.Limit > 0 && len(lines) > opts.Limit {
+		lines = lines[len(lines)-opts.Limit:]
+	}
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		e := c.parseLine(opts, line)
+		if !matcher.Match(e) {
+			continue
+		}
+		if err := emit(e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *flyCollector) Tail(ctx context.Context, opts Options, emit Emit) error {
+	if opts.Resource == "" {
+		return fmt.Errorf("flyio logs require --resource <app-name>")
+	}
+	matcher := newMatcher(opts)
+	return streamLines(ctx, "flyctl", c.args(opts, true), opts.Env, func(line string) error {
+		if strings.TrimSpace(line) == "" {
+			return nil
+		}
+		e := c.parseLine(opts, line)
+		if !matcher.Match(e) {
+			return nil
+		}
+		return emit(e)
+	})
+}
+
+func (c *flyCollector) Sources(ctx context.Context, opts Options) ([]Source, error) {
+	// `flyctl apps list` output is tabular and unstable to parse; app discovery
+	// is left to the dedicated `clanker fly` commands. Return empty so the UI
+	// prompts for an app name rather than failing.
+	return nil, nil
+}

--- a/internal/logs/k8s.go
+++ b/internal/logs/k8s.go
@@ -1,0 +1,139 @@
+package logs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+func init() { register("k8s", func() Collector { return &k8sCollector{} }) }
+
+// k8sCollector reads pod logs via `kubectl`. Mapping of the generic Options:
+//
+//	Resource -> kubectl target: a pod name or "deployment/<name>"
+//	Service  -> namespace (-n)
+//	Region   -> kube context (--context)
+//
+// Tail is a true live follow (`kubectl logs -f`).
+type k8sCollector struct{}
+
+func (c *k8sCollector) Provider() string { return "k8s" }
+
+func (c *k8sCollector) base(opts Options, extra ...string) []string {
+	args := append([]string{}, extra...)
+	ns := opts.Service
+	if ns == "" {
+		ns = "default"
+	}
+	args = append(args, "-n", ns)
+	if opts.Region != "" {
+		args = append(args, "--context", opts.Region)
+	}
+	return args
+}
+
+func (c *k8sCollector) Sources(ctx context.Context, opts Options) ([]Source, error) {
+	out, err := runJSON(ctx, "kubectl", c.base(opts, "get", "pods", "-o", "json"), opts.Env)
+	if err != nil {
+		return nil, err
+	}
+	var data struct {
+		Items []struct {
+			Metadata struct {
+				Name      string `json:"name"`
+				Namespace string `json:"namespace"`
+			} `json:"metadata"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(out, &data); err != nil {
+		return nil, fmt.Errorf("parse pods: %w", err)
+	}
+	sources := make([]Source, 0, len(data.Items))
+	for _, it := range data.Items {
+		sources = append(sources, Source{ID: it.Metadata.Name, Kind: "pod", Service: it.Metadata.Namespace, Region: opts.Region})
+	}
+	return sources, nil
+}
+
+func (c *k8sCollector) logArgs(opts Options, follow bool) []string {
+	if opts.Resource == "" {
+		opts.Resource = "" // validated by caller
+	}
+	args := c.base(opts, "logs", opts.Resource, "--timestamps")
+	if !opts.Since.IsZero() {
+		if d := time.Since(opts.Since); d > 0 {
+			args = append(args, fmt.Sprintf("--since=%ds", int64(d.Seconds())))
+		}
+	}
+	if opts.Limit > 0 && !follow {
+		args = append(args, fmt.Sprintf("--tail=%d", opts.Limit))
+	} else if follow {
+		args = append(args, "--tail=200")
+	}
+	if follow {
+		args = append(args, "-f")
+	}
+	return args
+}
+
+// parseLine splits a `--timestamps` line ("2026-06-23T12:00:00.000Z message")
+// into a timestamp and message. Falls back to now if the prefix isn't a time.
+func (c *k8sCollector) parseLine(opts Options, line string) Entry {
+	ts := time.Now()
+	msg := line
+	if idx := strings.IndexByte(line, ' '); idx > 0 {
+		if t, err := time.Parse(time.RFC3339Nano, line[:idx]); err == nil {
+			ts = t
+			msg = line[idx+1:]
+		}
+	}
+	e := NewEntry("k8s", opts.Resource, opts.Resource, msg, ts)
+	e.Service = opts.Service
+	if opts.Region != "" {
+		e.AddLabel("context", opts.Region)
+	}
+	return e
+}
+
+func (c *k8sCollector) Query(ctx context.Context, opts Options, emit Emit) error {
+	if opts.Resource == "" {
+		return fmt.Errorf("k8s logs require --resource <pod|deployment/name>")
+	}
+	out, err := runJSON(ctx, "kubectl", c.logArgs(opts, false), opts.Env)
+	if err != nil {
+		return err
+	}
+	matcher := newMatcher(opts)
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		e := c.parseLine(opts, line)
+		if !matcher.Match(e) {
+			continue
+		}
+		if err := emit(e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *k8sCollector) Tail(ctx context.Context, opts Options, emit Emit) error {
+	if opts.Resource == "" {
+		return fmt.Errorf("k8s logs require --resource <pod|deployment/name>")
+	}
+	matcher := newMatcher(opts)
+	return streamLines(ctx, "kubectl", c.logArgs(opts, true), opts.Env, func(line string) error {
+		if strings.TrimSpace(line) == "" {
+			return nil
+		}
+		e := c.parseLine(opts, line)
+		if !matcher.Match(e) {
+			return nil
+		}
+		return emit(e)
+	})
+}

--- a/internal/logs/k8s.go
+++ b/internal/logs/k8s.go
@@ -58,9 +58,6 @@ func (c *k8sCollector) Sources(ctx context.Context, opts Options) ([]Source, err
 }
 
 func (c *k8sCollector) logArgs(opts Options, follow bool) []string {
-	if opts.Resource == "" {
-		opts.Resource = "" // validated by caller
-	}
 	args := c.base(opts, "logs", opts.Resource, "--timestamps")
 	if !opts.Since.IsZero() {
 		if d := time.Since(opts.Since); d > 0 {

--- a/internal/logs/logs_test.go
+++ b/internal/logs/logs_test.go
@@ -1,0 +1,105 @@
+package logs
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewEntryStructuredJSON(t *testing.T) {
+	raw := `{"level":"ERROR","message":"upstream timeout","trace_id":"abc123"}`
+	e := NewEntry("aws", "/svc", "stream-1", raw, time.Unix(1750000000, 0))
+	if e.Level != LevelError {
+		t.Fatalf("level = %q, want error", e.Level)
+	}
+	if e.RawLevel != "ERROR" {
+		t.Fatalf("rawLevel = %q, want ERROR", e.RawLevel)
+	}
+	if e.Message != "upstream timeout" {
+		t.Fatalf("message = %q, want extracted text", e.Message)
+	}
+	if e.Labels["trace_id"] != "abc123" {
+		t.Fatalf("trace_id label not lifted: %v", e.Labels)
+	}
+	if e.Ref == "" || e.EpochMs == 0 {
+		t.Fatalf("ref/epoch not set: ref=%q epoch=%d", e.Ref, e.EpochMs)
+	}
+}
+
+func TestNewEntryUnstructuredHeuristicAndUnknown(t *testing.T) {
+	e := NewEntry("k8s", "pod", "pod", "plain readiness probe ok", time.Now())
+	if e.Level != LevelUnknown {
+		t.Fatalf("expected unknown for benign line, got %q", e.Level)
+	}
+	e2 := NewEntry("k8s", "pod", "pod", "FATAL panic: nil deref", time.Now())
+	if e2.Level != LevelFatal {
+		t.Fatalf("expected fatal heuristic, got %q", e2.Level)
+	}
+}
+
+func TestMatcherLevelAndGrep(t *testing.T) {
+	warn := NewEntry("aws", "g", "s", `{"level":"warn","message":"slow"}`, time.Now())
+	info := NewEntry("aws", "g", "s", `{"level":"info","message":"ok hello"}`, time.Now())
+
+	m := newMatcher(Options{Level: "warn"})
+	if !m.Match(warn) || m.Match(info) {
+		t.Fatalf("level filter wrong: warn=%v info=%v", m.Match(warn), m.Match(info))
+	}
+
+	mg := newMatcher(Options{Grep: "hello"})
+	if mg.Match(warn) || !mg.Match(info) {
+		t.Fatalf("grep filter wrong")
+	}
+
+	mr := newMatcher(Options{Grep: "/sl.w/"})
+	if !mr.Match(warn) {
+		t.Fatalf("regex grep should match 'slow'")
+	}
+}
+
+func TestParseSince(t *testing.T) {
+	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	got, err := ParseSince("15m", now)
+	if err != nil || !got.Equal(now.Add(-15*time.Minute)) {
+		t.Fatalf("15m => %v err=%v", got, err)
+	}
+	got, err = ParseSince("", now)
+	if err != nil || !got.Equal(now.Add(-15*time.Minute)) {
+		t.Fatalf("default => %v err=%v", got, err)
+	}
+	got, err = ParseSince("2026-06-23T11:00:00Z", now)
+	if err != nil || got.UTC().Hour() != 11 {
+		t.Fatalf("rfc3339 => %v err=%v", got, err)
+	}
+	if _, err := ParseSince("bogus", now); err == nil {
+		t.Fatalf("expected error for bogus since")
+	}
+}
+
+func TestClusterAndContext(t *testing.T) {
+	base := time.Unix(1750000000, 0)
+	var entries []Entry
+	for i := 0; i < 5; i++ {
+		entries = append(entries, NewEntry("aws", "g", "s", `{"level":"info","message":"request 12 served"}`, base.Add(time.Duration(i)*time.Second)))
+	}
+	entries = append(entries, NewEntry("aws", "g", "s", `{"level":"error","message":"db connection refused"}`, base))
+
+	clusters := ClusterEntries(entries)
+	if len(clusters) != 2 {
+		t.Fatalf("want 2 clusters (numbers templated together), got %d", len(clusters))
+	}
+	if clusters[0].Level != LevelError {
+		t.Fatalf("error cluster should sort first, got %q", clusters[0].Level)
+	}
+	infoCluster := clusters[1]
+	if infoCluster.Count != 5 {
+		t.Fatalf("info cluster count = %d, want 5", infoCluster.Count)
+	}
+
+	block, truncated := BuildChatContext(entries, 60)
+	if truncated {
+		t.Fatalf("should not truncate small set")
+	}
+	if block == "" {
+		t.Fatalf("empty context block")
+	}
+}

--- a/internal/logs/progress.go
+++ b/internal/logs/progress.go
@@ -1,0 +1,35 @@
+package logs
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+// EmitProgress writes a progress trace the cloud backend parses off stderr
+// (same `::clanker-progress {json}` framing the AI client uses), gated by
+// CLANKER_PROGRESS_TRACE so it never pollutes normal CLI output.
+func EmitProgress(phase, message string) {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("CLANKER_PROGRESS_TRACE"))) {
+	case "1", "true", "yes", "on":
+	default:
+		return
+	}
+	phase = strings.TrimSpace(phase)
+	message = strings.TrimSpace(message)
+	if phase == "" || message == "" {
+		return
+	}
+	payload, err := json.Marshal(map[string]string{
+		"type":      "trace",
+		"phase":     phase,
+		"message":   message,
+		"timestamp": time.Now().UTC().Format(time.RFC3339Nano),
+	})
+	if err != nil {
+		return
+	}
+	fmt.Fprintln(os.Stderr, "::clanker-progress "+string(payload))
+}

--- a/internal/logs/railway.go
+++ b/internal/logs/railway.go
@@ -93,26 +93,22 @@ func (c *railwayCollector) Query(ctx context.Context, opts Options, emit Emit) e
 
 func (c *railwayCollector) Tail(ctx context.Context, opts Options, emit Emit) error {
 	matcher := newMatcher(opts)
-	seen := map[string]struct{}{}
+	seen := newRefDedup(10 * time.Minute)
 	poll := func() error {
 		entries, err := c.records(ctx, opts, 200)
 		if err != nil {
 			return err
 		}
 		for _, e := range entries {
-			if _, dup := seen[e.Ref]; dup {
+			if !seen.add(e.Ref, e.EpochMs) {
 				continue
 			}
-			seen[e.Ref] = struct{}{}
 			if !matcher.Match(e) {
 				continue
 			}
 			if err := emit(e); err != nil {
 				return err
 			}
-		}
-		if len(seen) > 20000 {
-			seen = map[string]struct{}{}
 		}
 		return nil
 	}

--- a/internal/logs/railway.go
+++ b/internal/logs/railway.go
@@ -1,0 +1,134 @@
+package logs
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/bgdnvk/clanker/internal/railway"
+)
+
+func init() { register("railway", func() Collector { return &railwayCollector{} }) }
+
+// railwayCollector reads Railway deployment logs via the GraphQL client
+// (ListDeploymentLogs returns {timestamp, message, severity}). Resource is a
+// deployment id. Railway has no public tail, so Tail is poll-based.
+type railwayCollector struct{}
+
+func (c *railwayCollector) Provider() string { return "railway" }
+
+func (c *railwayCollector) client(opts Options) (*railway.Client, error) {
+	// Empty args make NewClient fall back to RAILWAY_API_TOKEN / RAILWAY_WORKSPACE_ID
+	// env vars, which the caller injects from request headers.
+	return railway.NewClient(opts.Env["RAILWAY_API_TOKEN"], opts.Env["RAILWAY_WORKSPACE_ID"], false)
+}
+
+func (c *railwayCollector) Sources(ctx context.Context, opts Options) ([]Source, error) {
+	cl, err := c.client(opts)
+	if err != nil {
+		return nil, err
+	}
+	deps, err := cl.ListDeployments(ctx, "", "", "", 50)
+	if err != nil {
+		return nil, err
+	}
+	sources := make([]Source, 0, len(deps))
+	for _, d := range deps {
+		sources = append(sources, Source{ID: d.ID, Kind: "deployment", Service: d.ServiceID})
+	}
+	return sources, nil
+}
+
+func (c *railwayCollector) records(ctx context.Context, opts Options, limit int) ([]Entry, error) {
+	if opts.Resource == "" {
+		return nil, fmt.Errorf("railway logs require --resource <deployment-id>")
+	}
+	cl, err := c.client(opts)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := cl.ListDeploymentLogs(ctx, opts.Resource, false, limit)
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]Entry, 0, len(rows))
+	for _, r := range rows {
+		msg, _ := r["message"].(string)
+		ts := time.Now()
+		if s, ok := r["timestamp"].(string); ok {
+			if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+				ts = t
+			}
+		}
+		e := NewEntry("railway", opts.Resource, opts.Service, msg, ts)
+		e.Service = opts.Service
+		if sev, ok := r["severity"].(string); ok {
+			e.SetLevel(sev)
+		}
+		entries = append(entries, e)
+	}
+	return entries, nil
+}
+
+func (c *railwayCollector) Query(ctx context.Context, opts Options, emit Emit) error {
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 200
+	}
+	entries, err := c.records(ctx, opts, limit)
+	if err != nil {
+		return err
+	}
+	matcher := newMatcher(opts)
+	for _, e := range entries {
+		if !matcher.Match(e) {
+			continue
+		}
+		if err := emit(e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *railwayCollector) Tail(ctx context.Context, opts Options, emit Emit) error {
+	matcher := newMatcher(opts)
+	seen := map[string]struct{}{}
+	poll := func() error {
+		entries, err := c.records(ctx, opts, 200)
+		if err != nil {
+			return err
+		}
+		for _, e := range entries {
+			if _, dup := seen[e.Ref]; dup {
+				continue
+			}
+			seen[e.Ref] = struct{}{}
+			if !matcher.Match(e) {
+				continue
+			}
+			if err := emit(e); err != nil {
+				return err
+			}
+		}
+		if len(seen) > 20000 {
+			seen = map[string]struct{}{}
+		}
+		return nil
+	}
+	if err := poll(); err != nil {
+		return err
+	}
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := poll(); err != nil {
+				return err
+			}
+		}
+	}
+}

--- a/internal/logs/railway.go
+++ b/internal/logs/railway.go
@@ -117,14 +117,20 @@ func (c *railwayCollector) Tail(ctx context.Context, opts Options, emit Emit) er
 	}
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
+	fails := 0
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
 			if err := poll(); err != nil {
-				return err
+				if fails++; fails >= maxConsecutivePollErrors {
+					return err
+				}
+				EmitProgress("tail", fmt.Sprintf("railway poll error (%d/%d), retrying: %v", fails, maxConsecutivePollErrors, err))
+				continue
 			}
+			fails = 0
 		}
 	}
 }

--- a/internal/logs/vercel.go
+++ b/internal/logs/vercel.go
@@ -126,26 +126,22 @@ func (c *vercelCollector) Query(ctx context.Context, opts Options, emit Emit) er
 
 func (c *vercelCollector) Tail(ctx context.Context, opts Options, emit Emit) error {
 	matcher := newMatcher(opts)
-	seen := map[string]struct{}{}
+	seen := newRefDedup(10 * time.Minute)
 	poll := func() error {
 		entries, err := c.events(ctx, opts, 100)
 		if err != nil {
 			return err
 		}
 		for _, e := range entries {
-			if _, dup := seen[e.Ref]; dup {
+			if !seen.add(e.Ref, e.EpochMs) {
 				continue
 			}
-			seen[e.Ref] = struct{}{}
 			if !matcher.Match(e) {
 				continue
 			}
 			if err := emit(e); err != nil {
 				return err
 			}
-		}
-		if len(seen) > 20000 {
-			seen = map[string]struct{}{}
 		}
 		return nil
 	}

--- a/internal/logs/vercel.go
+++ b/internal/logs/vercel.go
@@ -150,14 +150,20 @@ func (c *vercelCollector) Tail(ctx context.Context, opts Options, emit Emit) err
 	}
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
+	fails := 0
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
 			if err := poll(); err != nil {
-				return err
+				if fails++; fails >= maxConsecutivePollErrors {
+					return err
+				}
+				EmitProgress("tail", fmt.Sprintf("vercel poll error (%d/%d), retrying: %v", fails, maxConsecutivePollErrors, err))
+				continue
 			}
+			fails = 0
 		}
 	}
 }

--- a/internal/logs/vercel.go
+++ b/internal/logs/vercel.go
@@ -1,0 +1,167 @@
+package logs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/bgdnvk/clanker/internal/vercel"
+)
+
+func init() { register("vercel", func() Collector { return &vercelCollector{} }) }
+
+// vercelCollector reads Vercel deployment build/runtime events via the REST API
+// (/v2/deployments/<uid>/events). Resource is a deployment UID. Vercel runtime
+// logs are per-deployment and short-lived, so Tail is poll-based over events.
+type vercelCollector struct{}
+
+func (c *vercelCollector) Provider() string { return "vercel" }
+
+func (c *vercelCollector) client(opts Options) (*vercel.Client, error) {
+	return vercel.NewClient(opts.Env["VERCEL_TOKEN"], opts.Env["VERCEL_TEAM_ID"], false)
+}
+
+func (c *vercelCollector) Sources(ctx context.Context, opts Options) ([]Source, error) {
+	cl, err := c.client(opts)
+	if err != nil {
+		return nil, err
+	}
+	body, err := cl.RunAPIWithContext(ctx, "GET", "/v6/deployments?limit=20", "")
+	if err != nil {
+		return nil, err
+	}
+	var data struct {
+		Deployments []struct {
+			UID  string `json:"uid"`
+			Name string `json:"name"`
+			URL  string `json:"url"`
+		} `json:"deployments"`
+	}
+	if err := json.Unmarshal([]byte(body), &data); err != nil {
+		return nil, fmt.Errorf("parse deployments: %w", err)
+	}
+	sources := make([]Source, 0, len(data.Deployments))
+	for _, d := range data.Deployments {
+		sources = append(sources, Source{ID: d.UID, Kind: "deployment", Service: d.Name})
+	}
+	return sources, nil
+}
+
+func (c *vercelCollector) events(ctx context.Context, opts Options, limit int) ([]Entry, error) {
+	if opts.Resource == "" {
+		return nil, fmt.Errorf("vercel logs require --resource <deployment-uid>")
+	}
+	cl, err := c.client(opts)
+	if err != nil {
+		return nil, err
+	}
+	endpoint := "/v2/deployments/" + url.PathEscape(opts.Resource) + fmt.Sprintf("/events?limit=%d", limit)
+	body, err := cl.RunAPIWithContext(ctx, "GET", endpoint, "")
+	if err != nil {
+		return nil, err
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(body)), &rows); err != nil {
+		return nil, fmt.Errorf("parse events: %w", err)
+	}
+	entries := make([]Entry, 0, len(rows))
+	for _, r := range rows {
+		msg := vercelText(r)
+		if msg == "" {
+			continue
+		}
+		ts := time.Now()
+		if ms, ok := r["created"].(float64); ok {
+			ts = time.UnixMilli(int64(ms))
+		}
+		e := NewEntry("vercel", opts.Resource, opts.Service, msg, ts)
+		e.Service = opts.Service
+		if typ, ok := r["type"].(string); ok {
+			if typ == "stderr" || typ == "error" {
+				e.SetLevel("error")
+			}
+			e.AddLabel("type", typ)
+		}
+		entries = append(entries, e)
+	}
+	return entries, nil
+}
+
+// vercelText extracts the log text from an event row's varied shapes.
+func vercelText(r map[string]any) string {
+	if t, ok := r["text"].(string); ok && t != "" {
+		return t
+	}
+	if p, ok := r["payload"].(map[string]any); ok {
+		if t, ok := p["text"].(string); ok && t != "" {
+			return t
+		}
+	}
+	return ""
+}
+
+func (c *vercelCollector) Query(ctx context.Context, opts Options, emit Emit) error {
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	entries, err := c.events(ctx, opts, limit)
+	if err != nil {
+		return err
+	}
+	matcher := newMatcher(opts)
+	for _, e := range entries {
+		if !matcher.Match(e) {
+			continue
+		}
+		if err := emit(e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *vercelCollector) Tail(ctx context.Context, opts Options, emit Emit) error {
+	matcher := newMatcher(opts)
+	seen := map[string]struct{}{}
+	poll := func() error {
+		entries, err := c.events(ctx, opts, 100)
+		if err != nil {
+			return err
+		}
+		for _, e := range entries {
+			if _, dup := seen[e.Ref]; dup {
+				continue
+			}
+			seen[e.Ref] = struct{}{}
+			if !matcher.Match(e) {
+				continue
+			}
+			if err := emit(e); err != nil {
+				return err
+			}
+		}
+		if len(seen) > 20000 {
+			seen = map[string]struct{}{}
+		}
+		return nil
+	}
+	if err := poll(); err != nil {
+		return err
+	}
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := poll(); err != nil {
+				return err
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds `clanker logs` — a provider-agnostic log surface the Clanker Cloud app drives for its new unified log viewer + talk-to-logs agent. Part of the unified-logs feature (this CLI PR lands first; the cloud backend shells out to it).

## Surface

- `clanker logs sources --provider <p>` — discover available log sources (JSON).
- `clanker logs query --provider <p> --resource <id> [--since --until --level --grep --limit]` — bounded backfill; emits normalized `LogEntry` JSON-lines on stdout.
- `clanker logs tail --provider <p> --resource <id> [--since --level --grep] ` — live follow; JSON-lines until interrupted (process-group cleanup so sub-CLIs aren't orphaned).
- `clanker logs chat "<question>" --provider <p> --resource <id>` — agentic talk-to-logs: collect → compress → grounded, citation-required LLM answer.

## Design

- **`internal/logs`**: a normalized `LogEntry` (server-normalized UTC timestamp + epochMs, severity enum with auditable `rawLevel`, structured-JSON extraction, stable citation `ref`), a `Collector` interface, and a provider registry. Shared client-side level/grep matcher and relative (`15m`/`2h`/`3d`) or RFC3339 window parsing.
- **Collectors (v1):** AWS CloudWatch (poll `FilterLogEvents`), Kubernetes (live tail via `kubectl logs -f --timestamps`), Fly.io (`flyctl` `--no-tail`/follow), Vercel (deployment events), Railway (`deploymentLogs` poll). The registry leaves a clean slot for GCP/Azure/Cloudflare.
- **Compression pipeline** for chat: templated dedup into severity/frequency-ranked clusters + error-pattern signals, so a large window fits the model budget while every claim stays citable.
- **Streaming contract:** `query`/`tail` write JSON-lines on stdout; progress traces go to stderr as `::clanker-progress {json}` (the same framing the backend already parses).

## Honest scope

AWS + Kubernetes are the robust, primary paths. Fly/Vercel/Railway are wired through their existing CLIs/clients; some are poll-only (no true server-push tail), surfaced as such. GCP/Azure/Cloudflare are deliberate follow-ups behind the collector extension point.

## Tests

`internal/logs` unit tests cover JSON/severity normalization, the unknown-vs-heuristic level logic, level+grep (incl. regex) filtering, window parsing, and dedup clustering ordering. `go build ./...`, `go vet`, and `go test ./internal/logs/` pass; binary smoke-tested (help, unsupported-provider + missing-resource errors).