### PR TITLE
Logs poll/dedup edge-case fixes (review round)

### DIFF
--- a/internal/logs/azure.go
+++ b/internal/logs/azure.go
@@ -98,9 +98,17 @@ func (c *azureCollector) fetch(ctx context.Context, opts Options, limit int, sta
 	if err := json.Unmarshal(out, &rows); err != nil {
 		return nil, fmt.Errorf("parse azure activity log: %w", err)
 	}
-	// Don't rely on the CLI's default ordering for "last N".
-	sort.SliceStable(rows, func(i, j int) bool { return rows[i].EventTimestamp > rows[j].EventTimestamp })
+	// Don't rely on the CLI's default ordering for "last N". Compare parsed
+	// instants, not strings (mixed fractional precision sorts wrong lexically).
+	sort.SliceStable(rows, func(i, j int) bool { return azEpochMs(rows[i].EventTimestamp) > azEpochMs(rows[j].EventTimestamp) })
 	return rows, nil
+}
+
+func azEpochMs(ts string) int64 {
+	if t, err := time.Parse(time.RFC3339Nano, ts); err == nil {
+		return t.UnixMilli()
+	}
+	return 0
 }
 
 func (c *azureCollector) toEntry(opts Options, ev azEvent) Entry {
@@ -196,8 +204,10 @@ func (c *azureCollector) Tail(ctx context.Context, opts Options, emit Emit) erro
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			// Incremental: only events since the last seen (no full-window rescan).
-			start := time.UnixMilli(lastSeenMs + 1).UTC().Format(time.RFC3339)
+			// Incremental: events since the last seen (no full-window rescan).
+			// RFC3339 truncates to seconds (re-fetching the current second);
+			// refDedup drops the re-included events, so no +1 nudge is needed.
+			start := time.UnixMilli(lastSeenMs).UTC().Format(time.RFC3339)
 			rows, err := c.fetch(ctx, opts, 1000, start)
 			if err != nil {
 				if fails++; fails >= maxConsecutivePollErrors {

--- a/internal/logs/collector.go
+++ b/internal/logs/collector.go
@@ -174,13 +174,21 @@ func (d *refDedup) add(ref string, epochMs int64) bool {
 		return false
 	}
 	d.seen[ref] = epochMs
-	if epochMs > d.maxTs {
+	// Advance the high-water mark, but clamp against clock-skewed/garbage future
+	// timestamps so a single bad entry can't push the prune cutoff far ahead and
+	// empty the whole map (which would re-emit the next poll's overlap as dups).
+	nowMs := time.Now().UnixMilli() + int64(time.Minute/time.Millisecond)
+	if epochMs > d.maxTs && epochMs <= nowMs {
 		d.maxTs = epochMs
 	}
 	// Prune entries older than the retention window relative to the newest seen
 	// (not the just-added entry, which could be out-of-order/older).
 	if len(d.seen) > 4096 {
-		cutoff := d.maxTs - d.windowMs
+		base := d.maxTs
+		if base == 0 {
+			base = time.Now().UnixMilli()
+		}
+		cutoff := base - d.windowMs
 		for k, ts := range d.seen {
 			if ts < cutoff {
 				delete(d.seen, k)

--- a/internal/logs/gcp.go
+++ b/internal/logs/gcp.go
@@ -230,12 +230,15 @@ func (c *gcpCollector) Tail(ctx context.Context, opts Options, emit Emit) error 
 		case <-ticker.C:
 			// Incremental: only entries strictly newer than the last seen, asc.
 			// Bounds cost (no full-window rescan) and never skips a busy burst.
-			tsFilter := fmt.Sprintf("timestamp>%q", time.UnixMilli(lastSeenMs).UTC().Format(time.RFC3339Nano))
+			// >= (not >) so an entry exactly at the last-seen ms boundary isn't
+			// skipped; refDedup drops the re-included boundary rows. freshness=1d
+			// tolerates ingestion lag for backdated entries.
+			tsFilter := fmt.Sprintf("timestamp>=%q", time.UnixMilli(lastSeenMs).UTC().Format(time.RFC3339Nano))
 			filter := tsFilter
 			if r := strings.TrimSpace(opts.Resource); r != "" {
 				filter = "(" + r + ") AND " + tsFilter
 			}
-			rows, err := c.read(ctx, opts, filter, "asc", 1000, "1h")
+			rows, err := c.read(ctx, opts, filter, "asc", 1000, "1d")
 			if err != nil {
 				if fails++; fails >= maxConsecutivePollErrors {
 					return err


### PR DESCRIPTION
Second fresh-eyes round — residual correctness gaps in the new poll/dedup logic:

- **refDedup poisoning (medium)**: the high-water mark used for pruning only ever increased, so one clock-skewed/garbage future timestamp pushed the cutoff far ahead and emptied the dedup map every tick → duplicate flood for the rest of the session. Now clamped against `now + 1m`; falls back to wall-clock when no valid max.
- **GCP boundary skip (medium)**: the incremental poll used `timestamp>` at millisecond precision, so an entry exactly at the last-seen ms was never re-queried → missed. Now `timestamp>=` and let refDedup drop the re-included boundary rows; `--freshness=1d` tolerates ingestion lag.
- **Azure (low)**: dropped the `+1ms` `--start-time` nudge (RFC3339 truncates to seconds and re-fetches the boundary second anyway; dedup handles it) and sort batches by parsed instant instead of lexically (mixed fractional precision sorted incorrectly).

go build/vet/`test -race` green.