### PR TITLE
Fix GCP logs (live-verified): env resolution, sources parsing, message fallback

### DIFF
--- a/internal/logs/azure.go
+++ b/internal/logs/azure.go
@@ -26,7 +26,7 @@ func (c *azureCollector) baseArgs(opts Options, extra ...string) []string {
 	if rg := strings.TrimSpace(opts.Resource); rg != "" {
 		args = append(args, "--resource-group", rg)
 	}
-	if sub := strings.TrimSpace(opts.Env["AZURE_SUBSCRIPTION_ID"]); sub != "" {
+	if sub := opts.EnvValue("AZURE_SUBSCRIPTION_ID"); sub != "" {
 		args = append(args, "--subscription", sub)
 	}
 	return args
@@ -36,7 +36,7 @@ func (c *azureCollector) Sources(ctx context.Context, opts Options) ([]Source, e
 	// Activity log is subscription/resource-group scoped; surface resource groups
 	// as selectable "sources" so the UI can scope by RG.
 	args := []string{"group", "list", "-o", "json"}
-	if sub := strings.TrimSpace(opts.Env["AZURE_SUBSCRIPTION_ID"]); sub != "" {
+	if sub := opts.EnvValue("AZURE_SUBSCRIPTION_ID"); sub != "" {
 		args = append(args, "--subscription", sub)
 	}
 	out, err := runJSON(ctx, "az", args, opts.Env)

--- a/internal/logs/collector.go
+++ b/internal/logs/collector.go
@@ -3,11 +3,30 @@ package logs
 import (
 	"context"
 	"fmt"
+	"os"
 	"regexp"
 	"sort"
 	"strings"
 	"time"
 )
+
+// EnvValue resolves a config value (project, subscription, token, …) from the
+// first of the given keys found in Options.Env, then the process environment.
+// Both the direct CLI (shell env) and the cloud backend (which sets the spawned
+// CLI's process env) land here, so collectors must check os.Getenv too.
+func (o Options) EnvValue(keys ...string) string {
+	for _, k := range keys {
+		if o.Env != nil {
+			if v := strings.TrimSpace(o.Env[k]); v != "" {
+				return v
+			}
+		}
+		if v := strings.TrimSpace(os.Getenv(k)); v != "" {
+			return v
+		}
+	}
+	return ""
+}
 
 // Options are the normalized filters every collector understands. Collectors
 // push down what the provider API supports (time window, grep) and the caller

--- a/internal/logs/gcp.go
+++ b/internal/logs/gcp.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -22,12 +23,7 @@ type gcpCollector struct{}
 func (c *gcpCollector) Provider() string { return "gcp" }
 
 func (c *gcpCollector) project(opts Options) string {
-	for _, k := range []string{"GCP_PROJECT_ID", "GOOGLE_CLOUD_PROJECT", "CLOUDSDK_CORE_PROJECT"} {
-		if v := strings.TrimSpace(opts.Env[k]); v != "" {
-			return v
-		}
-	}
-	return ""
+	return opts.EnvValue("GCP_PROJECT_ID", "GOOGLE_CLOUD_PROJECT", "CLOUDSDK_CORE_PROJECT")
 }
 
 func (c *gcpCollector) projectArgs(opts Options, base ...string) []string {
@@ -43,21 +39,24 @@ func (c *gcpCollector) Sources(ctx context.Context, opts Options) ([]Source, err
 	if err != nil {
 		return nil, err
 	}
-	var rows []struct {
-		Name string `json:"name"` // projects/<p>/logs/<id>
-	}
-	if err := json.Unmarshal(out, &rows); err != nil {
+	// `gcloud logging logs list --format=json` returns an array of (URL-encoded)
+	// log-name strings, e.g. "projects/<p>/logs/run.googleapis.com%2Fstdout".
+	var names []string
+	if err := json.Unmarshal(out, &names); err != nil {
 		return nil, fmt.Errorf("parse gcp logs: %w", err)
 	}
-	sources := make([]Source, 0, len(rows))
-	for _, r := range rows {
-		id := r.Name
-		// Present a readable log id but keep a usable filter as the source id.
-		short := id
-		if i := strings.Index(id, "/logs/"); i >= 0 {
-			short = id[i+len("/logs/"):]
+	sources := make([]Source, 0, len(names))
+	for _, raw := range names {
+		name := raw
+		if d, derr := url.PathUnescape(raw); derr == nil {
+			name = d
 		}
-		sources = append(sources, Source{ID: fmt.Sprintf("logName=%q", id), Kind: "log", Service: short})
+		short := name
+		if i := strings.Index(name, "/logs/"); i >= 0 {
+			short = name[i+len("/logs/"):]
+		}
+		// The source id is a ready-to-use Cloud Logging filter.
+		sources = append(sources, Source{ID: fmt.Sprintf("logName=%q", name), Kind: "log", Service: short})
 	}
 	return sources, nil
 }
@@ -73,7 +72,14 @@ type gcpEntry struct {
 		Type   string            `json:"type"`
 		Labels map[string]string `json:"labels"`
 	} `json:"resource"`
-	Trace string `json:"trace"`
+	HTTPRequest struct {
+		RequestMethod string `json:"requestMethod"`
+		RequestURL    string `json:"requestUrl"`
+		Status        int    `json:"status"`
+		Latency       string `json:"latency"`
+	} `json:"httpRequest"`
+	ProtoPayload map[string]any `json:"protoPayload"`
+	Trace        string         `json:"trace"`
 }
 
 func (c *gcpCollector) freshness(opts Options) string {
@@ -114,6 +120,19 @@ func (c *gcpCollector) toEntry(opts Options, ge gcpEntry) Entry {
 		if m, ok := ge.JSONPayload["message"].(string); ok && m != "" {
 			msg = m
 		} else if b, err := json.Marshal(ge.JSONPayload); err == nil {
+			msg = string(b)
+		}
+	}
+	// Request logs (Cloud Run / API Gateway) carry no payload — synthesize from
+	// httpRequest; audit logs from protoPayload.methodName.
+	if msg == "" && ge.HTTPRequest.RequestMethod != "" {
+		msg = strings.TrimSpace(fmt.Sprintf("%s %s %d %s",
+			ge.HTTPRequest.RequestMethod, ge.HTTPRequest.RequestURL, ge.HTTPRequest.Status, ge.HTTPRequest.Latency))
+	}
+	if msg == "" && ge.ProtoPayload != nil {
+		if mn, ok := ge.ProtoPayload["methodName"].(string); ok && mn != "" {
+			msg = mn
+		} else if b, err := json.Marshal(ge.ProtoPayload); err == nil {
 			msg = string(b)
 		}
 	}


### PR DESCRIPTION
Verified the GCP collector live against a real project (Cloud Run logs) and fixed what was broken:

1. **Project/subscription not resolved** (the big one) — collectors read GCP project / Azure subscription from `Options.Env` only, but the CLI never populates that struct; the values live in the **process environment** (the shell, or the backend setting the spawned CLI's env). GCP failed with `project not set` even when configured. Added `Options.EnvValue()` (checks `Env` then `os.Getenv`) so `--project`/`--subscription` are passed. Applies to GCP + Azure.
2. **GCP Sources parsing** — `gcloud logging logs list --format=json` returns an array of URL-encoded log-name **strings**, not objects. Parse `[]string` and url-decode.
3. **Blank GCP messages** — request logs (Cloud Run / API Gateway) have no text/json payload; fall back to `httpRequest` (`GET /v1/account 200`) and audit logs to `protoPayload.methodName`.

Verified end-to-end: `logs sources/query --provider gcp` returns real log names + entries (severity normalized, messages populated); through the backend, `POST /api/logs/tail provider=gcp` streamed 100+ entry frames from an active Cloud Run service. build/vet/test green.