### PR TITLE
Logs: add GCP, Azure, Cloudflare, DigitalOcean collectors

### DIFF
--- a/internal/logs/azure.go
+++ b/internal/logs/azure.go
@@ -1,0 +1,179 @@
+package logs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+func init() {
+	register("azure", func() Collector { return &azureCollector{} })
+	register("az", func() Collector { return &azureCollector{} }) // alias
+}
+
+// azureCollector reads the Azure Activity Log (control-plane events) via
+// `az monitor activity-log list`. Resource optionally selects a resource group.
+// Application logs live in Log Analytics (KQL) and are a future addition; this
+// covers the subscription/resource-group event stream. Poll-based.
+type azureCollector struct{}
+
+func (c *azureCollector) Provider() string { return "azure" }
+
+func (c *azureCollector) baseArgs(opts Options, extra ...string) []string {
+	args := append([]string{"monitor", "activity-log", "list", "-o", "json"}, extra...)
+	if rg := strings.TrimSpace(opts.Resource); rg != "" {
+		args = append(args, "--resource-group", rg)
+	}
+	if sub := strings.TrimSpace(opts.Env["AZURE_SUBSCRIPTION_ID"]); sub != "" {
+		args = append(args, "--subscription", sub)
+	}
+	return args
+}
+
+func (c *azureCollector) Sources(ctx context.Context, opts Options) ([]Source, error) {
+	// Activity log is subscription/resource-group scoped; surface resource groups
+	// as selectable "sources" so the UI can scope by RG.
+	args := []string{"group", "list", "-o", "json"}
+	if sub := strings.TrimSpace(opts.Env["AZURE_SUBSCRIPTION_ID"]); sub != "" {
+		args = append(args, "--subscription", sub)
+	}
+	out, err := runJSON(ctx, "az", args, opts.Env)
+	if err != nil {
+		return nil, err
+	}
+	var groups []struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(out, &groups); err != nil {
+		return nil, fmt.Errorf("parse azure resource groups: %w", err)
+	}
+	sources := make([]Source, 0, len(groups))
+	for _, g := range groups {
+		sources = append(sources, Source{ID: g.Name, Kind: "resource-group"})
+	}
+	return sources, nil
+}
+
+type azEvent struct {
+	EventTimestamp string `json:"eventTimestamp"`
+	Level          string `json:"level"`
+	ResourceID     string `json:"resourceId"`
+	OperationName  struct {
+		LocalizedValue string `json:"localizedValue"`
+	} `json:"operationName"`
+	Status struct {
+		LocalizedValue string `json:"localizedValue"`
+	} `json:"status"`
+}
+
+func (c *azureCollector) fetch(ctx context.Context, opts Options, limit int) ([]azEvent, error) {
+	offset := "1h"
+	if !opts.Since.IsZero() {
+		if d := time.Since(opts.Since); d > 0 {
+			offset = fmt.Sprintf("%dm", int64(d.Minutes())+1)
+		}
+	} else {
+		offset = "24h" // count mode: wider lookback, capped by --max-events
+	}
+	args := c.baseArgs(opts, "--offset", offset, "--max-events", fmt.Sprintf("%d", limit))
+	out, err := runJSON(ctx, "az", args, opts.Env)
+	if err != nil {
+		return nil, err
+	}
+	var rows []azEvent
+	if err := json.Unmarshal(out, &rows); err != nil {
+		return nil, fmt.Errorf("parse azure activity log: %w", err)
+	}
+	return rows, nil
+}
+
+func (c *azureCollector) toEntry(opts Options, ev azEvent) Entry {
+	ts := time.Now()
+	if t, err := time.Parse(time.RFC3339Nano, ev.EventTimestamp); err == nil {
+		ts = t
+	}
+	msg := ev.OperationName.LocalizedValue
+	if ev.Status.LocalizedValue != "" {
+		msg = strings.TrimSpace(msg + " — " + ev.Status.LocalizedValue)
+	}
+	e := NewEntry("azure", ev.ResourceID, opts.Resource, msg, ts)
+	if ev.Level != "" {
+		// Azure levels: Informational/Warning/Error/Critical → normalized.
+		e.SetLevel(ev.Level)
+	}
+	e.Service = opts.Resource
+	return e
+}
+
+func (c *azureCollector) Query(ctx context.Context, opts Options, emit Emit) error {
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 1000
+	}
+	rows, err := c.fetch(ctx, opts, limit)
+	if err != nil {
+		return err
+	}
+	matcher := newMatcher(opts)
+	for _, ev := range rows {
+		e := c.toEntry(opts, ev)
+		if !matcher.Match(e) {
+			continue
+		}
+		if err := emit(e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *azureCollector) Tail(ctx context.Context, opts Options, emit Emit) error {
+	matcher := newMatcher(opts)
+	seen := newRefDedup(15 * time.Minute)
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 200
+	}
+	poll := func(n int) error {
+		rows, err := c.fetch(ctx, opts, n)
+		if err != nil {
+			return err
+		}
+		for i := len(rows) - 1; i >= 0; i-- { // oldest-first
+			e := c.toEntry(opts, rows[i])
+			if !seen.add(e.Ref, e.EpochMs) {
+				continue
+			}
+			if !matcher.Match(e) {
+				continue
+			}
+			if err := emit(e); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if err := poll(limit); err != nil {
+		return err
+	}
+	ticker := time.NewTicker(10 * time.Second) // activity-log is low-frequency + billed
+	defer ticker.Stop()
+	fails := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := poll(100); err != nil {
+				if fails++; fails >= maxConsecutivePollErrors {
+					return err
+				}
+				EmitProgress("tail", fmt.Sprintf("azure poll error (%d/%d), retrying: %v", fails, maxConsecutivePollErrors, err))
+				continue
+			}
+			fails = 0
+		}
+	}
+}

--- a/internal/logs/cloudflare.go
+++ b/internal/logs/cloudflare.go
@@ -1,0 +1,135 @@
+package logs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+func init() {
+	register("cloudflare", func() Collector { return &cfCollector{} })
+	register("cf", func() Collector { return &cfCollector{} }) // alias
+}
+
+// cfCollector tails Cloudflare Worker logs via `wrangler tail`. Resource is the
+// Worker (script) name. This is live-only — Workers logs aren't historically
+// queryable via wrangler (Logpush is the batch path), so Query returns nothing
+// and the UI's Latest/live mode (Tail) is the supported path.
+type cfCollector struct{}
+
+func (c *cfCollector) Provider() string { return "cloudflare" }
+
+func (c *cfCollector) Sources(ctx context.Context, opts Options) ([]Source, error) {
+	// Worker discovery needs the account API; left to the dedicated cf commands.
+	return nil, nil
+}
+
+func (c *cfCollector) Query(ctx context.Context, opts Options, emit Emit) error {
+	if opts.Resource == "" {
+		return fmt.Errorf("cloudflare logs require --resource <worker-name>")
+	}
+	// No historical query for Worker logs via wrangler. Surface a clear note
+	// rather than a confusing empty result; use Latest/live to tail.
+	EmitProgress("collect", "cloudflare Worker logs are live-only — use Latest/live to tail")
+	return nil
+}
+
+// cfTailEvent is one `wrangler tail --format json` record (a Worker invocation).
+type cfTailEvent struct {
+	ScriptName     string `json:"scriptName"`
+	Outcome        string `json:"outcome"`
+	EventTimestamp int64  `json:"eventTimestamp"`
+	Logs           []struct {
+		Message   []any  `json:"message"`
+		Level     string `json:"level"`
+		Timestamp int64  `json:"timestamp"`
+	} `json:"logs"`
+	Exceptions []struct {
+		Name      string `json:"name"`
+		Message   string `json:"message"`
+		Timestamp int64  `json:"timestamp"`
+	} `json:"exceptions"`
+	Event struct {
+		Request struct {
+			URL    string `json:"url"`
+			Method string `json:"method"`
+		} `json:"request"`
+	} `json:"event"`
+}
+
+func cfMessage(parts []any) string {
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		switch v := p.(type) {
+		case string:
+			out = append(out, v)
+		default:
+			if b, err := json.Marshal(v); err == nil {
+				out = append(out, string(b))
+			}
+		}
+	}
+	return strings.Join(out, " ")
+}
+
+func (c *cfCollector) Tail(ctx context.Context, opts Options, emit Emit) error {
+	if opts.Resource == "" {
+		return fmt.Errorf("cloudflare logs require --resource <worker-name>")
+	}
+	matcher := newMatcher(opts)
+	emitEntry := func(level, msg string, tsMs int64) error {
+		if strings.TrimSpace(msg) == "" {
+			return nil
+		}
+		ts := time.Now()
+		if tsMs > 0 {
+			ts = time.UnixMilli(tsMs)
+		}
+		e := NewEntry("cloudflare", opts.Resource, opts.Resource, msg, ts)
+		if level != "" {
+			e.SetLevel(level)
+		}
+		e.Service = opts.Service
+		if !matcher.Match(e) {
+			return nil
+		}
+		return emit(e)
+	}
+
+	return streamLines(ctx, "wrangler", []string{"tail", opts.Resource, "--format", "json"}, opts.Env, func(line string) error {
+		line = strings.TrimSpace(line)
+		if line == "" || line[0] != '{' {
+			return nil // skip wrangler's human banner lines
+		}
+		var ev cfTailEvent
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			return nil
+		}
+		for _, l := range ev.Logs {
+			if err := emitEntry(l.Level, cfMessage(l.Message), l.Timestamp); err != nil {
+				return err
+			}
+		}
+		for _, ex := range ev.Exceptions {
+			if err := emitEntry("error", strings.TrimSpace(ex.Name+": "+ex.Message), ex.Timestamp); err != nil {
+				return err
+			}
+		}
+		// If the invocation produced no logs/exceptions, record the request itself.
+		if len(ev.Logs) == 0 && len(ev.Exceptions) == 0 {
+			req := strings.TrimSpace(ev.Event.Request.Method + " " + ev.Event.Request.URL)
+			lvl := "info"
+			if ev.Outcome != "" && ev.Outcome != "ok" {
+				lvl = "error"
+			}
+			if req != "" {
+				if err := emitEntry(lvl, req+" ("+ev.Outcome+")", ev.EventTimestamp); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+}

--- a/internal/logs/digitalocean.go
+++ b/internal/logs/digitalocean.go
@@ -1,0 +1,104 @@
+package logs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+func init() {
+	register("digitalocean", func() Collector { return &doCollector{} })
+	register("do", func() Collector { return &doCollector{} }) // alias
+}
+
+// doCollector reads DigitalOcean App Platform logs via `doctl apps logs`.
+// Resource is the app id; Service optionally selects a component. doctl emits
+// plain text lines (no per-line timestamps), so entries are stamped on arrival.
+type doCollector struct{}
+
+func (c *doCollector) Provider() string { return "digitalocean" }
+
+func (c *doCollector) Sources(ctx context.Context, opts Options) ([]Source, error) {
+	out, err := runJSON(ctx, "doctl", []string{"apps", "list", "--output", "json"}, opts.Env)
+	if err != nil {
+		return nil, err
+	}
+	var apps []struct {
+		ID   string `json:"id"`
+		Spec struct {
+			Name string `json:"name"`
+		} `json:"spec"`
+	}
+	if err := json.Unmarshal(out, &apps); err != nil {
+		return nil, fmt.Errorf("parse do apps: %w", err)
+	}
+	sources := make([]Source, 0, len(apps))
+	for _, a := range apps {
+		sources = append(sources, Source{ID: a.ID, Kind: "app", Service: a.Spec.Name})
+	}
+	return sources, nil
+}
+
+func (c *doCollector) args(opts Options, follow bool) []string {
+	args := []string{"apps", "logs", opts.Resource, "--type", "run"}
+	if opts.Service != "" {
+		args = append(args, opts.Service) // optional component name
+	}
+	if follow {
+		args = append(args, "--follow")
+	}
+	return args
+}
+
+func (c *doCollector) toEntry(opts Options, line string) Entry {
+	e := NewEntry("digitalocean", opts.Resource, opts.Service, line, time.Now())
+	e.Service = opts.Service
+	return e
+}
+
+func (c *doCollector) Query(ctx context.Context, opts Options, emit Emit) error {
+	if opts.Resource == "" {
+		return fmt.Errorf("digitalocean logs require --resource <app-id>")
+	}
+	out, err := runJSON(ctx, "doctl", c.args(opts, false), opts.Env)
+	if err != nil {
+		return err
+	}
+	matcher := newMatcher(opts)
+	lines := strings.Split(string(out), "\n")
+	if opts.Limit > 0 && len(lines) > opts.Limit {
+		lines = lines[len(lines)-opts.Limit:]
+	}
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		e := c.toEntry(opts, line)
+		if !matcher.Match(e) {
+			continue
+		}
+		if err := emit(e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *doCollector) Tail(ctx context.Context, opts Options, emit Emit) error {
+	if opts.Resource == "" {
+		return fmt.Errorf("digitalocean logs require --resource <app-id>")
+	}
+	matcher := newMatcher(opts)
+	return streamLines(ctx, "doctl", c.args(opts, true), opts.Env, func(line string) error {
+		if strings.TrimSpace(line) == "" {
+			return nil
+		}
+		e := c.toEntry(opts, line)
+		if !matcher.Match(e) {
+			return nil
+		}
+		return emit(e)
+	})
+}

--- a/internal/logs/gcp.go
+++ b/internal/logs/gcp.go
@@ -1,0 +1,206 @@
+package logs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+func init() {
+	register("gcp", func() Collector { return &gcpCollector{} })
+	register("gcloud", func() Collector { return &gcpCollector{} }) // alias
+}
+
+// gcpCollector reads Cloud Logging via the `gcloud logging` CLI. The generic
+// Resource is a Cloud Logging filter (e.g. `resource.type="k8s_container"` or
+// `logName=...`); empty reads all logs. Tail is poll-based (gcloud's native
+// tail needs the alpha component).
+type gcpCollector struct{}
+
+func (c *gcpCollector) Provider() string { return "gcp" }
+
+func (c *gcpCollector) project(opts Options) string {
+	for _, k := range []string{"GCP_PROJECT_ID", "GOOGLE_CLOUD_PROJECT", "CLOUDSDK_CORE_PROJECT"} {
+		if v := strings.TrimSpace(opts.Env[k]); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func (c *gcpCollector) projectArgs(opts Options, base ...string) []string {
+	args := append([]string{}, base...)
+	if p := c.project(opts); p != "" {
+		args = append(args, "--project", p)
+	}
+	return args
+}
+
+func (c *gcpCollector) Sources(ctx context.Context, opts Options) ([]Source, error) {
+	out, err := runJSON(ctx, "gcloud", c.projectArgs(opts, "logging", "logs", "list", "--format=json", "--limit=200"), opts.Env)
+	if err != nil {
+		return nil, err
+	}
+	var rows []struct {
+		Name string `json:"name"` // projects/<p>/logs/<id>
+	}
+	if err := json.Unmarshal(out, &rows); err != nil {
+		return nil, fmt.Errorf("parse gcp logs: %w", err)
+	}
+	sources := make([]Source, 0, len(rows))
+	for _, r := range rows {
+		id := r.Name
+		// Present a readable log id but keep a usable filter as the source id.
+		short := id
+		if i := strings.Index(id, "/logs/"); i >= 0 {
+			short = id[i+len("/logs/"):]
+		}
+		sources = append(sources, Source{ID: fmt.Sprintf("logName=%q", id), Kind: "log", Service: short})
+	}
+	return sources, nil
+}
+
+type gcpEntry struct {
+	Timestamp   string         `json:"timestamp"`
+	Severity    string         `json:"severity"`
+	TextPayload string         `json:"textPayload"`
+	JSONPayload map[string]any `json:"jsonPayload"`
+	LogName     string         `json:"logName"`
+	InsertID    string         `json:"insertId"`
+	Resource    struct {
+		Type   string            `json:"type"`
+		Labels map[string]string `json:"labels"`
+	} `json:"resource"`
+	Trace string `json:"trace"`
+}
+
+func (c *gcpCollector) freshness(opts Options) string {
+	if opts.Since.IsZero() {
+		return "30d" // count mode: look back far; --limit caps to the last N
+	}
+	d := time.Since(opts.Since)
+	if d <= 0 {
+		return "1h"
+	}
+	return fmt.Sprintf("%ds", int64(d.Seconds())+60)
+}
+
+func (c *gcpCollector) fetch(ctx context.Context, opts Options, limit int) ([]gcpEntry, error) {
+	args := c.projectArgs(opts, "logging", "read")
+	if f := strings.TrimSpace(opts.Resource); f != "" {
+		args = append(args, f)
+	}
+	args = append(args, "--format=json", "--order=desc", fmt.Sprintf("--limit=%d", limit), "--freshness="+c.freshness(opts))
+	out, err := runJSON(ctx, "gcloud", args, opts.Env)
+	if err != nil {
+		return nil, err
+	}
+	var rows []gcpEntry
+	if err := json.Unmarshal(out, &rows); err != nil {
+		return nil, fmt.Errorf("parse gcp log entries: %w", err)
+	}
+	return rows, nil
+}
+
+func (c *gcpCollector) toEntry(opts Options, ge gcpEntry) Entry {
+	ts := time.Now()
+	if t, err := time.Parse(time.RFC3339Nano, ge.Timestamp); err == nil {
+		ts = t
+	}
+	msg := ge.TextPayload
+	if msg == "" && ge.JSONPayload != nil {
+		if m, ok := ge.JSONPayload["message"].(string); ok && m != "" {
+			msg = m
+		} else if b, err := json.Marshal(ge.JSONPayload); err == nil {
+			msg = string(b)
+		}
+	}
+	// Use the unique insertId as the stream so the citation ref is unique even
+	// for identical messages (avoids dedup dropping distinct entries).
+	e := NewEntry("gcp", ge.LogName, ge.InsertID, msg, ts)
+	if sev := strings.TrimSpace(ge.Severity); sev != "" && !strings.EqualFold(sev, "DEFAULT") {
+		e.SetLevel(sev)
+	}
+	if ge.Resource.Type != "" {
+		e.AddLabel("resourceType", ge.Resource.Type)
+	}
+	if ge.Trace != "" {
+		e.AddLabel("trace", ge.Trace)
+	}
+	e.Service = opts.Service
+	return e
+}
+
+func (c *gcpCollector) Query(ctx context.Context, opts Options, emit Emit) error {
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 1000
+	}
+	rows, err := c.fetch(ctx, opts, limit)
+	if err != nil {
+		return err
+	}
+	matcher := newMatcher(opts)
+	for _, ge := range rows {
+		e := c.toEntry(opts, ge)
+		if !matcher.Match(e) {
+			continue
+		}
+		if err := emit(e); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *gcpCollector) Tail(ctx context.Context, opts Options, emit Emit) error {
+	matcher := newMatcher(opts)
+	seen := newRefDedup(10 * time.Minute)
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 200
+	}
+	poll := func(n int) error {
+		rows, err := c.fetch(ctx, opts, n)
+		if err != nil {
+			return err
+		}
+		// gcloud returns newest-first; emit oldest-first so the merged view orders right.
+		for i := len(rows) - 1; i >= 0; i-- {
+			e := c.toEntry(opts, rows[i])
+			if !seen.add(e.Ref, e.EpochMs) {
+				continue
+			}
+			if !matcher.Match(e) {
+				continue
+			}
+			if err := emit(e); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if err := poll(limit); err != nil {
+		return err
+	}
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	fails := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := poll(100); err != nil {
+				if fails++; fails >= maxConsecutivePollErrors {
+					return err
+				}
+				EmitProgress("tail", fmt.Sprintf("gcp poll error (%d/%d), retrying: %v", fails, maxConsecutivePollErrors, err))
+				continue
+			}
+			fails = 0
+		}
+	}
+}

--- a/internal/logs/logs_test.go
+++ b/internal/logs/logs_test.go
@@ -103,3 +103,19 @@ func TestClusterAndContext(t *testing.T) {
 		t.Fatalf("empty context block")
 	}
 }
+
+func TestProvidersRegistered(t *testing.T) {
+	want := []string{"aws", "k8s", "flyio", "vercel", "railway", "gcp", "azure", "cloudflare", "digitalocean"}
+	have := map[string]bool{}
+	for _, p := range Providers() {
+		have[p] = true
+	}
+	for _, w := range want {
+		if !have[w] {
+			t.Errorf("provider %q not registered (have: %v)", w, Providers())
+		}
+		if _, err := Get(w); err != nil {
+			t.Errorf("Get(%q) failed: %v", w, err)
+		}
+	}
+}


### PR DESCRIPTION
Expands the unified logs providers beyond aws/k8s/fly/vercel/railway, all via the existing collector registry (shared matcher, ref-dedup, poll-tail resilience):

- **GCP** — Cloud Logging via `gcloud logging read/list`. Resource = a Cloud Logging filter (blank = all logs). Count/window via `--freshness` + `--order desc`; poll tail keyed on `insertId` so identical messages don't dedup away.
- **Azure** — Activity Log via `az monitor activity-log list`. Resource = resource group (blank = subscription); resource groups surface as discoverable sources. Poll-based. (App logs via Log Analytics/KQL are a future addition.)
- **Cloudflare** — Worker logs via `wrangler tail --format json` (live-only; `query` returns a clear note, Latest/live tails). Parses per-invocation logs + exceptions.
- **DigitalOcean** — App Platform via `doctl apps logs` (apps list as sources, `--follow` for tail).

No backend changes needed — credentials already flow via the existing provider-env injection (GCP project, Azure subscription, CF/DO tokens).

Verified: all register (`logs query --provider …`), build/vet/test green, and each errors cleanly when creds/CLI are missing (no panics). Live cred testing pending valid provider auth on the host. Pairs with the clanker-cloud PR adding them to the viewer's provider list.