### PR TITLE
Harden GCP/Azure/Cloudflare/DigitalOcean log collectors (review fixes)

### DIFF
--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -20,6 +20,9 @@ import (
 // early exit, distinct from a cancelled context).
 var errCollectLimit = errors.New("collect limit reached")
 
+// liveOnlyProviders have no historical query; chat samples their live stream.
+var liveOnlyProviders = map[string]bool{"cloudflare": true, "cf": true}
+
 // newLogsCmd builds `clanker logs`, the provider-agnostic log surface the cloud
 // app drives. `query`/`tail` stream normalized JSON-lines on stdout (progress
 // on stderr); `chat` runs the agentic talk-to-logs flow; `sources` discovers
@@ -206,18 +209,30 @@ func runLogsChat(ctx context.Context, opts logs.Options, question, aiProfile str
 
 	logs.EmitProgress("collect", fmt.Sprintf("collecting %s logs for analysis", opts.Provider))
 	var entries []logs.Entry
-	cap := opts.Limit
-	if cap <= 0 {
-		cap = 2000
+	capN := opts.Limit
+	if capN <= 0 {
+		capN = 2000
 	}
-	collectErr := collector.Query(ctx, opts, func(e logs.Entry) error {
+	collect := func(e logs.Entry) error {
 		entries = append(entries, e)
-		if len(entries) >= cap {
+		if len(entries) >= capN {
 			return errCollectLimit // stop once we hit the cap
 		}
 		return nil
-	})
-	if collectErr != nil && !errors.Is(collectErr, errCollectLimit) {
+	}
+	var collectErr error
+	if liveOnlyProviders[strings.ToLower(opts.Provider)] {
+		// Live-only providers (e.g. cloudflare) have no historical query — sample
+		// the live stream for a bounded window so chat has real context instead
+		// of always seeing zero logs.
+		logs.EmitProgress("collect", "sampling live logs (up to 8s) for analysis")
+		cctx, cancel := context.WithTimeout(ctx, 8*time.Second)
+		collectErr = collector.Tail(cctx, opts, collect)
+		cancel()
+	} else {
+		collectErr = collector.Query(ctx, opts, collect)
+	}
+	if collectErr != nil && !errors.Is(collectErr, errCollectLimit) && !errors.Is(collectErr, context.DeadlineExceeded) {
 		return collectErr
 	}
 
@@ -259,7 +274,11 @@ func buildLogsChatPrompt(opts logs.Options, question, contextBlock string, patte
 	if opts.Grep != "" {
 		fmt.Fprintf(&b, " grep=%q", opts.Grep)
 	}
-	fmt.Fprintf(&b, " window-from=%s\n", opts.Since.UTC().Format(time.RFC3339))
+	if opts.Since.IsZero() {
+		fmt.Fprintf(&b, " window=last %d entries\n", total)
+	} else {
+		fmt.Fprintf(&b, " window-from=%s\n", opts.Since.UTC().Format(time.RFC3339))
+	}
 	fmt.Fprintf(&b, "Signal counts: %d errors, %d timeouts, %d connection failures across %d lines.\n",
 		patterns["errors"], patterns["timeouts"], patterns["connection_failures"], total)
 	if truncated {

--- a/internal/logs/azure.go
+++ b/internal/logs/azure.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 )
@@ -58,6 +59,8 @@ func (c *azureCollector) Sources(ctx context.Context, opts Options) ([]Source, e
 
 type azEvent struct {
 	EventTimestamp string `json:"eventTimestamp"`
+	EventDataID    string `json:"eventDataId"`
+	CorrelationID  string `json:"correlationId"`
 	Level          string `json:"level"`
 	ResourceID     string `json:"resourceId"`
 	OperationName  struct {
@@ -68,17 +71,26 @@ type azEvent struct {
 	} `json:"status"`
 }
 
-func (c *azureCollector) fetch(ctx context.Context, opts Options, limit int) ([]azEvent, error) {
-	offset := "1h"
-	if !opts.Since.IsZero() {
-		if d := time.Since(opts.Since); d > 0 {
-			offset = fmt.Sprintf("%dm", int64(d.Minutes())+1)
-		}
+// fetch lists activity-log events. When startTime is non-empty it requests
+// events since that instant (incremental poll); otherwise it uses an --offset
+// window. Results are sorted newest-first regardless of CLI default ordering.
+func (c *azureCollector) fetch(ctx context.Context, opts Options, limit int, startTime string) ([]azEvent, error) {
+	var extra []string
+	if startTime != "" {
+		extra = []string{"--start-time", startTime}
 	} else {
-		offset = "24h" // count mode: wider lookback, capped by --max-events
+		offset := "1h"
+		if !opts.Since.IsZero() {
+			if d := time.Since(opts.Since); d > 0 {
+				offset = fmt.Sprintf("%dm", int64(d.Minutes())+1)
+			}
+		} else {
+			offset = "24h" // count mode: wider lookback, capped by --max-events
+		}
+		extra = []string{"--offset", offset}
 	}
-	args := c.baseArgs(opts, "--offset", offset, "--max-events", fmt.Sprintf("%d", limit))
-	out, err := runJSON(ctx, "az", args, opts.Env)
+	extra = append(extra, "--max-events", fmt.Sprintf("%d", limit))
+	out, err := runJSON(ctx, "az", c.baseArgs(opts, extra...), opts.Env)
 	if err != nil {
 		return nil, err
 	}
@@ -86,6 +98,8 @@ func (c *azureCollector) fetch(ctx context.Context, opts Options, limit int) ([]
 	if err := json.Unmarshal(out, &rows); err != nil {
 		return nil, fmt.Errorf("parse azure activity log: %w", err)
 	}
+	// Don't rely on the CLI's default ordering for "last N".
+	sort.SliceStable(rows, func(i, j int) bool { return rows[i].EventTimestamp > rows[j].EventTimestamp })
 	return rows, nil
 }
 
@@ -98,7 +112,13 @@ func (c *azureCollector) toEntry(opts Options, ev azEvent) Entry {
 	if ev.Status.LocalizedValue != "" {
 		msg = strings.TrimSpace(msg + " — " + ev.Status.LocalizedValue)
 	}
-	e := NewEntry("azure", ev.ResourceID, opts.Resource, msg, ts)
+	// Use the unique event id as the stream so the citation ref is unique even
+	// for same-millisecond events with identical operation+status.
+	streamID := ev.EventDataID
+	if streamID == "" {
+		streamID = ev.CorrelationID
+	}
+	e := NewEntry("azure", ev.ResourceID, streamID, msg, ts)
 	if ev.Level != "" {
 		// Azure levels: Informational/Warning/Error/Critical → normalized.
 		e.SetLevel(ev.Level)
@@ -112,7 +132,7 @@ func (c *azureCollector) Query(ctx context.Context, opts Options, emit Emit) err
 	if limit <= 0 {
 		limit = 1000
 	}
-	rows, err := c.fetch(ctx, opts, limit)
+	rows, err := c.fetch(ctx, opts, limit, "")
 	if err != nil {
 		return err
 	}
@@ -136,13 +156,14 @@ func (c *azureCollector) Tail(ctx context.Context, opts Options, emit Emit) erro
 	if limit <= 0 {
 		limit = 200
 	}
-	poll := func(n int) error {
-		rows, err := c.fetch(ctx, opts, n)
-		if err != nil {
-			return err
-		}
-		for i := len(rows) - 1; i >= 0; i-- { // oldest-first
+	var lastSeenMs int64
+	emitRows := func(rows []azEvent) error {
+		// rows are newest-first; emit oldest-first for correct merge ordering.
+		for i := len(rows) - 1; i >= 0; i-- {
 			e := c.toEntry(opts, rows[i])
+			if e.EpochMs > lastSeenMs {
+				lastSeenMs = e.EpochMs
+			}
 			if !seen.add(e.Ref, e.EpochMs) {
 				continue
 			}
@@ -155,9 +176,18 @@ func (c *azureCollector) Tail(ctx context.Context, opts Options, emit Emit) erro
 		}
 		return nil
 	}
-	if err := poll(limit); err != nil {
+
+	backfill, err := c.fetch(ctx, opts, limit, "")
+	if err != nil {
 		return err
 	}
+	if err := emitRows(backfill); err != nil {
+		return err
+	}
+	if lastSeenMs == 0 {
+		lastSeenMs = time.Now().Add(-1 * time.Minute).UnixMilli()
+	}
+
 	ticker := time.NewTicker(10 * time.Second) // activity-log is low-frequency + billed
 	defer ticker.Stop()
 	fails := 0
@@ -166,7 +196,10 @@ func (c *azureCollector) Tail(ctx context.Context, opts Options, emit Emit) erro
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			if err := poll(100); err != nil {
+			// Incremental: only events since the last seen (no full-window rescan).
+			start := time.UnixMilli(lastSeenMs + 1).UTC().Format(time.RFC3339)
+			rows, err := c.fetch(ctx, opts, 1000, start)
+			if err != nil {
 				if fails++; fails >= maxConsecutivePollErrors {
 					return err
 				}
@@ -174,6 +207,9 @@ func (c *azureCollector) Tail(ctx context.Context, opts Options, emit Emit) erro
 				continue
 			}
 			fails = 0
+			if err := emitRows(rows); err != nil {
+				return err
+			}
 		}
 	}
 }

--- a/internal/logs/cloudflare.go
+++ b/internal/logs/cloudflare.go
@@ -38,18 +38,18 @@ func (c *cfCollector) Query(ctx context.Context, opts Options, emit Emit) error 
 
 // cfTailEvent is one `wrangler tail --format json` record (a Worker invocation).
 type cfTailEvent struct {
-	ScriptName     string `json:"scriptName"`
-	Outcome        string `json:"outcome"`
-	EventTimestamp int64  `json:"eventTimestamp"`
+	ScriptName     string  `json:"scriptName"`
+	Outcome        string  `json:"outcome"`
+	EventTimestamp float64 `json:"eventTimestamp"`
 	Logs           []struct {
-		Message   []any  `json:"message"`
-		Level     string `json:"level"`
-		Timestamp int64  `json:"timestamp"`
+		Message   []any   `json:"message"`
+		Level     string  `json:"level"`
+		Timestamp float64 `json:"timestamp"`
 	} `json:"logs"`
 	Exceptions []struct {
-		Name      string `json:"name"`
-		Message   string `json:"message"`
-		Timestamp int64  `json:"timestamp"`
+		Name      string  `json:"name"`
+		Message   string  `json:"message"`
+		Timestamp float64 `json:"timestamp"`
 	} `json:"exceptions"`
 	Event struct {
 		Request struct {
@@ -79,13 +79,13 @@ func (c *cfCollector) Tail(ctx context.Context, opts Options, emit Emit) error {
 		return fmt.Errorf("cloudflare logs require --resource <worker-name>")
 	}
 	matcher := newMatcher(opts)
-	emitEntry := func(level, msg string, tsMs int64) error {
+	emitEntry := func(level, msg string, tsMs float64) error {
 		if strings.TrimSpace(msg) == "" {
 			return nil
 		}
 		ts := time.Now()
 		if tsMs > 0 {
-			ts = time.UnixMilli(tsMs)
+			ts = time.UnixMilli(int64(tsMs))
 		}
 		e := NewEntry("cloudflare", opts.Resource, opts.Resource, msg, ts)
 		if level != "" {

--- a/internal/logs/collector.go
+++ b/internal/logs/collector.go
@@ -161,6 +161,7 @@ const maxConsecutivePollErrors = 5
 type refDedup struct {
 	seen     map[string]int64
 	windowMs int64
+	maxTs    int64
 }
 
 func newRefDedup(window time.Duration) *refDedup {
@@ -173,9 +174,13 @@ func (d *refDedup) add(ref string, epochMs int64) bool {
 		return false
 	}
 	d.seen[ref] = epochMs
-	// Prune entries older than the retention window relative to this one.
+	if epochMs > d.maxTs {
+		d.maxTs = epochMs
+	}
+	// Prune entries older than the retention window relative to the newest seen
+	// (not the just-added entry, which could be out-of-order/older).
 	if len(d.seen) > 4096 {
-		cutoff := epochMs - d.windowMs
+		cutoff := d.maxTs - d.windowMs
 		for k, ts := range d.seen {
 			if ts < cutoff {
 				delete(d.seen, k)

--- a/internal/logs/digitalocean.go
+++ b/internal/logs/digitalocean.go
@@ -53,7 +53,20 @@ func (c *doCollector) args(opts Options, follow bool) []string {
 }
 
 func (c *doCollector) toEntry(opts Options, line string) Entry {
-	e := NewEntry("digitalocean", opts.Resource, opts.Service, line, time.Now())
+	// doctl App Platform run logs are prefixed with an RFC3339 timestamp on most
+	// components; parse it when present so ordering/time-filtering work, else now.
+	ts := time.Now()
+	msg := line
+	if idx := strings.IndexByte(line, ' '); idx > 0 {
+		if t, err := time.Parse(time.RFC3339Nano, line[:idx]); err == nil {
+			ts = t
+			msg = line[idx+1:]
+		} else if t, err := time.Parse(time.RFC3339, line[:idx]); err == nil {
+			ts = t
+			msg = line[idx+1:]
+		}
+	}
+	e := NewEntry("digitalocean", opts.Resource, opts.Service, msg, ts)
 	e.Service = opts.Service
 	return e
 }

--- a/internal/logs/entry.go
+++ b/internal/logs/entry.go
@@ -161,9 +161,9 @@ func normalizeLevel(s string) string {
 	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "trace":
 		return LevelTrace
-	case "debug", "dbg", "fine", "finer", "finest", "verbose", "default":
+	case "debug", "dbg", "fine", "finer", "finest", "verbose":
 		return LevelDebug
-	case "info", "information", "informational", "notice", "i":
+	case "log", "info", "information", "informational", "notice", "i":
 		return LevelInfo
 	case "warn", "warning", "w":
 		return LevelWarn

--- a/internal/logs/gcp.go
+++ b/internal/logs/gcp.go
@@ -93,12 +93,16 @@ func (c *gcpCollector) freshness(opts Options) string {
 	return fmt.Sprintf("%ds", int64(d.Seconds())+60)
 }
 
-func (c *gcpCollector) fetch(ctx context.Context, opts Options, limit int) ([]gcpEntry, error) {
+// read runs `gcloud logging read` with an explicit filter/order/freshness.
+func (c *gcpCollector) read(ctx context.Context, opts Options, filter, order string, limit int, freshness string) ([]gcpEntry, error) {
 	args := c.projectArgs(opts, "logging", "read")
-	if f := strings.TrimSpace(opts.Resource); f != "" {
+	if f := strings.TrimSpace(filter); f != "" {
 		args = append(args, f)
 	}
-	args = append(args, "--format=json", "--order=desc", fmt.Sprintf("--limit=%d", limit), "--freshness="+c.freshness(opts))
+	args = append(args, "--format=json", "--order="+order, fmt.Sprintf("--limit=%d", limit))
+	if freshness != "" {
+		args = append(args, "--freshness="+freshness)
+	}
 	out, err := runJSON(ctx, "gcloud", args, opts.Env)
 	if err != nil {
 		return nil, err
@@ -157,7 +161,7 @@ func (c *gcpCollector) Query(ctx context.Context, opts Options, emit Emit) error
 	if limit <= 0 {
 		limit = 1000
 	}
-	rows, err := c.fetch(ctx, opts, limit)
+	rows, err := c.read(ctx, opts, opts.Resource, "desc", limit, c.freshness(opts))
 	if err != nil {
 		return err
 	}
@@ -181,14 +185,13 @@ func (c *gcpCollector) Tail(ctx context.Context, opts Options, emit Emit) error 
 	if limit <= 0 {
 		limit = 200
 	}
-	poll := func(n int) error {
-		rows, err := c.fetch(ctx, opts, n)
-		if err != nil {
-			return err
-		}
-		// gcloud returns newest-first; emit oldest-first so the merged view orders right.
-		for i := len(rows) - 1; i >= 0; i-- {
-			e := c.toEntry(opts, rows[i])
+	var lastSeenMs int64
+	emitRows := func(rows []gcpEntry) error {
+		for _, ge := range rows {
+			e := c.toEntry(opts, ge)
+			if e.EpochMs > lastSeenMs {
+				lastSeenMs = e.EpochMs
+			}
 			if !seen.add(e.Ref, e.EpochMs) {
 				continue
 			}
@@ -201,9 +204,22 @@ func (c *gcpCollector) Tail(ctx context.Context, opts Options, emit Emit) error 
 		}
 		return nil
 	}
-	if err := poll(limit); err != nil {
+
+	// Backfill: newest N (desc), emitted oldest-first.
+	backfill, err := c.read(ctx, opts, opts.Resource, "desc", limit, c.freshness(opts))
+	if err != nil {
 		return err
 	}
+	for i, j := 0, len(backfill)-1; i < j; i, j = i+1, j-1 {
+		backfill[i], backfill[j] = backfill[j], backfill[i]
+	}
+	if err := emitRows(backfill); err != nil {
+		return err
+	}
+	if lastSeenMs == 0 {
+		lastSeenMs = time.Now().Add(-1 * time.Minute).UnixMilli()
+	}
+
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 	fails := 0
@@ -212,7 +228,15 @@ func (c *gcpCollector) Tail(ctx context.Context, opts Options, emit Emit) error 
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			if err := poll(100); err != nil {
+			// Incremental: only entries strictly newer than the last seen, asc.
+			// Bounds cost (no full-window rescan) and never skips a busy burst.
+			tsFilter := fmt.Sprintf("timestamp>%q", time.UnixMilli(lastSeenMs).UTC().Format(time.RFC3339Nano))
+			filter := tsFilter
+			if r := strings.TrimSpace(opts.Resource); r != "" {
+				filter = "(" + r + ") AND " + tsFilter
+			}
+			rows, err := c.read(ctx, opts, filter, "asc", 1000, "1h")
+			if err != nil {
 				if fails++; fails >= maxConsecutivePollErrors {
 					return err
 				}
@@ -220,6 +244,9 @@ func (c *gcpCollector) Tail(ctx context.Context, opts Options, emit Emit) error 
 				continue
 			}
 			fails = 0
+			if err := emitRows(rows); err != nil {
+				return err
+			}
 		}
 	}
 }

--- a/internal/logs/logs_test.go
+++ b/internal/logs/logs_test.go
@@ -119,3 +119,16 @@ func TestProvidersRegistered(t *testing.T) {
 		}
 	}
 }
+
+func TestSeverityEdgeCases(t *testing.T) {
+	// GCP "DEFAULT" means unspecified, not debug.
+	e := NewEntry("gcp", "g", "i", `{"severity":"DEFAULT","message":"x"}`, time.Now())
+	if e.Level != LevelUnknown {
+		t.Errorf("DEFAULT severity = %q, want unknown", e.Level)
+	}
+	// Cloudflare console.log level "log" → info.
+	e2 := NewEntry("cloudflare", "w", "w", `{"level":"log","message":"hi"}`, time.Now())
+	if e2.Level != LevelInfo {
+		t.Errorf("log level = %q, want info", e2.Level)
+	}
+}


### PR DESCRIPTION
Fresh-eyes review of the new providers surfaced real bugs — fixed here:

**Tail poll loops (highest risk)**
- GCP/Azure polls re-scanned the *entire* backfill window every tick (GCP `--freshness=30d`, Azure `--offset 24h`) and could **skip** any burst larger than the limit between ticks. Now incremental: GCP filters `timestamp>lastSeen` (asc, 1000); Azure uses `--start-time lastSeen`. Bounded cost, no rescan, no skips.
- Azure: dedup by unique `eventDataId`/`correlationId` (was empty stream → distinct same-millisecond events dropped); sort newest-first instead of trusting CLI order for 'last N'.

**Cloudflare**
- Chat fed the model **zero logs** (Query is a no-op for live-only) → now samples the live tail for a bounded 8s window. Timestamps parsed as `float64` so a non-integer JSON value no longer silently drops the event.

**DigitalOcean** — parse a leading RFC3339 timestamp when present (ordering + `--since`/`--until` filtering) instead of stamping `now` on every line.

**Cross-cutting** — GCP `DEFAULT` severity → unknown (not debug); Cloudflare `log` → info; `refDedup` prunes by max-seen ts (not a possibly-older just-added entry); chat prompt prints 'last N entries' instead of a zero-value `window-from`.

Verified GCP live (query messages/severity + incremental tail streaming). build/vet/test green; added a severity edge-case test.