### PR TITLE
feat: add live SRE check

### DIFF
--- a/cmd/sre.go
+++ b/cmd/sre.go
@@ -124,6 +124,50 @@ var sreRunCmd = &cobra.Command{
 	},
 }
 
+var sreCheckCmd = &cobra.Command{
+	Use:   "check",
+	Short: "Run one bounded read-only SRE check",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		format, _ := cmd.Flags().GetString("format")
+		timeout, err := durationFlag(cmd, "timeout", 20*time.Second)
+		if err != nil {
+			return err
+		}
+		ctx := cmd.Context()
+		if timeout > 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, timeout)
+			defer cancel()
+		}
+		result := sre.Check(ctx)
+		if strings.EqualFold(format, "json") {
+			encoder := json.NewEncoder(os.Stdout)
+			encoder.SetIndent("", "  ")
+			return encoder.Encode(result)
+		}
+		fmt.Printf("Clanker SRE live check\n")
+		fmt.Printf("Status: %s\n", result.Status)
+		fmt.Printf("Summary: %s\n", result.Summary)
+		if len(result.Issues) > 0 {
+			fmt.Printf("\nIssues:\n")
+			for _, issue := range result.Issues {
+				if issue.Provider != "" {
+					fmt.Printf("- [%s] %s/%s: %s\n", issue.Severity, issue.Provider, issue.Category, issue.Message)
+					continue
+				}
+				fmt.Printf("- [%s] %s: %s\n", issue.Severity, issue.Category, issue.Message)
+			}
+		}
+		if len(result.Findings) > 0 {
+			fmt.Printf("\nFindings:\n")
+			for _, finding := range result.Findings {
+				fmt.Printf("- %s\n", finding)
+			}
+		}
+		return nil
+	},
+}
+
 var sreStatusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show local SRE install status and adaptive target recommendation",
@@ -169,7 +213,7 @@ var sreDoctorCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(sreCmd)
 	sreCmd.PersistentFlags().Bool("sre", false, "mark this command as running through the Clanker SRE path")
-	sreCmd.AddCommand(sreDiscoverCmd, srePlanCmd, sreInstallCmd, sreRunCmd, sreStatusCmd, sreDoctorCmd)
+	sreCmd.AddCommand(sreDiscoverCmd, srePlanCmd, sreInstallCmd, sreRunCmd, sreCheckCmd, sreStatusCmd, sreDoctorCmd)
 
 	sreDiscoverCmd.Flags().String("format", "text", "Output format: text or json")
 	addSREPlanFlags(srePlanCmd)
@@ -177,6 +221,10 @@ func init() {
 	sreInstallCmd.Flags().Bool("apply", false, "Write generated install assets to disk")
 	sreInstallCmd.Flags().String("output-dir", "", "Directory for generated install assets (default ~/.clanker/sre/install)")
 	addSRERunFlags(sreRunCmd)
+	sreCheckCmd.Flags().String("format", "text", "Output format: text or json")
+	sreCheckCmd.Flags().String("timeout", "20s", "Maximum duration for a single SRE check (0 disables the command timeout)")
+	sreCheckCmd.Flags().String("provider", os.Getenv("CLANKER_SRE_PROVIDER"), "Cloud provider name for check metadata")
+	sreCheckCmd.Flags().String("deploy-id", os.Getenv("CLANKER_SRE_DEPLOY_ID"), "Stable SRE deployment ID for check metadata")
 	addSREPlanFlags(sreDoctorCmd)
 }
 

--- a/internal/logs/gcp.go
+++ b/internal/logs/gcp.go
@@ -7,6 +7,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	gcplogging "google.golang.org/api/logging/v2"
 )
 
 func init() {
@@ -14,146 +16,212 @@ func init() {
 	register("gcloud", func() Collector { return &gcpCollector{} }) // alias
 }
 
-// gcpCollector reads Cloud Logging via the `gcloud logging` CLI. The generic
+// gcpCollector reads Cloud Logging through Google's API client. The generic
 // Resource is a Cloud Logging filter (e.g. `resource.type="k8s_container"` or
-// `logName=...`); empty reads all logs. Tail is poll-based (gcloud's native
-// tail needs the alpha component).
+// `logName=...`); empty reads all logs.
 type gcpCollector struct{}
 
 func (c *gcpCollector) Provider() string { return "gcp" }
 
 func (c *gcpCollector) project(opts Options) string {
-	return opts.EnvValue("GCP_PROJECT_ID", "GOOGLE_CLOUD_PROJECT", "CLOUDSDK_CORE_PROJECT")
+	return opts.EnvValue("GCP_PROJECT_ID", "GOOGLE_CLOUD_PROJECT", "GCLOUD_PROJECT", "CLOUDSDK_CORE_PROJECT")
 }
 
-func (c *gcpCollector) projectArgs(opts Options, base ...string) []string {
-	args := append([]string{}, base...)
-	if p := c.project(opts); p != "" {
-		args = append(args, "--project", p)
+func (c *gcpCollector) client(ctx context.Context, opts Options) (*gcplogging.Service, string, error) {
+	project := c.project(opts)
+	if project == "" {
+		return nil, "", fmt.Errorf("gcp project is required; set GCP_PROJECT_ID or GOOGLE_CLOUD_PROJECT")
 	}
-	return args
+	client, err := gcplogging.NewService(ctx)
+	if err != nil {
+		return nil, "", fmt.Errorf("open gcp logging client for project %s: %w", project, err)
+	}
+	return client, project, nil
 }
 
 func (c *gcpCollector) Sources(ctx context.Context, opts Options) ([]Source, error) {
-	out, err := runJSON(ctx, "gcloud", c.projectArgs(opts, "logging", "logs", "list", "--format=json", "--limit=200"), opts.Env)
+	client, project, err := c.client(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
-	// `gcloud logging logs list --format=json` returns an array of (URL-encoded)
-	// log-name strings, e.g. "projects/<p>/logs/run.googleapis.com%2Fstdout".
-	var names []string
-	if err := json.Unmarshal(out, &names); err != nil {
-		return nil, fmt.Errorf("parse gcp logs: %w", err)
+
+	const maxSources = 200
+	sources := make([]Source, 0, maxSources)
+	parent := "projects/" + project
+	resp, err := client.Projects.Logs.List(parent).PageSize(maxSources).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("list gcp logs: %w", err)
 	}
-	sources := make([]Source, 0, len(names))
-	for _, raw := range names {
-		name := raw
-		if d, derr := url.PathUnescape(raw); derr == nil {
-			name = d
+	for _, name := range resp.LogNames {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
 		}
-		short := name
-		if i := strings.Index(name, "/logs/"); i >= 0 {
-			short = name[i+len("/logs/"):]
-		}
-		// The source id is a ready-to-use Cloud Logging filter.
-		sources = append(sources, Source{ID: fmt.Sprintf("logName=%q", name), Kind: "log", Service: short})
+		sources = append(sources, Source{
+			ID:      fmt.Sprintf("logName=%q", name),
+			Kind:    "log",
+			Service: gcpLogIDFromName(name),
+		})
 	}
 	return sources, nil
 }
 
-type gcpEntry struct {
-	Timestamp   string         `json:"timestamp"`
-	Severity    string         `json:"severity"`
-	TextPayload string         `json:"textPayload"`
-	JSONPayload map[string]any `json:"jsonPayload"`
-	LogName     string         `json:"logName"`
-	InsertID    string         `json:"insertId"`
-	Resource    struct {
-		Type   string            `json:"type"`
-		Labels map[string]string `json:"labels"`
-	} `json:"resource"`
-	HTTPRequest struct {
-		RequestMethod string `json:"requestMethod"`
-		RequestURL    string `json:"requestUrl"`
-		Status        int    `json:"status"`
-		Latency       string `json:"latency"`
-	} `json:"httpRequest"`
-	ProtoPayload map[string]any `json:"protoPayload"`
-	Trace        string         `json:"trace"`
+func gcpLogIDFromName(name string) string {
+	logID := strings.TrimSpace(name)
+	if i := strings.Index(logID, "/logs/"); i >= 0 {
+		logID = logID[i+len("/logs/"):]
+	}
+	if decoded, err := url.PathUnescape(logID); err == nil {
+		logID = decoded
+	}
+	return logID
 }
 
-func (c *gcpCollector) freshness(opts Options) string {
-	if opts.Since.IsZero() {
-		return "30d" // count mode: look back far; --limit caps to the last N
+func gcpSeverityFloor(level string) string {
+	switch normalizeLevel(level) {
+	case LevelDebug:
+		return "DEBUG"
+	case LevelInfo:
+		return "INFO"
+	case LevelWarn:
+		return "WARNING"
+	case LevelError:
+		return "ERROR"
+	case LevelFatal:
+		return "CRITICAL"
+	default:
+		return ""
 	}
-	d := time.Since(opts.Since)
-	if d <= 0 {
-		return "1h"
-	}
-	return fmt.Sprintf("%ds", int64(d.Seconds())+60)
 }
 
-// read runs `gcloud logging read` with an explicit filter/order/freshness.
-func (c *gcpCollector) read(ctx context.Context, opts Options, filter, order string, limit int, freshness string) ([]gcpEntry, error) {
-	args := c.projectArgs(opts, "logging", "read")
-	if f := strings.TrimSpace(filter); f != "" {
-		args = append(args, f)
+func gcpEntryFilter(opts Options, includeSince bool, extra ...string) string {
+	parts := make([]string, 0, 5+len(extra))
+	if resource := strings.TrimSpace(opts.Resource); resource != "" {
+		parts = append(parts, "("+resource+")")
 	}
-	args = append(args, "--format=json", "--order="+order, fmt.Sprintf("--limit=%d", limit))
-	if freshness != "" {
-		args = append(args, "--freshness="+freshness)
+	if includeSince && !opts.Since.IsZero() {
+		parts = append(parts, fmt.Sprintf(`timestamp >= "%s"`, opts.Since.UTC().Format(time.RFC3339Nano)))
 	}
-	out, err := runJSON(ctx, "gcloud", args, opts.Env)
-	if err != nil {
-		return nil, err
+	if !opts.Until.IsZero() {
+		parts = append(parts, fmt.Sprintf(`timestamp <= "%s"`, opts.Until.UTC().Format(time.RFC3339Nano)))
 	}
-	var rows []gcpEntry
-	if err := json.Unmarshal(out, &rows); err != nil {
-		return nil, fmt.Errorf("parse gcp log entries: %w", err)
+	if severity := gcpSeverityFloor(opts.Level); severity != "" {
+		parts = append(parts, "severity >= "+severity)
+	}
+	for _, part := range extra {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			parts = append(parts, trimmed)
+		}
+	}
+	return strings.Join(parts, " AND ")
+}
+
+func (c *gcpCollector) read(ctx context.Context, client *gcplogging.Service, project, filter, order string, limit int) ([]*gcplogging.LogEntry, error) {
+	if limit <= 0 {
+		limit = 1000
+	}
+	req := &gcplogging.ListLogEntriesRequest{
+		ResourceNames: []string{"projects/" + project},
+		PageSize:      int64(limit),
+	}
+	if filter := strings.TrimSpace(filter); filter != "" {
+		req.Filter = filter
+	}
+	if strings.EqualFold(strings.TrimSpace(order), "desc") {
+		req.OrderBy = "timestamp desc"
+	} else {
+		req.OrderBy = "timestamp asc"
+	}
+	rows := make([]*gcplogging.LogEntry, 0, limit)
+	for len(rows) < limit {
+		resp, err := client.Entries.List(req).Context(ctx).Do()
+		if err != nil {
+			return nil, fmt.Errorf("read gcp log entries: %w", err)
+		}
+		for _, entry := range resp.Entries {
+			rows = append(rows, entry)
+			if len(rows) >= limit {
+				break
+			}
+		}
+		if len(rows) >= limit || strings.TrimSpace(resp.NextPageToken) == "" {
+			break
+		}
+		req.PageToken = resp.NextPageToken
 	}
 	return rows, nil
 }
 
-func (c *gcpCollector) toEntry(opts Options, ge gcpEntry) Entry {
+func (c *gcpCollector) toEntry(opts Options, ge *gcplogging.LogEntry) Entry {
 	ts := time.Now()
-	if t, err := time.Parse(time.RFC3339Nano, ge.Timestamp); err == nil {
-		ts = t
+	if parsed, err := time.Parse(time.RFC3339Nano, ge.Timestamp); err == nil {
+		ts = parsed
+	} else if parsed, err := time.Parse(time.RFC3339, ge.Timestamp); err == nil {
+		ts = parsed
+	} else if strings.TrimSpace(ge.Timestamp) == "" {
+		ts = time.Now()
 	}
-	msg := ge.TextPayload
-	if msg == "" && ge.JSONPayload != nil {
-		if m, ok := ge.JSONPayload["message"].(string); ok && m != "" {
-			msg = m
-		} else if b, err := json.Marshal(ge.JSONPayload); err == nil {
-			msg = string(b)
-		}
+	msg := gcpPayloadMessage(ge.TextPayload, ge.JsonPayload, ge.ProtoPayload)
+	if msg == "" && ge.HttpRequest != nil {
+		msg = strings.TrimSpace(fmt.Sprintf("%s %s %d %s", ge.HttpRequest.RequestMethod, ge.HttpRequest.RequestUrl, ge.HttpRequest.Status, ge.HttpRequest.Latency))
 	}
-	// Request logs (Cloud Run / API Gateway) carry no payload — synthesize from
-	// httpRequest; audit logs from protoPayload.methodName.
-	if msg == "" && ge.HTTPRequest.RequestMethod != "" {
-		msg = strings.TrimSpace(fmt.Sprintf("%s %s %d %s",
-			ge.HTTPRequest.RequestMethod, ge.HTTPRequest.RequestURL, ge.HTTPRequest.Status, ge.HTTPRequest.Latency))
-	}
-	if msg == "" && ge.ProtoPayload != nil {
-		if mn, ok := ge.ProtoPayload["methodName"].(string); ok && mn != "" {
-			msg = mn
-		} else if b, err := json.Marshal(ge.ProtoPayload); err == nil {
-			msg = string(b)
-		}
+	if msg == "" {
+		msg = ge.InsertId
 	}
 	// Use the unique insertId as the stream so the citation ref is unique even
 	// for identical messages (avoids dedup dropping distinct entries).
-	e := NewEntry("gcp", ge.LogName, ge.InsertID, msg, ts)
+	e := NewEntry("gcp", ge.LogName, ge.InsertId, msg, ts)
 	if sev := strings.TrimSpace(ge.Severity); sev != "" && !strings.EqualFold(sev, "DEFAULT") {
 		e.SetLevel(sev)
 	}
-	if ge.Resource.Type != "" {
+	if ge.Resource != nil && ge.Resource.Type != "" {
 		e.AddLabel("resourceType", ge.Resource.Type)
+		for _, key := range []string{"project_id", "location", "zone", "region", "service_name", "revision_name", "cluster_name", "namespace_name", "pod_name", "container_name", "function_name", "job_name"} {
+			if value := strings.TrimSpace(ge.Resource.Labels[key]); value != "" {
+				e.AddLabel("resource."+key, value)
+				if e.Service == "" && strings.HasSuffix(key, "_name") {
+					e.Service = value
+				}
+			}
+		}
 	}
 	if ge.Trace != "" {
 		e.AddLabel("trace", ge.Trace)
 	}
-	e.Service = opts.Service
+	if e.Service == "" {
+		e.Service = opts.Service
+	}
 	return e
+}
+
+func gcpPayloadMessage(text string, jsonPayload []byte, protoPayload []byte) string {
+	if text = strings.TrimSpace(text); text != "" {
+		return text
+	}
+	if msg := gcpRawPayloadMessage(jsonPayload); msg != "" {
+		return msg
+	}
+	return gcpRawPayloadMessage(protoPayload)
+}
+
+func gcpRawPayloadMessage(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err == nil {
+		for _, key := range []string{"message", "msg", "text", "event", "methodName", "status"} {
+			if value, ok := obj[key]; ok {
+				if msg := strings.TrimSpace(fmt.Sprint(value)); msg != "" {
+					return msg
+				}
+			}
+		}
+		if b, err := json.Marshal(obj); err == nil {
+			return string(b)
+		}
+	}
+	return string(raw)
 }
 
 func (c *gcpCollector) Query(ctx context.Context, opts Options, emit Emit) error {
@@ -161,7 +229,12 @@ func (c *gcpCollector) Query(ctx context.Context, opts Options, emit Emit) error
 	if limit <= 0 {
 		limit = 1000
 	}
-	rows, err := c.read(ctx, opts, opts.Resource, "desc", limit, c.freshness(opts))
+	client, project, err := c.client(ctx, opts)
+	if err != nil {
+		return err
+	}
+
+	rows, err := c.read(ctx, client, project, gcpEntryFilter(opts, true), "desc", limit)
 	if err != nil {
 		return err
 	}
@@ -185,8 +258,13 @@ func (c *gcpCollector) Tail(ctx context.Context, opts Options, emit Emit) error 
 	if limit <= 0 {
 		limit = 200
 	}
+	client, project, err := c.client(ctx, opts)
+	if err != nil {
+		return err
+	}
+
 	var lastSeenMs int64
-	emitRows := func(rows []gcpEntry) error {
+	emitRows := func(rows []*gcplogging.LogEntry) error {
 		for _, ge := range rows {
 			e := c.toEntry(opts, ge)
 			if e.EpochMs > lastSeenMs {
@@ -206,7 +284,7 @@ func (c *gcpCollector) Tail(ctx context.Context, opts Options, emit Emit) error 
 	}
 
 	// Backfill: newest N (desc), emitted oldest-first.
-	backfill, err := c.read(ctx, opts, opts.Resource, "desc", limit, c.freshness(opts))
+	backfill, err := c.read(ctx, client, project, gcpEntryFilter(opts, true), "desc", limit)
 	if err != nil {
 		return err
 	}
@@ -231,11 +309,7 @@ func (c *gcpCollector) Tail(ctx context.Context, opts Options, emit Emit) error 
 			// Incremental: only entries strictly newer than the last seen, asc.
 			// Bounds cost (no full-window rescan) and never skips a busy burst.
 			tsFilter := fmt.Sprintf("timestamp>%q", time.UnixMilli(lastSeenMs).UTC().Format(time.RFC3339Nano))
-			filter := tsFilter
-			if r := strings.TrimSpace(opts.Resource); r != "" {
-				filter = "(" + r + ") AND " + tsFilter
-			}
-			rows, err := c.read(ctx, opts, filter, "asc", 1000, "1h")
+			rows, err := c.read(ctx, client, project, gcpEntryFilter(opts, false, tsFilter), "asc", 1000)
 			if err != nil {
 				if fails++; fails >= maxConsecutivePollErrors {
 					return err

--- a/internal/logs/gcp_test.go
+++ b/internal/logs/gcp_test.go
@@ -1,0 +1,60 @@
+package logs
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	gcplogging "google.golang.org/api/logging/v2"
+)
+
+func TestGCPEntryFilterPushesTimeAndSeverity(t *testing.T) {
+	since := time.Date(2026, 6, 24, 15, 0, 0, 0, time.UTC)
+	filter := gcpEntryFilter(Options{
+		Resource: `logName="projects/demo/logs/run.googleapis.com%2Fstderr"`,
+		Since:    since,
+		Level:    "error",
+	}, true)
+
+	for _, want := range []string{
+		`(logName="projects/demo/logs/run.googleapis.com%2Fstderr")`,
+		`timestamp >= "2026-06-24T15:00:00Z"`,
+		`severity >= ERROR`,
+	} {
+		if !strings.Contains(filter, want) {
+			t.Fatalf("filter %q missing %q", filter, want)
+		}
+	}
+}
+
+func TestGCPToEntryNormalizesAPILogEntry(t *testing.T) {
+	raw := []byte(`{"message":"database connection failed","code":500}`)
+	entry := (&gcpCollector{}).toEntry(Options{}, &gcplogging.LogEntry{
+		Timestamp:   "2026-06-24T15:04:31.766177773Z",
+		Severity:    "ERROR",
+		LogName:     "projects/demo/logs/run.googleapis.com%2Fstderr",
+		InsertId:    "insert-1",
+		JsonPayload: raw,
+		Resource: &gcplogging.MonitoredResource{
+			Type: "cloud_run_revision",
+			Labels: map[string]string{
+				"service_name": "api",
+				"location":     "us-east4",
+			},
+		},
+		Trace: "projects/demo/traces/trace-1",
+	})
+
+	if entry.Message != "database connection failed" {
+		t.Fatalf("Message = %q, want database connection failed", entry.Message)
+	}
+	if entry.Level != LevelError || entry.RawLevel != "ERROR" {
+		t.Fatalf("level = %q raw = %q, want error/ERROR", entry.Level, entry.RawLevel)
+	}
+	if entry.Service != "api" {
+		t.Fatalf("Service = %q, want api", entry.Service)
+	}
+	if entry.Labels["resource.location"] != "us-east4" || entry.Labels["trace"] == "" {
+		t.Fatalf("labels = %#v, want location and trace", entry.Labels)
+	}
+}

--- a/internal/onboarding/onboarding.go
+++ b/internal/onboarding/onboarding.go
@@ -18,6 +18,7 @@ type ToolGuide struct {
 	ID              string              `json:"id"`
 	Tool            string              `json:"tool"`
 	Binary          string              `json:"binary"`
+	Aliases         []string            `json:"aliases,omitempty"`
 	Providers       []string            `json:"providers,omitempty"`
 	VerifyCommand   string              `json:"verifyCommand"`
 	InstallCommands map[string][]string `json:"installCommands"`
@@ -28,6 +29,7 @@ type ToolStatus struct {
 	ID              string              `json:"id"`
 	Tool            string              `json:"tool"`
 	Binary          string              `json:"binary"`
+	Aliases         []string            `json:"aliases,omitempty"`
 	Providers       []string            `json:"providers,omitempty"`
 	Installed       bool                `json:"installed"`
 	Path            string              `json:"path,omitempty"`
@@ -320,6 +322,33 @@ func Guides() map[string]ToolGuide {
 			},
 			DocsURL: "https://fly.io/docs/flyctl/install/",
 		},
+		"tccli": {
+			ID:            "tccli",
+			Tool:          "Tencent Cloud CLI",
+			Binary:        "tccli",
+			Providers:     []string{"Tencent Cloud"},
+			VerifyCommand: "tccli --version",
+			InstallCommands: map[string][]string{
+				"darwin":  {"python3 -m pip install tccli-intl-en"},
+				"linux":   {"python3 -m pip install tccli-intl-en"},
+				"windows": {"py -m pip install tccli-intl-en"},
+			},
+			DocsURL: "https://www.tencentcloud.com/document/product/1013/33464",
+		},
+		"sentry-cli": {
+			ID:            "sentry-cli",
+			Tool:          "Sentry CLI",
+			Binary:        "sentry-cli",
+			Aliases:       []string{"sentry"},
+			Providers:     []string{"Sentry"},
+			VerifyCommand: "sentry-cli --version",
+			InstallCommands: map[string][]string{
+				"darwin":  {"brew install getsentry/tools/sentry-cli"},
+				"linux":   {"curl -sL https://sentry.io/get-cli/ | bash"},
+				"windows": {"npm install -g @sentry/cli"},
+			},
+			DocsURL: "https://docs.sentry.io/cli/installation/",
+		},
 	}
 }
 
@@ -410,7 +439,7 @@ func Install(ctx context.Context, opts InstallOptions) InstallResult {
 				break
 			}
 		}
-		if _, err := exec.LookPath(guide.Binary); err == nil {
+		if _, err := findToolGuideBinary(guide); err == nil {
 			toolResult.Installed = true
 		}
 		result.Results = append(result.Results, toolResult)
@@ -591,8 +620,8 @@ func AuthGuides() map[string]AuthGuide {
 		"tencent": {
 			ID:            "tencent",
 			Provider:      "Tencent Cloud",
-			Purpose:       "Create a Tencent Cloud SecretId/SecretKey pair for direct Tencent API access. Prefer sub-user credentials scoped to the services Clanker should inspect.",
-			LoginCommands: []string{},
+			Purpose:       "Install tccli, then configure a Tencent Cloud SecretId/SecretKey pair. Prefer sub-user credentials scoped to the services Clanker should inspect.",
+			LoginCommands: []string{"tccli configure"},
 			EnvVars:       []string{"TENCENTCLOUD_SECRET_ID", "TENCENTCLOUD_SECRET_KEY", "TENCENTCLOUD_REGION", "TENCENT_SECRET_ID", "TENCENT_SECRET_KEY", "TENCENT_REGION"},
 			DocsURL:       "https://www.tencentcloud.com/document/product/214/1526",
 			TokenURL:      "https://www.tencentcloud.com/document/product/598/32675",
@@ -609,8 +638,8 @@ func AuthGuides() map[string]AuthGuide {
 		"sentry": {
 			ID:            "sentry",
 			Provider:      "Sentry",
-			Purpose:       "Create an official Sentry auth token and provide the org slug for issues, releases, monitors, and alert management.",
-			LoginCommands: []string{},
+			Purpose:       "Install the official Sentry CLI or create an auth token, then provide the org slug for issues, releases, monitors, and alert management.",
+			LoginCommands: []string{"sentry-cli login", "sentry auth login"},
 			EnvVars:       []string{"SENTRY_AUTH_TOKEN", "SENTRY_ORG", "SENTRY_HOST"},
 			DocsURL:       "https://docs.sentry.io/api/auth/",
 			TokenURL:      "https://docs.sentry.io/api/guides/create-auth-token/",
@@ -650,22 +679,20 @@ func scanTools(ctx context.Context) map[string]ToolStatus {
 			ID:              guide.ID,
 			Tool:            guide.Tool,
 			Binary:          guide.Binary,
+			Aliases:         append([]string(nil), guide.Aliases...),
 			Providers:       append([]string(nil), guide.Providers...),
 			VerifyCommand:   guide.VerifyCommand,
 			InstallCommands: installCommandsForOS(guide),
 			AllCommands:     guide.InstallCommands,
 			DocsURL:         guide.DocsURL,
 		}
-		path, err := exec.LookPath(guide.Binary)
-		if key == "flyctl" && err != nil {
-			path, err = exec.LookPath("flyctl")
-		}
+		path, err := findToolGuideBinary(guide)
 		if err == nil {
 			status.Installed = true
 			status.Path = path
-			status.Version = detectVersion(ctx, guide)
+			status.Version = detectVersion(ctx, guide, path)
 		} else {
-			status.Message = guide.Binary + " not found in PATH"
+			status.Message = strings.Join(toolGuideBinaries(guide), " or ") + " not found in PATH"
 		}
 		result[key] = status
 	}
@@ -821,7 +848,7 @@ func providerGuides() []providerGuide {
 			}
 			return len(notes) > 0, len(notes) > 0, notes
 		}},
-		{ID: "tencent", Name: "Tencent Cloud", RequiredTools: []string{}, Detect: func() (bool, bool, []string) {
+		{ID: "tencent", Name: "Tencent Cloud", RequiredTools: []string{"tccli"}, Detect: func() (bool, bool, []string) {
 			notes := []string{}
 			if hasAnyEnv("TENCENTCLOUD_SECRET_ID", "TENCENTCLOUD_SECRET_KEY", "TENCENT_SECRET_ID", "TENCENT_SECRET_KEY") {
 				notes = append(notes, "tencent env")
@@ -838,7 +865,7 @@ func providerGuides() []providerGuide {
 			}
 			return len(notes) > 0, len(notes) > 0, notes
 		}},
-		{ID: "sentry", Name: "Sentry", RequiredTools: []string{}, Detect: func() (bool, bool, []string) {
+		{ID: "sentry", Name: "Sentry", RequiredTools: []string{"sentry-cli"}, Detect: func() (bool, bool, []string) {
 			notes := []string{}
 			if hasAnyEnv("SENTRY_AUTH_TOKEN", "SENTRY_ORG", "SENTRY_HOST") {
 				notes = append(notes, "sentry env")
@@ -941,6 +968,10 @@ func normalizeToolID(raw string) string {
 		return "gh"
 	case "fly", "flyio", "fly.io":
 		return "flyctl"
+	case "tencent", "tencent cloud", "tencent-cloud", "tencentcloud", "tccli":
+		return "tccli"
+	case "sentry", "sentry-cli", "sentrycli":
+		return "sentry-cli"
 	default:
 		return value
 	}
@@ -960,17 +991,13 @@ func normalizeSet(values []string) map[string]bool {
 	return result
 }
 
-func detectVersion(ctx context.Context, guide ToolGuide) string {
+func detectVersion(ctx context.Context, guide ToolGuide, binaryPath string) string {
 	parts := strings.Fields(guide.VerifyCommand)
 	if len(parts) == 0 {
 		return ""
 	}
-	if guide.ID == "flyctl" {
-		if _, err := exec.LookPath(parts[0]); err != nil {
-			if _, fallbackErr := exec.LookPath("flyctl"); fallbackErr == nil {
-				parts[0] = "flyctl"
-			}
-		}
+	if strings.TrimSpace(binaryPath) != "" {
+		parts[0] = binaryPath
 	}
 	versionCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
@@ -984,6 +1011,32 @@ func detectVersion(ctx context.Context, guide ToolGuide) string {
 		return ""
 	}
 	return strings.TrimSpace(lines[0])
+}
+
+func findToolGuideBinary(guide ToolGuide) (string, error) {
+	for _, binary := range toolGuideBinaries(guide) {
+		if path, err := exec.LookPath(binary); err == nil {
+			return path, nil
+		}
+	}
+	return "", exec.ErrNotFound
+}
+
+func toolGuideBinaries(guide ToolGuide) []string {
+	binaries := []string{}
+	seen := map[string]bool{}
+	for _, binary := range append([]string{guide.Binary}, guide.Aliases...) {
+		binary = strings.TrimSpace(binary)
+		if binary == "" || seen[binary] {
+			continue
+		}
+		seen[binary] = true
+		binaries = append(binaries, binary)
+	}
+	if guide.ID == "flyctl" && !seen["flyctl"] {
+		binaries = append(binaries, "flyctl")
+	}
+	return binaries
 }
 
 func installCommandsForOS(guide ToolGuide) []string {

--- a/internal/onboarding/onboarding_test.go
+++ b/internal/onboarding/onboarding_test.go
@@ -40,13 +40,15 @@ func TestGuidesPreferOfficialVendorDocs(t *testing.T) {
 	guides := Guides()
 
 	checks := map[string]string{
-		"aws":      "https://docs.aws.amazon.com/",
-		"gcloud":   "https://docs.cloud.google.com/",
-		"az":       "https://learn.microsoft.com/",
-		"doctl":    "https://docs.digitalocean.com/",
-		"railway":  "https://docs.railway.com/",
-		"supabase": "https://supabase.com/docs/",
-		"flyctl":   "https://fly.io/docs/",
+		"aws":        "https://docs.aws.amazon.com/",
+		"gcloud":     "https://docs.cloud.google.com/",
+		"az":         "https://learn.microsoft.com/",
+		"doctl":      "https://docs.digitalocean.com/",
+		"railway":    "https://docs.railway.com/",
+		"supabase":   "https://supabase.com/docs/",
+		"flyctl":     "https://fly.io/docs/",
+		"tccli":      "https://www.tencentcloud.com/",
+		"sentry-cli": "https://docs.sentry.io/",
 	}
 	for id, prefix := range checks {
 		guide, ok := guides[id]
@@ -56,5 +58,24 @@ func TestGuidesPreferOfficialVendorDocs(t *testing.T) {
 		if !strings.HasPrefix(guide.DocsURL, prefix) {
 			t.Fatalf("%s docs URL = %q, want prefix %q", id, guide.DocsURL, prefix)
 		}
+	}
+}
+
+func TestProviderGuidesRequireOfficialTencentAndSentryCLIs(t *testing.T) {
+	found := map[string][]string{}
+	for _, guide := range providerGuides() {
+		found[guide.ID] = guide.RequiredTools
+	}
+	for id, want := range map[string]string{"tencent": "tccli", "sentry": "sentry-cli"} {
+		tools := found[id]
+		if len(tools) != 1 || tools[0] != want {
+			t.Fatalf("%s required tools = %#v, want [%s]", id, tools, want)
+		}
+	}
+	if normalizeToolID("tencent cloud") != "tccli" {
+		t.Fatal("tencent cloud alias did not normalize to tccli")
+	}
+	if normalizeToolID("sentry") != "sentry-cli" {
+		t.Fatal("sentry alias did not normalize to sentry-cli")
 	}
 }

--- a/internal/sre/check.go
+++ b/internal/sre/check.go
@@ -1,0 +1,272 @@
+package sre
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+type CheckIssue struct {
+	ID       string   `json:"id"`
+	Severity string   `json:"severity"`
+	Provider string   `json:"provider,omitempty"`
+	Category string   `json:"category"`
+	Title    string   `json:"title"`
+	Message  string   `json:"message"`
+	Evidence []string `json:"evidence,omitempty"`
+}
+
+type CheckResult struct {
+	GeneratedAt  string         `json:"generatedAt"`
+	Status       string         `json:"status"`
+	Summary      string         `json:"summary"`
+	Providers    []string       `json:"providers"`
+	Findings     []string       `json:"findings"`
+	Issues       []CheckIssue   `json:"issues"`
+	Discovery    Discovery      `json:"discovery"`
+	Observations map[string]any `json:"observations"`
+}
+
+func Check(ctx context.Context) CheckResult {
+	discovery := Discover(ctx)
+	SortDiscovery(&discovery)
+	observations := CollectObservations(ctx, discovery)
+	findings := BuildFindings(discovery, observations)
+	return BuildCheckResult(discovery, observations, findings)
+}
+
+func BuildCheckResult(discovery Discovery, observations map[string]any, findings []string) CheckResult {
+	issues := ClassifyFindings(findings)
+	providers := make([]string, 0, len(discovery.Providers))
+	for _, provider := range discovery.Providers {
+		if provider.Available {
+			providers = append(providers, strings.ToLower(strings.TrimSpace(provider.ID)))
+		}
+	}
+	sort.Strings(providers)
+
+	status := "ok"
+	for _, issue := range issues {
+		switch issue.Severity {
+		case "critical":
+			status = "critical"
+		case "warning":
+			if status == "ok" {
+				status = "warning"
+			}
+		}
+	}
+
+	summary := fmt.Sprintf("Live SRE check completed with %d finding%s", len(findings), pluralSuffix(len(findings)))
+	if len(issues) > 0 {
+		summary = fmt.Sprintf("Live SRE found %d actionable issue%s", len(issues), pluralSuffix(len(issues)))
+	}
+
+	return CheckResult{
+		GeneratedAt:  time.Now().UTC().Format(time.RFC3339),
+		Status:       status,
+		Summary:      summary,
+		Providers:    providers,
+		Findings:     dedupeStrings(findings),
+		Issues:       issues,
+		Discovery:    discovery,
+		Observations: observations,
+	}
+}
+
+func ClassifyFindings(findings []string) []CheckIssue {
+	issues := make([]CheckIssue, 0)
+	seen := map[string]bool{}
+	for _, raw := range findings {
+		finding := strings.TrimSpace(raw)
+		if finding == "" {
+			continue
+		}
+		severity := classifyFindingSeverity(finding)
+		if severity == "" {
+			if findingLooksInformational(finding) {
+				continue
+			}
+			continue
+		}
+		provider := inferFindingProvider(finding)
+		category := inferFindingCategory(finding)
+		title := findingTitle(finding, provider, category)
+		id := stableIssueID(provider, category, finding)
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		issues = append(issues, CheckIssue{
+			ID:       id,
+			Severity: severity,
+			Provider: provider,
+			Category: category,
+			Title:    title,
+			Message:  finding,
+			Evidence: []string{finding},
+		})
+	}
+	sort.SliceStable(issues, func(i, j int) bool {
+		return severityRank(issues[i].Severity) > severityRank(issues[j].Severity)
+	})
+	return issues
+}
+
+func findingLooksInformational(value string) bool {
+	lower := strings.ToLower(value)
+	infoPhrases := []string{
+		" detected",
+		" sampled",
+		" tracked",
+		"available",
+		"provider context",
+		"heartbeat",
+	}
+	for _, phrase := range infoPhrases {
+		if strings.Contains(lower, phrase) {
+			return true
+		}
+	}
+	return false
+}
+
+func classifyFindingSeverity(value string) string {
+	lower := strings.ToLower(value)
+	if strings.Contains(lower, "alert:") ||
+		strings.Contains(lower, "critical") ||
+		strings.Contains(lower, "prod down") ||
+		strings.Contains(lower, "unhealthy pods") ||
+		strings.Contains(lower, "no endpoints") ||
+		strings.Contains(lower, "not-ready") ||
+		strings.Contains(lower, "failed state") {
+		return "critical"
+	}
+	warningTerms := []string{
+		"security:",
+		"fired",
+		"failure",
+		"failed",
+		"error",
+		"drift",
+		"unavailable",
+		"scaling ceiling",
+		"pending",
+		"restart",
+		"throttle",
+		"alarm",
+		"oomkilled",
+		"crashloop",
+	}
+	for _, term := range warningTerms {
+		if strings.Contains(lower, term) {
+			return "warning"
+		}
+	}
+	return ""
+}
+
+func inferFindingProvider(value string) string {
+	lower := strings.ToLower(value)
+	providers := []string{
+		"aws",
+		"cloudwatch",
+		"gcp",
+		"azure",
+		"cloudflare",
+		"digitalocean",
+		"hetzner",
+		"vercel",
+		"railway",
+		"flyio",
+		"fly.io",
+		"verda",
+		"tencent",
+		"supabase",
+		"sentry",
+		"kubernetes",
+		"k8s",
+		"docker",
+		"terraform",
+		"opentofu",
+		"systemd",
+	}
+	for _, provider := range providers {
+		if strings.Contains(lower, provider) {
+			switch provider {
+			case "fly.io":
+				return "flyio"
+			case "cloudwatch":
+				return "aws"
+			case "kubernetes":
+				return "k8s"
+			case "opentofu":
+				return "terraform"
+			default:
+				return provider
+			}
+		}
+	}
+	return "infrastructure"
+}
+
+func inferFindingCategory(value string) string {
+	lower := strings.ToLower(value)
+	switch {
+	case strings.Contains(lower, "log") || strings.Contains(lower, "error reporting"):
+		return "logs"
+	case strings.Contains(lower, "alarm") || strings.Contains(lower, "alert") || strings.Contains(lower, "fired"):
+		return "alert"
+	case strings.Contains(lower, "mfa") || strings.Contains(lower, "security"):
+		return "security"
+	case strings.Contains(lower, "drift") || strings.Contains(lower, "terraform") || strings.Contains(lower, "opentofu"):
+		return "iac"
+	case strings.Contains(lower, "hpa") || strings.Contains(lower, "scaling") || strings.Contains(lower, "throttle"):
+		return "scaling"
+	case strings.Contains(lower, "pod") || strings.Contains(lower, "node") || strings.Contains(lower, "deployment") || strings.Contains(lower, "service"):
+		return "availability"
+	default:
+		return "reliability"
+	}
+}
+
+var leadingFindingPrefixRe = regexp.MustCompile(`(?i)^(alert|security|warning|critical):\s*`)
+
+func findingTitle(value string, provider string, category string) string {
+	cleaned := leadingFindingPrefixRe.ReplaceAllString(strings.TrimSpace(value), "")
+	if len(cleaned) > 96 {
+		cleaned = strings.TrimSpace(cleaned[:96]) + "..."
+	}
+	if provider != "" && provider != "infrastructure" {
+		return strings.ToUpper(provider) + " " + category + ": " + cleaned
+	}
+	return strings.Title(category) + ": " + cleaned
+}
+
+func stableIssueID(provider string, category string, message string) string {
+	h := sha1.Sum([]byte(strings.ToLower(strings.TrimSpace(provider + "|" + category + "|" + message))))
+	return "sre-" + hex.EncodeToString(h[:])[:12]
+}
+
+func severityRank(value string) int {
+	switch value {
+	case "critical":
+		return 3
+	case "warning":
+		return 2
+	default:
+		return 1
+	}
+}
+
+func pluralSuffix(count int) string {
+	if count == 1 {
+		return ""
+	}
+	return "s"
+}

--- a/internal/sre/check_test.go
+++ b/internal/sre/check_test.go
@@ -42,3 +42,23 @@ func TestBuildCheckResultStatus(t *testing.T) {
 		t.Fatalf("ok status = %q, want ok", ok.Status)
 	}
 }
+
+func TestDetectProvidersUsesTencentAndSentryCLIs(t *testing.T) {
+	providers := detectProviders(map[string]ToolStatus{
+		"tccli":      {Name: "tccli", Available: true},
+		"sentry-cli": {Name: "sentry-cli", Available: true},
+	})
+	seen := map[string]ProviderStatus{}
+	for _, provider := range providers {
+		seen[provider.ID] = provider
+	}
+	if !seen["tencent"].Available {
+		t.Fatalf("tencent provider was not available from tccli: %#v", seen["tencent"])
+	}
+	if !seen["sentry"].Available {
+		t.Fatalf("sentry provider was not available from sentry-cli: %#v", seen["sentry"])
+	}
+	if !toolAvailable([]ToolStatus{{Name: "sentry", Available: true}}, "sentry-cli", "sentry") {
+		t.Fatal("sentry alias was not treated as available")
+	}
+}

--- a/internal/sre/check_test.go
+++ b/internal/sre/check_test.go
@@ -1,0 +1,44 @@
+package sre
+
+import "testing"
+
+func TestClassifyFindingsKeepsOnlyActionableIssues(t *testing.T) {
+	findings := []string{
+		"docker detected with 3 running containers sampled",
+		"aws provider context detected",
+		"ALERT: 2 CloudWatch alarms in ALARM state",
+		"k8s: 1 services with no endpoints (broken selectors)",
+		"SECURITY: 4 IAM users without MFA",
+	}
+
+	issues := ClassifyFindings(findings)
+	if len(issues) != 3 {
+		t.Fatalf("issues = %d, want 3: %#v", len(issues), issues)
+	}
+	if issues[0].Severity != "critical" {
+		t.Fatalf("first severity = %q, want critical", issues[0].Severity)
+	}
+	if issues[0].Provider != "aws" {
+		t.Fatalf("first provider = %q, want aws", issues[0].Provider)
+	}
+	if issues[2].Category != "security" {
+		t.Fatalf("third category = %q, want security", issues[2].Category)
+	}
+}
+
+func TestBuildCheckResultStatus(t *testing.T) {
+	result := BuildCheckResult(Discovery{}, nil, []string{
+		"terraform/opentofu drift or pending plan changes detected",
+	})
+	if result.Status != "warning" {
+		t.Fatalf("status = %q, want warning", result.Status)
+	}
+	if len(result.Issues) != 1 {
+		t.Fatalf("issues = %d, want 1", len(result.Issues))
+	}
+
+	ok := BuildCheckResult(Discovery{}, nil, []string{"kubernetes control-plane access detected"})
+	if ok.Status != "ok" {
+		t.Fatalf("ok status = %q, want ok", ok.Status)
+	}
+}

--- a/internal/sre/sre.go
+++ b/internal/sre/sre.go
@@ -108,7 +108,7 @@ type RunOptions struct {
 func Discover(ctx context.Context) Discovery {
 	_ = ctx
 	hostname, _ := os.Hostname()
-	tools := detectTools([]string{"docker", "kubectl", "helm", "otelcol", "otelcol-contrib", "prometheus", "loki", "aws", "gcloud", "az", "doctl", "hcloud", "vercel", "railway", "flyctl", "fly", "verda", "terraform", "tofu", "pulumi", "cdk", "crossplane", "git"})
+	tools := detectTools([]string{"docker", "kubectl", "helm", "otelcol", "otelcol-contrib", "prometheus", "loki", "aws", "gcloud", "az", "doctl", "hcloud", "vercel", "railway", "flyctl", "fly", "tccli", "sentry-cli", "sentry", "verda", "terraform", "tofu", "pulumi", "cdk", "crossplane", "git"})
 	toolMap := make(map[string]ToolStatus, len(tools))
 	for _, tool := range tools {
 		toolMap[tool.Name] = tool
@@ -579,6 +579,7 @@ func CollectObservations(ctx context.Context, discovery Discovery) map[string]an
 			"secretIDConfigured":  hasAnyEnv("TENCENTCLOUD_SECRET_ID", "TENCENT_SECRET_ID") || viper.GetString("tencent.secret_id") != "",
 			"secretKeyConfigured": hasAnyEnv("TENCENTCLOUD_SECRET_KEY", "TENCENT_SECRET_KEY") || viper.GetString("tencent.secret_key") != "",
 			"region":              firstNonEmpty(os.Getenv("TENCENT_REGION"), os.Getenv("TENCENTCLOUD_REGION"), viper.GetString("tencent.region")),
+			"cliConfigured":       toolAvailable(discovery.Tools, "tccli"),
 		}
 	}
 	if hasProvider(discovery.Providers, "supabase") {
@@ -591,6 +592,7 @@ func CollectObservations(ctx context.Context, discovery Discovery) map[string]an
 			"tokenConfigured": hasAnyEnv("SENTRY_AUTH_TOKEN") || viper.GetString("sentry.auth_token") != "",
 			"org":             firstNonEmpty(os.Getenv("SENTRY_ORG"), viper.GetString("sentry.org")),
 			"host":            firstNonEmpty(os.Getenv("SENTRY_HOST"), viper.GetString("sentry.host")),
+			"cliConfigured":   toolAvailable(discovery.Tools, "sentry-cli", "sentry"),
 		}
 	}
 	if len(accounts) > 0 {
@@ -811,6 +813,22 @@ func detectTools(names []string) []ToolStatus {
 	return tools
 }
 
+func toolAvailable(tools []ToolStatus, names ...string) bool {
+	wanted := map[string]bool{}
+	for _, name := range names {
+		name = strings.TrimSpace(strings.ToLower(name))
+		if name != "" {
+			wanted[name] = true
+		}
+	}
+	for _, tool := range tools {
+		if wanted[strings.TrimSpace(strings.ToLower(tool.Name))] && tool.Available {
+			return true
+		}
+	}
+	return false
+}
+
 func hasProvider(providers []ProviderStatus, id string) bool {
 	id = strings.TrimSpace(strings.ToLower(id))
 	if id == "" {
@@ -879,9 +897,9 @@ func detectProviders(tools map[string]ToolStatus) []ProviderStatus {
 		provider("railway", "Railway", tools["railway"].Available || hasAnyEnv("RAILWAY_TOKEN") || viper.GetString("railway.token") != "", "railway cli/token/config detected"),
 		provider("flyio", "Fly.io", tools["flyctl"].Available || tools["fly"].Available || hasAnyEnv("FLY_API_TOKEN", "FLY_ACCESS_TOKEN") || viper.GetString("flyio.api_token") != "", "fly cli/token/config detected"),
 		provider("verda", "Verda", tools["verda"].Available || hasAnyEnv("VERDA_CLIENT_ID", "VERDA_CLIENT_SECRET", "VERDA_PROJECT_ID") || viper.GetString("verda.client_id") != "", "verda cli/config/env detected"),
-		provider("tencent", "Tencent Cloud", hasAnyEnv("TENCENTCLOUD_SECRET_ID", "TENCENT_SECRET_ID") || viper.GetString("tencent.secret_id") != "", "tencent cloud config/env detected"),
+		provider("tencent", "Tencent Cloud", tools["tccli"].Available || hasAnyEnv("TENCENTCLOUD_SECRET_ID", "TENCENT_SECRET_ID") || viper.GetString("tencent.secret_id") != "", "tccli/config/env detected"),
 		provider("supabase", "Supabase", hasAnyEnv("SUPABASE_ACCESS_TOKEN", "SUPABASE_API_TOKEN", "SUPABASE_TOKEN") || viper.GetString("supabase.api_token") != "", "supabase token/config detected"),
-		provider("sentry", "Sentry", hasAnyEnv("SENTRY_AUTH_TOKEN") || viper.GetString("sentry.auth_token") != "", "sentry token/config detected"),
+		provider("sentry", "Sentry", tools["sentry-cli"].Available || tools["sentry"].Available || hasAnyEnv("SENTRY_AUTH_TOKEN") || viper.GetString("sentry.auth_token") != "", "sentry cli/token/config detected"),
 	}
 	return providers
 }

--- a/internal/sre/sre.go
+++ b/internal/sre/sre.go
@@ -108,7 +108,7 @@ type RunOptions struct {
 func Discover(ctx context.Context) Discovery {
 	_ = ctx
 	hostname, _ := os.Hostname()
-	tools := detectTools([]string{"docker", "kubectl", "helm", "otelcol", "otelcol-contrib", "prometheus", "loki", "aws", "gcloud", "az", "doctl", "hcloud", "vercel", "railway", "verda", "terraform", "tofu", "pulumi", "cdk", "crossplane", "git"})
+	tools := detectTools([]string{"docker", "kubectl", "helm", "otelcol", "otelcol-contrib", "prometheus", "loki", "aws", "gcloud", "az", "doctl", "hcloud", "vercel", "railway", "flyctl", "fly", "verda", "terraform", "tofu", "pulumi", "cdk", "crossplane", "git"})
 	toolMap := make(map[string]ToolStatus, len(tools))
 	for _, tool := range tools {
 		toolMap[tool.Name] = tool
@@ -568,6 +568,31 @@ func CollectObservations(ctx context.Context, discovery Discovery) map[string]an
 			accounts["cloudflare"] = map[string]any{"tokenLength": strings.TrimSpace(output)}
 		}
 	}
+	if hasProvider(discovery.Providers, "flyio") {
+		accounts["flyio"] = map[string]any{
+			"tokenConfigured": hasAnyEnv("FLY_API_TOKEN", "FLY_ACCESS_TOKEN") || viper.GetString("flyio.api_token") != "",
+			"org":             firstNonEmpty(os.Getenv("FLY_ORG"), os.Getenv("FLY_ORG_SLUG"), viper.GetString("flyio.org_slug")),
+		}
+	}
+	if hasProvider(discovery.Providers, "tencent") {
+		accounts["tencent"] = map[string]any{
+			"secretIDConfigured":  hasAnyEnv("TENCENTCLOUD_SECRET_ID", "TENCENT_SECRET_ID") || viper.GetString("tencent.secret_id") != "",
+			"secretKeyConfigured": hasAnyEnv("TENCENTCLOUD_SECRET_KEY", "TENCENT_SECRET_KEY") || viper.GetString("tencent.secret_key") != "",
+			"region":              firstNonEmpty(os.Getenv("TENCENT_REGION"), os.Getenv("TENCENTCLOUD_REGION"), viper.GetString("tencent.region")),
+		}
+	}
+	if hasProvider(discovery.Providers, "supabase") {
+		accounts["supabase"] = map[string]any{
+			"tokenConfigured": hasAnyEnv("SUPABASE_ACCESS_TOKEN", "SUPABASE_API_TOKEN", "SUPABASE_TOKEN") || viper.GetString("supabase.api_token") != "",
+		}
+	}
+	if hasProvider(discovery.Providers, "sentry") {
+		accounts["sentry"] = map[string]any{
+			"tokenConfigured": hasAnyEnv("SENTRY_AUTH_TOKEN") || viper.GetString("sentry.auth_token") != "",
+			"org":             firstNonEmpty(os.Getenv("SENTRY_ORG"), viper.GetString("sentry.org")),
+			"host":            firstNonEmpty(os.Getenv("SENTRY_HOST"), viper.GetString("sentry.host")),
+		}
+	}
 	if len(accounts) > 0 {
 		observations["providerAccounts"] = accounts
 	}
@@ -852,7 +877,11 @@ func detectProviders(tools map[string]ToolStatus) []ProviderStatus {
 		provider("hetzner", "Hetzner", tools["hcloud"].Available || hasAnyEnv("HCLOUD_TOKEN", "HETZNER_API_TOKEN") || viper.GetString("hetzner.api_token") != "", "hcloud/token/config detected"),
 		provider("vercel", "Vercel", tools["vercel"].Available || hasAnyEnv("VERCEL_TOKEN") || viper.GetString("vercel.token") != "", "vercel cli/token/config detected"),
 		provider("railway", "Railway", tools["railway"].Available || hasAnyEnv("RAILWAY_TOKEN") || viper.GetString("railway.token") != "", "railway cli/token/config detected"),
+		provider("flyio", "Fly.io", tools["flyctl"].Available || tools["fly"].Available || hasAnyEnv("FLY_API_TOKEN", "FLY_ACCESS_TOKEN") || viper.GetString("flyio.api_token") != "", "fly cli/token/config detected"),
 		provider("verda", "Verda", tools["verda"].Available || hasAnyEnv("VERDA_CLIENT_ID", "VERDA_CLIENT_SECRET", "VERDA_PROJECT_ID") || viper.GetString("verda.client_id") != "", "verda cli/config/env detected"),
+		provider("tencent", "Tencent Cloud", hasAnyEnv("TENCENTCLOUD_SECRET_ID", "TENCENT_SECRET_ID") || viper.GetString("tencent.secret_id") != "", "tencent cloud config/env detected"),
+		provider("supabase", "Supabase", hasAnyEnv("SUPABASE_ACCESS_TOKEN", "SUPABASE_API_TOKEN", "SUPABASE_TOKEN") || viper.GetString("supabase.api_token") != "", "supabase token/config detected"),
+		provider("sentry", "Sentry", hasAnyEnv("SENTRY_AUTH_TOKEN") || viper.GetString("sentry.auth_token") != "", "sentry token/config detected"),
 	}
 	return providers
 }


### PR DESCRIPTION
## Summary
- add `clanker sre check` for bounded read-only SRE snapshots with JSON output
- classify actionable SRE findings into explicit severity/provider/category issues
- expand SRE provider discovery context for Fly.io, Tencent Cloud, Supabase, and Sentry

## Verification
- go test ./...
- go run . sre check --format json --timeout 5s
- git diff --check