### PR TITLE
logs: make process-group handling cross-platform (fix Windows build)

### DIFF
--- a/internal/logs/exec.go
+++ b/internal/logs/exec.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"syscall"
 )
 
 // runJSON runs a CLI to completion and returns stdout. Extra env vars are
@@ -36,7 +35,7 @@ func runJSON(ctx context.Context, name string, args []string, env map[string]str
 func streamLines(ctx context.Context, name string, args []string, env map[string]string, fn func(line string) error) error {
 	cmd := exec.Command(name, args...)
 	cmd.Env = mergedEnv(env)
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	setProcessGroup(cmd)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -55,9 +54,7 @@ func streamLines(ctx context.Context, name string, args []string, env map[string
 	go func() {
 		select {
 		case <-ctx.Done():
-			if cmd.Process != nil {
-				_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-			}
+			killProcessGroup(cmd)
 		case <-done:
 		}
 	}()
@@ -68,9 +65,7 @@ func streamLines(ctx context.Context, name string, args []string, env map[string
 		if err := fn(scanner.Text()); err != nil {
 			// Consumer gave up (e.g. broken pipe): kill the whole process group
 			// and reap, so kubectl/flyctl don't outlive us as orphans.
-			if cmd.Process != nil {
-				_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
-			}
+			killProcessGroup(cmd)
 			_ = cmd.Wait()
 			return err
 		}

--- a/internal/logs/exec_unix.go
+++ b/internal/logs/exec_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package logs
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setProcessGroup starts the child in its own process group so cancellation can
+// signal the whole tree (kubectl/flyctl spawn helpers) rather than orphaning it.
+func setProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// killProcessGroup sends SIGKILL to the child's entire process group (negative
+// pid), so descendants die with it.
+func killProcessGroup(cmd *exec.Cmd) {
+	if cmd.Process != nil {
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+}

--- a/internal/logs/exec_windows.go
+++ b/internal/logs/exec_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package logs
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setProcessGroup starts the child in a new process group. Windows has no
+// setpgid; CREATE_NEW_PROCESS_GROUP is the closest equivalent and lets the
+// child be terminated independently of this process's console group.
+func setProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP}
+}
+
+// killProcessGroup terminates the child. Windows has no negative-pid group
+// kill; Process.Kill() ends the process, which is sufficient for the CLI tools
+// (kubectl/flyctl/etc.) we tail here.
+func killProcessGroup(cmd *exec.Cmd) {
+	if cmd.Process != nil {
+		_ = cmd.Process.Kill()
+	}
+}


### PR DESCRIPTION
## Problem
`internal/logs/exec.go` (unified logs) used `syscall.SysProcAttr{Setpgid: true}` and `syscall.Kill(-pid, SIGKILL)` directly. Those are Unix-only, so the CLI failed to cross-compile for Windows:

```
internal/logs/exec.go:39: unknown field Setpgid in struct literal of type syscall.SysProcAttr
internal/logs/exec.go:59,72: undefined: syscall.Kill
```

This broke the Windows desktop-app build (the bundled `clanker.exe`).

## Fix
Move process-group setup/teardown behind `setProcessGroup(cmd)` / `killProcessGroup(cmd)` helpers, split by build tag:
- `exec_unix.go` (`//go:build !windows`) — `Setpgid: true` + `syscall.Kill(-pid, SIGKILL)` (unchanged behavior).
- `exec_windows.go` (`//go:build windows`) — `CREATE_NEW_PROCESS_GROUP` + `Process.Kill()`.

## Testing
- `go build ./...` (host) and `GOOS=windows GOARCH=amd64 go build ./...` both succeed.
- `go vet ./internal/logs/` and `go test ./internal/logs/` pass.