### PR TITLE
Logs: count-based 'last N' tail mode (--tail)

### DIFF
--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -35,28 +35,36 @@ func newLogsCmd() *cobra.Command {
 		level     string
 		grep      string
 		limit     int
+		tailLines int
 		format    string
 		profile   string
 		aiProfile string
 	)
 
 	buildOpts := func() (logs.Options, error) {
-		now := time.Now()
-		sinceT, err := logs.ParseSince(since, now)
-		if err != nil {
-			return logs.Options{}, err
-		}
 		opts := logs.Options{
 			Provider: provider,
 			Resource: resource,
 			Service:  service,
 			Region:   region,
-			Since:    sinceT,
 			Level:    level,
 			Grep:     grep,
-			Limit:    limit,
 			Profile:  profile,
 		}
+		if tailLines > 0 {
+			// Count-based "latest N" mode: show the last N entries regardless of
+			// age (no time floor) then follow. Avoids the empty/looks-broken view
+			// that a time window gives for a quiet source.
+			opts.Limit = tailLines
+			return opts, nil
+		}
+		now := time.Now()
+		sinceT, err := logs.ParseSince(since, now)
+		if err != nil {
+			return logs.Options{}, err
+		}
+		opts.Since = sinceT
+		opts.Limit = limit
 		if strings.TrimSpace(until) != "" {
 			t, err := time.Parse(time.RFC3339, until)
 			if err != nil {
@@ -82,6 +90,7 @@ the talk-to-logs agent.`,
 	persistent.StringVar(&region, "region", "", "region (also kube context for k8s)")
 	persistent.StringVar(&since, "since", "15m", "window start: 15m, 2h, 3d, or RFC3339")
 	persistent.StringVar(&until, "until", "", "window end (RFC3339, default now)")
+	persistent.IntVar(&tailLines, "tail", 0, "count-based: show the last N entries (no time floor) then follow; overrides --since")
 	persistent.StringVar(&level, "level", "", "minimum level: debug|info|warn|error")
 	persistent.StringVar(&grep, "grep", "", "message filter (substring, or /regex/)")
 	persistent.IntVar(&limit, "limit", 1000, "max entries for bounded queries")

--- a/internal/logs/aws.go
+++ b/internal/logs/aws.go
@@ -123,9 +123,20 @@ func (c *awsCollector) Query(ctx context.Context, opts Options, emit Emit) error
 
 func (c *awsCollector) Tail(ctx context.Context, opts Options, emit Emit) error {
 	matcher := newMatcher(opts)
-	// Backfill the requested window, then poll for new events.
-	lastMs := opts.Since.UnixMilli()
-	backfill, err := c.fetch(ctx, opts, lastMs, time.Now().UnixMilli(), 1000)
+	// Backfill, then poll for new events. CloudWatch has no count-based "last N";
+	// in count mode (no time floor) fall back to a 1h lookback so an active group
+	// shows recent activity instead of scanning from the epoch.
+	var lastMs int64
+	if opts.Since.IsZero() {
+		lastMs = time.Now().Add(-1 * time.Hour).UnixMilli()
+	} else {
+		lastMs = opts.Since.UnixMilli()
+	}
+	backfillLimit := opts.Limit
+	if backfillLimit <= 0 {
+		backfillLimit = 1000
+	}
+	backfill, err := c.fetch(ctx, opts, lastMs, time.Now().UnixMilli(), backfillLimit)
 	if err != nil {
 		return err
 	}

--- a/internal/logs/k8s.go
+++ b/internal/logs/k8s.go
@@ -82,11 +82,13 @@ func (c *k8sCollector) logArgs(opts Options, follow bool) []string {
 			args = append(args, fmt.Sprintf("--since=%ds", int64(d.Seconds())))
 		}
 	}
-	if opts.Limit > 0 && !follow {
-		args = append(args, fmt.Sprintf("--tail=%d", opts.Limit))
-	} else if follow {
-		args = append(args, "--tail=200")
+	// Count-based backfill: --tail=N returns the last N lines regardless of age
+	// (for both one-shot query and the initial follow backfill).
+	tail := opts.Limit
+	if tail <= 0 {
+		tail = 200
 	}
+	args = append(args, fmt.Sprintf("--tail=%d", tail))
 	if follow {
 		args = append(args, "-f")
 	}


### PR DESCRIPTION
Adds `--tail N` for count-based backfill — show the last N entries regardless of age (no time floor) then follow. Powers the viewer's new default 'Latest' mode so a quiet source shows its last lines instead of an empty/looks-broken window.

- k8s: `kubectl logs --tail=N` (age-independent) for query + follow backfill.
- aws: 1h backfill fallback (CloudWatch has no count API), capped at N, then poll.
- railway/vercel already return latest-N.

Verified live: `--tail 5` on a pod whose last log was weeks ago returns those 5 lines (instead of empty). go build/vet/test green.