### PR TITLE
Annotate SRE heartbeats for Cerebro

### DIFF
--- a/internal/sre/sre.go
+++ b/internal/sre/sre.go
@@ -322,6 +322,10 @@ func PostHeartbeat(ctx context.Context, discovery Discovery, observations map[st
 		"observations":      observations,
 		"findings":          BuildFindings(discovery, observations),
 		"category":          "sre.discovery",
+		"brainKind":         "state",
+		"brainStatus":       "active",
+		"brainTitle":        fmt.Sprintf("%s SRE heartbeat from %s", strings.ToUpper(provider), discovery.Hostname),
+		"brainTags":         []string{"sre", "heartbeat", provider, normalizeTarget(opts.Target)},
 	}
 
 	_, _, _ = flushQueuedHeartbeats(ctx, baseURL, token)


### PR DESCRIPTION
## Summary
- include Cerebro brain metadata on SRE heartbeat payloads so Clanker Cloud can persist provider heartbeat state as brain state
- tag heartbeat records by SRE, heartbeat, provider, and normalized target

## Tests
- go test ./...