### PR TITLE
fix(aws): don't panic on missing optional cluster_name in ECS log tools

### DIFF
--- a/internal/aws/llm.go
+++ b/internal/aws/llm.go
@@ -1868,7 +1868,7 @@ func (c *Client) executeAWSOperation(ctx context.Context, toolName string, input
 		if !ok {
 			return "", fmt.Errorf("service_name parameter required")
 		}
-		clusterName := input["cluster_name"].(string) // optional
+		clusterName, _ := input["cluster_name"].(string) // optional; absent → nil interface
 		if clusterName == "" {
 			clusterName = "default"
 		}
@@ -1911,7 +1911,7 @@ func (c *Client) executeAWSOperation(ctx context.Context, toolName string, input
 		if !ok {
 			return "", fmt.Errorf("task_arn parameter required")
 		}
-		clusterName := input["cluster_name"].(string)
+		clusterName, _ := input["cluster_name"].(string) // optional; absent → nil interface
 		if clusterName == "" {
 			clusterName = "default"
 		}


### PR DESCRIPTION
## Problem
`analyze_ecs_service_logs` and `get_ecs_task_logs` read `cluster_name` with a bare single-value type assertion (`input["cluster_name"].(string)`). The field is documented optional; when the LLM omits it, the map value is a nil interface and the assertion **panics**. The tool dispatcher runs inside goroutines with no `recover()`, so the panic crashes the whole process.

## Where
- `internal/aws/llm.go:1871` (analyze_ecs_service_logs)
- `internal/aws/llm.go:1914` (get_ecs_task_logs)

## Fix
Use the comma-ok form (`clusterName, _ := input["cluster_name"].(string)`); the existing `if clusterName == "" { clusterName = "default" }` fallback already handles the absent case — matching how `service_name`/`task_arn` are read two lines above.

## Testing
`go build ./internal/aws/` and `go vet ./internal/aws/` pass. (A panic-regression unit test needs AWS-CLI mocking of `executeAWSOperation`; the fix is the standard comma-ok idiom and is self-contained.)

Closes #207