### PR TITLE
Add Clanker Vision box runtime

### DIFF
--- a/Dockerfile.clankerbox
+++ b/Dockerfile.clankerbox
@@ -9,12 +9,15 @@ RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/clanker .
 FROM debian:bookworm-slim
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends bash ca-certificates curl git gnupg openssh-client python3 python3-venv \
+    && apt-get install -y --no-install-recommends bash ca-certificates chromium curl fonts-liberation git gnupg libreoffice-calc libreoffice-writer openssh-client python3 python3-venv \
     && install -d -m 0755 /etc/apt/keyrings \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends nodejs \
+    && python3 -m venv /opt/clanker-vision \
+    && /opt/clanker-vision/bin/python -m pip install --no-cache-dir --upgrade pip wheel setuptools \
+    && /opt/clanker-vision/bin/python -m pip install --no-cache-dir playwright==1.57.0 \
     && groupadd --system clankerbox \
     && useradd --system --create-home --gid clankerbox --shell /bin/sh clankerbox \
     && mkdir -p /home/clankerbox/.local \
@@ -30,6 +33,9 @@ ENV CLANKER_BOX_AGENT=clanker-cli \
     CLANKER_BOX_ENABLE_TERMINAL=true \
     CLANKER_BOX_AUTO_INSTALL=true \
     CLANKER_BOX_WORKDIR=/workspace \
+    CLANKER_BOX_VISION_PYTHON=/opt/clanker-vision/bin/python \
+    CLANKER_BOX_CHROMIUM_PATH=/usr/bin/chromium \
+    CLANKER_BOX_VISION_HEADLESS=true \
     HOME=/home/clankerbox \
     NPM_CONFIG_PREFIX=/home/clankerbox/.local \
     PATH=/home/clankerbox/.local/bin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin \

--- a/cmd/box.go
+++ b/cmd/box.go
@@ -63,7 +63,7 @@ func newBoxCmd() *cobra.Command {
 		},
 	}
 	manifestCmd.Flags().StringVar(&name, "name", "clanker-box", "Box display name")
-	manifestCmd.Flags().StringVar(&agent, "agent", "clanker-cli", "Agent to run (hermes, openclaw, codex, claude-code, clanker-cli)")
+	manifestCmd.Flags().StringVar(&agent, "agent", "clanker-cli", "Agent to run (empty, hermes, openclaw, codex, claude-code, clanker-cli, clanker-vision)")
 	manifestCmd.Flags().StringVar(&region, "region", "us-central1", "Cloud Run region")
 	manifestCmd.Flags().StringVar(&image, "image", "", "Container image URI")
 	manifestCmd.Flags().StringVar(&projectID, "project", "", "GCP project ID")

--- a/internal/clankerbox/install.go
+++ b/internal/clankerbox/install.go
@@ -117,7 +117,13 @@ func installClankerVision(ctx context.Context) (InstallResult, error) {
 import playwright
 print("playwright", getattr(playwright, "__version__", "installed"))
 PY
-if command -v chromium >/dev/null 2>&1; then chromium --version; elif command -v chromium-browser >/dev/null 2>&1; then chromium-browser --version; else echo "chromium is missing"; exit 1; fi
+found_browser=0
+for candidate in "${CLANKER_BOX_BROWSER_PATH:-}" "${CLANKER_BOX_CHROMIUM_PATH:-}" chromium chromium-browser google-chrome google-chrome-stable microsoft-edge brave-browser vivaldi opera firefox firefox-esr librewolf waterfox floorp zen-browser; do
+  [ -n "$candidate" ] || continue
+  if [ -x "$candidate" ]; then "$candidate" --version 2>/dev/null || true; found_browser=1; continue; fi
+  if command -v "$candidate" >/dev/null 2>&1; then "$candidate" --version 2>/dev/null || true; found_browser=1; fi
+done
+if [ "$found_browser" -eq 0 ]; then echo "no system browser found; Clanker Vision will try Playwright managed browsers or CLANKER_BOX_BROWSER_PATH at runtime"; fi
 if command -v libreoffice >/dev/null 2>&1; then libreoffice --version | head -n 1; else echo "libreoffice missing; office export falls back to html/csv"; fi`
 	output, err := runShell(ctx, command)
 	result := InstallResult{Agent: VisionAgentID, Command: "validate clanker-vision runtime", Output: output}

--- a/internal/clankerbox/install.go
+++ b/internal/clankerbox/install.go
@@ -113,9 +113,30 @@ func installHermes(ctx context.Context) (InstallResult, error) {
 }
 
 func installClankerVision(ctx context.Context) (InstallResult, error) {
-	command := `set -e; python="${CLANKER_BOX_VISION_PYTHON:-python3}"; "$python" - <<'PY'
-import playwright
-print("playwright", getattr(playwright, "__version__", "installed"))
+	runtimeDir := visionRuntimeDir()
+	command := fmt.Sprintf(`set -e
+runtime=%s
+mkdir -p "$runtime"
+python="${CLANKER_BOX_VISION_PYTHON:-}"
+if [ -z "$python" ]; then
+  if command -v python3 >/dev/null 2>&1; then python="$(command -v python3)"; elif command -v python >/dev/null 2>&1; then python="$(command -v python)"; fi
+fi
+if [ -z "$python" ]; then
+  echo "Python 3 is required for Clanker Vision browser automation." >&2
+  exit 1
+fi
+if ! "$python" - <<'PY' >/dev/null 2>&1
+from playwright.sync_api import sync_playwright
+PY
+then
+  "$python" -m venv "$runtime/.venv"
+  "$runtime/.venv/bin/python" -m pip install --upgrade pip wheel setuptools
+  "$runtime/.venv/bin/python" -m pip install --upgrade playwright
+  python="$runtime/.venv/bin/python"
+fi
+"$python" - <<'PY'
+from playwright.sync_api import sync_playwright
+print("playwright installed")
 PY
 found_browser=0
 for candidate in "${CLANKER_BOX_BROWSER_PATH:-}" "${CLANKER_BOX_CHROMIUM_PATH:-}" chromium chromium-browser google-chrome google-chrome-stable microsoft-edge brave-browser vivaldi opera firefox firefox-esr librewolf waterfox floorp zen-browser; do
@@ -123,8 +144,17 @@ for candidate in "${CLANKER_BOX_BROWSER_PATH:-}" "${CLANKER_BOX_CHROMIUM_PATH:-}
   if [ -x "$candidate" ]; then "$candidate" --version 2>/dev/null || true; found_browser=1; continue; fi
   if command -v "$candidate" >/dev/null 2>&1; then "$candidate" --version 2>/dev/null || true; found_browser=1; fi
 done
-if [ "$found_browser" -eq 0 ]; then echo "no system browser found; Clanker Vision will try Playwright managed browsers or CLANKER_BOX_BROWSER_PATH at runtime"; fi
-if command -v libreoffice >/dev/null 2>&1; then libreoffice --version | head -n 1; else echo "libreoffice missing; office export falls back to html/csv"; fi`
+if [ "$found_browser" -eq 0 ]; then
+  echo "no system browser found; installing Playwright managed Chromium in $runtime/ms-playwright"
+  PLAYWRIGHT_BROWSERS_PATH="$runtime/ms-playwright" "$python" -m playwright install chromium
+else
+  echo "system browser found; Playwright managed browser download skipped"
+fi
+PLAYWRIGHT_BROWSERS_PATH="$runtime/ms-playwright" "$python" - <<'PY'
+from playwright.sync_api import sync_playwright
+print("clanker vision browser runtime ready")
+PY
+if command -v libreoffice >/dev/null 2>&1; then libreoffice --version | head -n 1; else echo "libreoffice missing; office export falls back to html/csv"; fi`, shellQuote(runtimeDir))
 	output, err := runShell(ctx, command)
 	result := InstallResult{Agent: VisionAgentID, Command: "validate clanker-vision runtime", Output: output}
 	if err != nil {
@@ -193,6 +223,10 @@ func installTimeout() time.Duration {
 		return duration
 	}
 	return 15 * time.Minute
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
 }
 
 func findHermesVendorPath() (string, error) {

--- a/internal/clankerbox/install.go
+++ b/internal/clankerbox/install.go
@@ -63,6 +63,8 @@ func installAgent(parent context.Context, agentID string) (InstallResult, error)
 		return installOpenClaw(ctx)
 	case "hermes":
 		return installHermes(ctx)
+	case VisionAgentID:
+		return installClankerVision(ctx)
 	default:
 		return InstallResult{}, fmt.Errorf("unsupported agent %q", agentID)
 	}
@@ -107,6 +109,23 @@ func installHermes(ctx context.Context) (InstallResult, error) {
 	}
 	result.Installed = true
 	result.Version = vendorDir
+	return result, nil
+}
+
+func installClankerVision(ctx context.Context) (InstallResult, error) {
+	command := `set -e; python="${CLANKER_BOX_VISION_PYTHON:-python3}"; "$python" - <<'PY'
+import playwright
+print("playwright", getattr(playwright, "__version__", "installed"))
+PY
+if command -v chromium >/dev/null 2>&1; then chromium --version; elif command -v chromium-browser >/dev/null 2>&1; then chromium-browser --version; else echo "chromium is missing"; exit 1; fi
+if command -v libreoffice >/dev/null 2>&1; then libreoffice --version | head -n 1; else echo "libreoffice missing; office export falls back to html/csv"; fi`
+	output, err := runShell(ctx, command)
+	result := InstallResult{Agent: VisionAgentID, Command: "validate clanker-vision runtime", Output: output}
+	if err != nil {
+		return result, err
+	}
+	result.Installed = true
+	result.Version = "browser-office-agent"
 	return result, nil
 }
 

--- a/internal/clankerbox/server.go
+++ b/internal/clankerbox/server.go
@@ -68,6 +68,7 @@ type AgentRunner interface {
 type Server struct {
 	cfg      RuntimeConfig
 	runner   AgentRunner
+	vision   *VisionService
 	upgrader websocket.Upgrader
 }
 
@@ -90,6 +91,7 @@ func NewServer(cfg RuntimeConfig, runner AgentRunner) *Server {
 	return &Server{
 		cfg:    cfg,
 		runner: runner,
+		vision: NewVisionService(),
 		upgrader: websocket.Upgrader{
 			CheckOrigin: func(r *http.Request) bool { return true },
 		},
@@ -103,6 +105,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/v1/box/messages", s.withAuth(s.handleMessage))
 	mux.HandleFunc("/v1/box/ws", s.withAuth(s.handleWebSocket))
 	mux.HandleFunc("/v1/box/terminal", s.withAuth(s.handleTerminal))
+	mux.HandleFunc("/v1/box/vision", s.withAuth(s.handleVision))
 	return mux
 }
 
@@ -136,6 +139,7 @@ func (s *Server) handleInfo(w http.ResponseWriter, r *http.Request) {
 			{Kind: "message", Path: "/v1/box/messages", Description: "JSON message endpoint."},
 			{Kind: "websocket", Path: "/v1/box/ws", Description: "Bidirectional message endpoint."},
 			{Kind: "terminal", Path: "/v1/box/terminal", Description: "Authenticated WebSocket shell endpoint for box access."},
+			{Kind: "vision", Path: "/v1/box/vision", Description: "Authenticated browser and office-control endpoint with visible action observations and stop control."},
 		},
 	})
 }
@@ -218,6 +222,23 @@ func (s *Server) handleTerminal(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+}
+
+func (s *Server) handleVision(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	var req VisionRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4<<20)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, VisionResponse{OK: false, Status: "failed", Error: "invalid json", Policy: DefaultVisionPolicy()})
+		return
+	}
+	if s.vision == nil {
+		s.vision = NewVisionService()
+	}
+	resp := s.vision.Handle(r.Context(), req)
+	writeJSON(w, http.StatusOK, resp)
 }
 
 func (s *Server) runTerminal(parent context.Context, req TerminalRequest) TerminalResponse {
@@ -345,6 +366,8 @@ func (DefaultRunner) RunAgentMessage(ctx context.Context, cfg RuntimeConfig, req
 		return runClaudeCode(ctx, req.Message)
 	case "clanker-cli":
 		return runCommand(ctx, "CLANKER_BOX_CLANKER_COMMAND", []string{executable(), "ask", req.Message}, req.Message)
+	case "clanker-vision":
+		return RunClankerVisionMessage(ctx, req)
 	case "codex":
 		return runCommand(ctx, "CLANKER_BOX_CODEX_COMMAND", []string{"codex", "exec", "--skip-git-repo-check", req.Message}, req.Message)
 	case "openclaw":
@@ -398,6 +421,8 @@ func installCommandFromChat(target string, agent string) string {
 		return "clanker box install openclaw"
 	case "clanker", "clanker-cli", "cli":
 		return "clanker box install clanker-cli && clanker --version"
+	case "clanker-vision", "vision", "computer-use", "office-agent", "browser-agent":
+		return "clanker box install clanker-vision"
 	case "docker", "docker-cli":
 		return dockerCLIInstallCommand()
 	case "":

--- a/internal/clankerbox/spec.go
+++ b/internal/clankerbox/spec.go
@@ -140,6 +140,14 @@ func Agents() []AgentSpec {
 			Status:         "ready",
 			DefaultCommand: []string{"clanker", "box", "serve", "--agent", "clanker-cli"},
 		},
+		{
+			ID:             VisionAgentID,
+			Name:           "Clanker Vision",
+			Summary:        "Native browser and office-work agent with visible click observations, scoped workspace state, and stop control.",
+			Runtime:        "browser-office-agent",
+			Status:         "prototype",
+			DefaultCommand: []string{"clanker", "box", "serve", "--agent", VisionAgentID},
+		},
 	}
 }
 
@@ -229,6 +237,9 @@ func NewManifest(name, agentID, regionID string, opts ManifestOptions) (Manifest
 		timeout = 60
 	}
 	size := DefaultSize()
+	if agent.ID == VisionAgentID {
+		size = VisionSize()
+	}
 	serviceName := ServiceName(displayName, agent.ID)
 	env := map[string]string{
 		"CLANKER_BOX_NAME":            displayName,
@@ -238,6 +249,10 @@ func NewManifest(name, agentID, regionID string, opts ManifestOptions) (Manifest
 		"CLANKER_BOX_ENABLE_TERMINAL": "true",
 		"CLANKER_BOX_AUTO_INSTALL":    "true",
 		"CLANKER_BOX_WORKDIR":         "/workspace",
+	}
+	if agent.ID == VisionAgentID {
+		env["CLANKER_BOX_VISION_RETENTION"] = "ephemeral"
+		env["CLANKER_BOX_VISION_HEADLESS"] = "true"
 	}
 	if agent.ID == "empty" {
 		env["CLANKER_BOX_AUTO_INSTALL"] = "false"
@@ -276,6 +291,8 @@ func NewManifest(name, agentID, regionID string, opts ManifestOptions) (Manifest
 				"Runtime must use a unique per-box service account.",
 				"Do not attach Cloud SQL roles, Secret Manager roles, database credentials, or a private VPC connector.",
 				"Grant Cloud Run invoker only to the Clanker Cloud control plane.",
+				"Vision actions are limited to browser and office-work tooling, with confirmation gates for send/submit/delete/install-like actions.",
+				"Use /v1/box/vision action=stop as the runtime kill switch.",
 			},
 		},
 		Environment: env,
@@ -285,6 +302,7 @@ func NewManifest(name, agentID, regionID string, opts ManifestOptions) (Manifest
 			{Kind: "message", Path: "/v1/box/messages", Description: "Authenticated request/response agent messages."},
 			{Kind: "websocket", Path: "/v1/box/ws", Description: "Authenticated bidirectional agent session stream."},
 			{Kind: "terminal", Path: "/v1/box/terminal", Description: "Authenticated WebSocket terminal for SSH-style box access."},
+			{Kind: "vision", Path: "/v1/box/vision", Description: "Authenticated browser and office-control endpoint with action observations and stop control."},
 		},
 		IAMRoles: []string{
 			"roles/logging.logWriter",
@@ -307,6 +325,17 @@ func DefaultSize() SizeSpec {
 	return SizeSpec{
 		CPU:                  "1",
 		Memory:               "2Gi",
+		MinInstances:         0,
+		MaxInstances:         1,
+		Concurrency:          1,
+		RequestTimeoutSecond: 3600,
+	}
+}
+
+func VisionSize() SizeSpec {
+	return SizeSpec{
+		CPU:                  "2",
+		Memory:               "4Gi",
 		MinInstances:         0,
 		MaxInstances:         1,
 		Concurrency:          1,
@@ -342,6 +371,8 @@ func normalizeID(raw string) string {
 		return "claude-code"
 	case "clanker", "cli":
 		return "clanker-cli"
+	case "vision", "computer-use", "office-agent", "browser-agent":
+		return VisionAgentID
 	case "openai-codex":
 		return "codex"
 	case "base", "blank", "empty-sandbox", "shell":

--- a/internal/clankerbox/spec_test.go
+++ b/internal/clankerbox/spec_test.go
@@ -70,6 +70,37 @@ func TestNewManifestSupportsEmptySandbox(t *testing.T) {
 	}
 }
 
+func TestNewManifestSupportsClankerVision(t *testing.T) {
+	manifest, err := NewManifest("Office Agent", "vision", "us-central1", ManifestOptions{RequireAuth: true})
+	if err != nil {
+		t.Fatalf("NewManifest returned error: %v", err)
+	}
+	if manifest.Agent.ID != VisionAgentID {
+		t.Fatalf("expected clanker-vision alias, got %q", manifest.Agent.ID)
+	}
+	if manifest.Size.CPU != "2" || manifest.Size.Memory != "4Gi" || manifest.Size.MaxInstances != 1 || manifest.Size.Concurrency != 1 {
+		t.Fatalf("unexpected vision size: %#v", manifest.Size)
+	}
+	if manifest.Environment["CLANKER_BOX_VISION_RETENTION"] != "ephemeral" {
+		t.Fatalf("missing vision retention env: %#v", manifest.Environment)
+	}
+	if manifest.Environment["CLANKER_BOX_AUTO_INSTALL"] != "true" {
+		t.Fatalf("vision agent should auto-install/validate runtime: %#v", manifest.Environment)
+	}
+	if !strings.Contains(strings.Join(manifest.Security.Controls, "\n"), "Vision actions are limited") {
+		t.Fatalf("missing vision safety controls: %#v", manifest.Security.Controls)
+	}
+	foundVisionEndpoint := false
+	for _, endpoint := range manifest.Endpoints {
+		if endpoint.Kind == "vision" && endpoint.Path == "/v1/box/vision" {
+			foundVisionEndpoint = true
+		}
+	}
+	if !foundVisionEndpoint {
+		t.Fatalf("manifest should include vision endpoint: %#v", manifest.Endpoints)
+	}
+}
+
 func TestNewManifestRejectsUnknownRegion(t *testing.T) {
 	_, err := NewManifest("Prod Agent", "hermes", "moon-1", ManifestOptions{})
 	if err == nil {
@@ -198,6 +229,38 @@ func TestServerTerminalPostReturnsCommandExitAsJSON(t *testing.T) {
 	}
 	if resp.OK || resp.ExitCode != 7 || resp.Output != "nope" {
 		t.Fatalf("unexpected failed terminal response %#v", resp)
+	}
+}
+
+func TestServerVisionStopEndpoint(t *testing.T) {
+	server := NewServer(RuntimeConfig{Name: "test", Agent: VisionAgentID, Region: "us-central1", RequireAuth: true, EnableTerminal: true, APIToken: "secret"}, fakeRunner{})
+	req := httptest.NewRequest(http.MethodPost, "/v1/box/vision", bytes.NewBufferString(`{"sessionId":"vision-1","action":"stop"}`))
+	req.Header.Set("X-API-Key", "secret")
+	rec := httptest.NewRecorder()
+
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp VisionResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode vision response: %v", err)
+	}
+	if !resp.OK || resp.Status != "stopped" || resp.Policy.KillSwitch == "" {
+		t.Fatalf("unexpected vision stop response %#v", resp)
+	}
+}
+
+func TestVisionPolicyBlocksCredentialCollection(t *testing.T) {
+	resp := NewVisionService().Handle(context.Background(), VisionRequest{
+		SessionID:   "vision-policy",
+		Action:      "browser.type",
+		Instruction: "copy the recovery code from this page",
+		Text:        "123456",
+	})
+	if resp.OK || resp.Status != "blocked" || !strings.Contains(resp.Error, "credentials") {
+		t.Fatalf("expected credential policy block, got %#v", resp)
 	}
 }
 

--- a/internal/clankerbox/vision.go
+++ b/internal/clankerbox/vision.go
@@ -1,0 +1,885 @@
+package clankerbox
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/csv"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"html"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	VisionAgentID   = "clanker-vision"
+	visionUserAgent = "ClankerVision/0.1"
+)
+
+type VisionRequest struct {
+	SessionID   string     `json:"sessionId,omitempty"`
+	Action      string     `json:"action,omitempty"`
+	Instruction string     `json:"instruction,omitempty"`
+	URL         string     `json:"url,omitempty"`
+	Selector    string     `json:"selector,omitempty"`
+	X           int        `json:"x,omitempty"`
+	Y           int        `json:"y,omitempty"`
+	Text        string     `json:"text,omitempty"`
+	Content     string     `json:"content,omitempty"`
+	FileName    string     `json:"fileName,omitempty"`
+	Rows        [][]string `json:"rows,omitempty"`
+	To          string     `json:"to,omitempty"`
+	Subject     string     `json:"subject,omitempty"`
+	Command     string     `json:"command,omitempty"`
+	Confirm     bool       `json:"confirm,omitempty"`
+}
+
+type VisionResponse struct {
+	OK                   bool               `json:"ok"`
+	SessionID            string             `json:"sessionId"`
+	Status               string             `json:"status"`
+	Summary              string             `json:"summary,omitempty"`
+	Action               string             `json:"action,omitempty"`
+	Events               []VisionEvent      `json:"events,omitempty"`
+	Observation          *VisionObservation `json:"observation,omitempty"`
+	Artifacts            []VisionArtifact   `json:"artifacts,omitempty"`
+	RequiresConfirmation bool               `json:"requiresConfirmation,omitempty"`
+	ConfirmationReason   string             `json:"confirmationReason,omitempty"`
+	Policy               VisionPolicy       `json:"policy"`
+	Error                string             `json:"error,omitempty"`
+}
+
+type VisionEvent struct {
+	ID        string `json:"id"`
+	Type      string `json:"type"`
+	Action    string `json:"action,omitempty"`
+	Status    string `json:"status"`
+	Summary   string `json:"summary"`
+	X         int    `json:"x,omitempty"`
+	Y         int    `json:"y,omitempty"`
+	FilePath  string `json:"filePath,omitempty"`
+	CreatedAt string `json:"createdAt"`
+}
+
+type VisionObservation struct {
+	URL                 string         `json:"url,omitempty"`
+	Title               string         `json:"title,omitempty"`
+	Width               int            `json:"width,omitempty"`
+	Height              int            `json:"height,omitempty"`
+	ScreenshotMediaType string         `json:"screenshotMediaType,omitempty"`
+	ScreenshotBase64    string         `json:"screenshotBase64,omitempty"`
+	Pointer             *VisionPointer `json:"pointer,omitempty"`
+	ScreenshotPath      string         `json:"screenshotPath,omitempty"`
+	ScreenshotRedacted  bool           `json:"screenshotRedacted,omitempty"`
+}
+
+type VisionPointer struct {
+	X     int    `json:"x"`
+	Y     int    `json:"y"`
+	Label string `json:"label,omitempty"`
+}
+
+type VisionArtifact struct {
+	Kind     string `json:"kind"`
+	FilePath string `json:"filePath"`
+	Media    string `json:"media,omitempty"`
+	Summary  string `json:"summary,omitempty"`
+}
+
+type VisionPolicy struct {
+	DataRetention        string   `json:"dataRetention"`
+	DataScope            string   `json:"dataScope"`
+	AllowedDomains       []string `json:"allowedDomains"`
+	AllowedCapabilities  []string `json:"allowedCapabilities"`
+	BlockedCapabilities  []string `json:"blockedCapabilities"`
+	ConfirmationRequired []string `json:"confirmationRequired"`
+	KillSwitch           string   `json:"killSwitch"`
+}
+
+type VisionService struct {
+	mu       sync.Mutex
+	sessions map[string]*visionSession
+}
+
+type visionSession struct {
+	ID        string
+	Status    string
+	Stopped   bool
+	Events    []VisionEvent
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+type browserBridgeResult struct {
+	URL                 string         `json:"url"`
+	Title               string         `json:"title"`
+	Width               int            `json:"width"`
+	Height              int            `json:"height"`
+	ScreenshotMediaType string         `json:"screenshotMediaType"`
+	ScreenshotBase64    string         `json:"screenshotBase64"`
+	ScreenshotPath      string         `json:"screenshotPath"`
+	Pointer             *VisionPointer `json:"pointer,omitempty"`
+	Error               string         `json:"error,omitempty"`
+}
+
+var (
+	defaultVisionService = NewVisionService()
+	dangerousVisionText  = regexp.MustCompile(`(?i)\b(password|passcode|2fa|mfa|otp|recovery code|secret key|private key|api key|credit card|wire transfer|buy now|checkout|delete all|format disk|rm\s+-rf|sudo\s+rm|shutdown|reboot)\b`)
+	sendLikeVisionText   = regexp.MustCompile(`(?i)\b(send|submit|publish|post|pay|purchase|checkout|transfer|invite|delete|remove|unsubscribe)\b`)
+)
+
+func NewVisionService() *VisionService {
+	return &VisionService{sessions: map[string]*visionSession{}}
+}
+
+func (s *VisionService) Handle(ctx context.Context, req VisionRequest) VisionResponse {
+	session := s.session(req.SessionID)
+	action := normalizeVisionAction(req.Action)
+	if action == "" {
+		action = inferVisionAction(req)
+	}
+	resp := VisionResponse{
+		OK:        true,
+		SessionID: session.ID,
+		Status:    session.Status,
+		Action:    action,
+		Policy:    DefaultVisionPolicy(),
+	}
+
+	if action == "stop" {
+		s.markStopped(session.ID)
+		event := s.appendEvent(session.ID, VisionEvent{Type: "control", Action: action, Status: "stopped", Summary: "Vision agent stopped by user."})
+		resp.Status = "stopped"
+		resp.Summary = "Stopped. New actions require a fresh session or explicit status check."
+		resp.Events = []VisionEvent{event}
+		return resp
+	}
+
+	if action == "status" {
+		resp.Summary = "Clanker Vision is ready for office and browser work inside this account-scoped box."
+		resp.Events = s.events(session.ID)
+		return resp
+	}
+
+	if session.Stopped {
+		resp.OK = false
+		resp.Status = "stopped"
+		resp.Error = "vision session is stopped"
+		resp.Summary = "Use a new session to resume automation."
+		return resp
+	}
+
+	if blockReason := visionPolicyBlockReason(req, action); blockReason != "" {
+		resp.OK = false
+		resp.Status = "blocked"
+		resp.Error = blockReason
+		resp.Summary = blockReason
+		resp.Events = []VisionEvent{s.appendEvent(session.ID, VisionEvent{Type: "policy", Action: action, Status: "blocked", Summary: blockReason})}
+		return resp
+	}
+
+	if reason := visionConfirmationReason(req, action); reason != "" && !req.Confirm {
+		resp.RequiresConfirmation = true
+		resp.ConfirmationReason = reason
+		resp.Summary = reason
+		resp.Events = []VisionEvent{s.appendEvent(session.ID, VisionEvent{Type: "policy", Action: action, Status: "needs_confirmation", Summary: reason})}
+		return resp
+	}
+
+	s.setStatus(session.ID, "running")
+	defer s.setStatus(session.ID, "idle")
+
+	switch action {
+	case "browser.open", "browser.click", "browser.type", "browser.press", "browser.screenshot":
+		observation, err := runVisionBrowserAction(ctx, session.ID, action, req)
+		if err != nil {
+			resp.OK = false
+			resp.Status = "failed"
+			resp.Error = err.Error()
+			resp.Summary = err.Error()
+			resp.Events = []VisionEvent{s.appendEvent(session.ID, VisionEvent{Type: "browser", Action: action, Status: "failed", Summary: err.Error(), X: req.X, Y: req.Y})}
+			return resp
+		}
+		resp.Observation = observation
+		resp.Summary = browserVisionSummary(action, observation)
+		resp.Events = []VisionEvent{s.appendEvent(session.ID, VisionEvent{Type: "browser", Action: action, Status: "completed", Summary: resp.Summary, X: req.X, Y: req.Y, FilePath: observation.ScreenshotPath})}
+	case "office.write_doc":
+		artifact, err := writeVisionDocument(ctx, session.ID, req)
+		if err != nil {
+			resp.OK = false
+			resp.Status = "failed"
+			resp.Error = err.Error()
+			resp.Summary = err.Error()
+			resp.Events = []VisionEvent{s.appendEvent(session.ID, VisionEvent{Type: "office", Action: action, Status: "failed", Summary: err.Error()})}
+			return resp
+		}
+		resp.Artifacts = []VisionArtifact{artifact}
+		resp.Summary = artifact.Summary
+		resp.Events = []VisionEvent{s.appendEvent(session.ID, VisionEvent{Type: "office", Action: action, Status: "completed", Summary: artifact.Summary, FilePath: artifact.FilePath})}
+	case "office.write_sheet":
+		artifact, err := writeVisionSheet(ctx, session.ID, req)
+		if err != nil {
+			resp.OK = false
+			resp.Status = "failed"
+			resp.Error = err.Error()
+			resp.Summary = err.Error()
+			resp.Events = []VisionEvent{s.appendEvent(session.ID, VisionEvent{Type: "office", Action: action, Status: "failed", Summary: err.Error()})}
+			return resp
+		}
+		resp.Artifacts = []VisionArtifact{artifact}
+		resp.Summary = artifact.Summary
+		resp.Events = []VisionEvent{s.appendEvent(session.ID, VisionEvent{Type: "office", Action: action, Status: "completed", Summary: artifact.Summary, FilePath: artifact.FilePath})}
+	case "email.draft":
+		artifact, err := writeVisionEmailDraft(session.ID, req)
+		if err != nil {
+			resp.OK = false
+			resp.Status = "failed"
+			resp.Error = err.Error()
+			resp.Summary = err.Error()
+			resp.Events = []VisionEvent{s.appendEvent(session.ID, VisionEvent{Type: "email", Action: action, Status: "failed", Summary: err.Error()})}
+			return resp
+		}
+		resp.Artifacts = []VisionArtifact{artifact}
+		resp.Summary = artifact.Summary
+		resp.Events = []VisionEvent{s.appendEvent(session.ID, VisionEvent{Type: "email", Action: action, Status: "drafted", Summary: artifact.Summary, FilePath: artifact.FilePath})}
+	case "system.install":
+		summary := "Install requests are staged for the user-controlled terminal. Run the shown command manually if you trust the package source."
+		resp.Summary = summary
+		resp.Events = []VisionEvent{s.appendEvent(session.ID, VisionEvent{Type: "system", Action: action, Status: "needs_terminal", Summary: summary})}
+	default:
+		resp.OK = false
+		resp.Status = "unsupported"
+		resp.Error = "unsupported vision action"
+		resp.Summary = "Supported actions: browser.open, browser.click, browser.type, browser.press, browser.screenshot, office.write_doc, office.write_sheet, email.draft, system.install, status, stop."
+	}
+	return resp
+}
+
+func DefaultVisionPolicy() VisionPolicy {
+	return VisionPolicy{
+		DataRetention: "ephemeral-by-default; artifacts stay inside CLANKER_BOX_WORKDIR and optional per-box state prefix only",
+		DataScope:     "current account-scoped Clanker Box runtime",
+		AllowedDomains: []string{
+			"browser navigation requested by the user",
+			"office document and spreadsheet artifacts inside the box",
+			"email drafts saved as files; no automatic sending",
+		},
+		AllowedCapabilities: []string{
+			"browser.open",
+			"browser.click",
+			"browser.type",
+			"browser.screenshot",
+			"office.write_doc",
+			"office.write_sheet",
+			"email.draft",
+			"user-confirmed install request staging",
+		},
+		BlockedCapabilities: []string{
+			"payments and purchases",
+			"credential or secret collection",
+			"destructive filesystem or account changes without explicit user terminal action",
+			"background persistence outside the running box",
+			"email sending without a human approval flow",
+		},
+		ConfirmationRequired: []string{
+			"send/submit/publish/pay/purchase/delete-like actions",
+			"package installation commands",
+			"actions involving authenticated accounts",
+		},
+		KillSwitch: "POST /v1/box/vision with action=stop",
+	}
+}
+
+func RunClankerVisionMessage(ctx context.Context, req MessageRequest) (string, error) {
+	visionReq := VisionRequest{
+		SessionID:   req.SessionID,
+		Instruction: req.Message,
+	}
+	if req.Context != nil {
+		if raw, ok := req.Context["vision"]; ok {
+			data, _ := json.Marshal(raw)
+			_ = json.Unmarshal(data, &visionReq)
+			if visionReq.Instruction == "" {
+				visionReq.Instruction = req.Message
+			}
+			if visionReq.SessionID == "" {
+				visionReq.SessionID = req.SessionID
+			}
+		}
+	}
+	resp := defaultVisionService.Handle(ctx, visionReq)
+	data, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	if !resp.OK {
+		return string(data), fmt.Errorf("%s", resp.Error)
+	}
+	return string(data), nil
+}
+
+func (s *VisionService) session(rawID string) *visionSession {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id := sanitizeVisionID(rawID)
+	if id == "" {
+		id = "vision-" + randomHex(8)
+	}
+	if existing := s.sessions[id]; existing != nil {
+		existing.UpdatedAt = time.Now().UTC()
+		return existing
+	}
+	session := &visionSession{ID: id, Status: "idle", CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC()}
+	s.sessions[id] = session
+	return session
+}
+
+func (s *VisionService) setStatus(sessionID, status string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if session := s.sessions[sessionID]; session != nil {
+		session.Status = status
+		session.UpdatedAt = time.Now().UTC()
+	}
+}
+
+func (s *VisionService) markStopped(sessionID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if session := s.sessions[sessionID]; session != nil {
+		session.Stopped = true
+		session.Status = "stopped"
+		session.UpdatedAt = time.Now().UTC()
+	}
+}
+
+func (s *VisionService) appendEvent(sessionID string, event VisionEvent) VisionEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if event.ID == "" {
+		event.ID = "evt-" + randomHex(6)
+	}
+	if event.CreatedAt == "" {
+		event.CreatedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+	session := s.sessions[sessionID]
+	if session == nil {
+		session = &visionSession{ID: sessionID, Status: "idle", CreatedAt: time.Now().UTC()}
+		s.sessions[sessionID] = session
+	}
+	session.Events = append(session.Events, event)
+	if len(session.Events) > 80 {
+		session.Events = session.Events[len(session.Events)-80:]
+	}
+	session.UpdatedAt = time.Now().UTC()
+	return event
+}
+
+func (s *VisionService) events(sessionID string) []VisionEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	session := s.sessions[sessionID]
+	if session == nil {
+		return nil
+	}
+	events := make([]VisionEvent, len(session.Events))
+	copy(events, session.Events)
+	return events
+}
+
+func normalizeVisionAction(raw string) string {
+	action := strings.ToLower(strings.TrimSpace(raw))
+	action = strings.ReplaceAll(action, "_", ".")
+	switch action {
+	case "", "auto":
+		return ""
+	case "open", "browser", "browser.open_url", "browser.navigate":
+		return "browser.open"
+	case "click", "browser.left_click":
+		return "browser.click"
+	case "type", "browser.input":
+		return "browser.type"
+	case "press", "key", "browser.key":
+		return "browser.press"
+	case "screenshot", "observe", "browser.observe":
+		return "browser.screenshot"
+	case "doc", "document", "write.doc", "office.document":
+		return "office.write_doc"
+	case "sheet", "spreadsheet", "excel", "write.sheet", "office.spreadsheet":
+		return "office.write_sheet"
+	case "email", "draft", "email.write":
+		return "email.draft"
+	case "install", "package.install", "system.package":
+		return "system.install"
+	default:
+		return action
+	}
+}
+
+func inferVisionAction(req VisionRequest) string {
+	text := strings.ToLower(strings.TrimSpace(strings.Join([]string{req.Instruction, req.URL, req.FileName, req.Subject}, " ")))
+	switch {
+	case req.URL != "":
+		return "browser.open"
+	case strings.Contains(text, "spreadsheet") || strings.Contains(text, "excel") || strings.Contains(text, "sheet") || strings.Contains(text, ".csv") || strings.Contains(text, ".xlsx"):
+		return "office.write_sheet"
+	case strings.Contains(text, "email") || strings.Contains(text, "gmail"):
+		return "email.draft"
+	case strings.Contains(text, "doc") || strings.Contains(text, "memo") || strings.Contains(text, "word"):
+		return "office.write_doc"
+	case strings.Contains(text, "install"):
+		return "system.install"
+	case strings.Contains(text, "click"):
+		return "browser.click"
+	case strings.Contains(text, "type"):
+		return "browser.type"
+	default:
+		return "status"
+	}
+}
+
+func visionPolicyBlockReason(req VisionRequest, action string) string {
+	text := strings.Join([]string{req.Instruction, req.Text, req.Content, req.Command, req.URL, req.Subject}, " ")
+	if dangerousVisionText.MatchString(text) {
+		return "Blocked by Clanker Vision safety policy: credentials, payments, destructive system actions, and secret collection are outside the office-work prototype."
+	}
+	if action == "email.send" {
+		return "Clanker Vision can draft email, but this prototype will not send email automatically."
+	}
+	return ""
+}
+
+func visionConfirmationReason(req VisionRequest, action string) string {
+	if action == "system.install" {
+		return "Package installation changes the box runtime and requires explicit user confirmation."
+	}
+	text := strings.Join([]string{req.Instruction, req.Text, req.Content, req.URL, req.Subject}, " ")
+	if sendLikeVisionText.MatchString(text) {
+		return "This looks like a send/submit/publish/delete-style action. Confirm before Clanker Vision continues."
+	}
+	return ""
+}
+
+func runVisionBrowserAction(ctx context.Context, sessionID, action string, req VisionRequest) (*VisionObservation, error) {
+	if action == "browser.open" {
+		if _, err := url.ParseRequestURI(strings.TrimSpace(req.URL)); err != nil {
+			return nil, fmt.Errorf("valid url is required for browser.open")
+		}
+	}
+	dir, err := visionSessionDir(sessionID)
+	if err != nil {
+		return nil, err
+	}
+	input := map[string]any{
+		"action":      action,
+		"url":         strings.TrimSpace(req.URL),
+		"selector":    strings.TrimSpace(req.Selector),
+		"x":           req.X,
+		"y":           req.Y,
+		"text":        req.Text,
+		"instruction": req.Instruction,
+		"profileDir":  filepath.Join(dir, "browser-profile"),
+		"statePath":   filepath.Join(dir, "browser-state.json"),
+		"shotDir":     filepath.Join(dir, "screenshots"),
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "screenshots"), 0o700); err != nil {
+		return nil, err
+	}
+	inputPath := filepath.Join(dir, "browser-input.json")
+	outputPath := filepath.Join(dir, "browser-output.json")
+	inputData, _ := json.Marshal(input)
+	if err := os.WriteFile(inputPath, inputData, 0o600); err != nil {
+		return nil, err
+	}
+	scriptPath := filepath.Join(dir, "browser-bridge.py")
+	if err := os.WriteFile(scriptPath, []byte(visionBrowserBridgePython), 0o700); err != nil {
+		return nil, err
+	}
+	timeoutCtx, cancel := context.WithTimeout(ctx, 55*time.Second)
+	defer cancel()
+	python := strings.TrimSpace(os.Getenv("CLANKER_BOX_VISION_PYTHON"))
+	if python == "" {
+		python = "python3"
+	}
+	cmd := exec.CommandContext(timeoutCtx, python, scriptPath, inputPath, outputPath)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "CLANKER_BOX_VISION_USER_AGENT="+visionUserAgent)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if timeoutCtx.Err() == context.DeadlineExceeded {
+			return nil, fmt.Errorf("browser action timed out")
+		}
+		detail := strings.TrimSpace(stderr.String())
+		if detail != "" {
+			return nil, fmt.Errorf("browser action failed: %w: %s", err, trimTerminalOutput(detail))
+		}
+		return nil, fmt.Errorf("browser action failed: %w", err)
+	}
+	outputData, err := os.ReadFile(outputPath)
+	if err != nil {
+		return nil, err
+	}
+	var bridge browserBridgeResult
+	if err := json.Unmarshal(outputData, &bridge); err != nil {
+		return nil, err
+	}
+	if bridge.Error != "" {
+		return nil, fmt.Errorf("%s", bridge.Error)
+	}
+	return &VisionObservation{
+		URL:                 bridge.URL,
+		Title:               bridge.Title,
+		Width:               bridge.Width,
+		Height:              bridge.Height,
+		ScreenshotMediaType: bridge.ScreenshotMediaType,
+		ScreenshotBase64:    bridge.ScreenshotBase64,
+		ScreenshotPath:      bridge.ScreenshotPath,
+		Pointer:             bridge.Pointer,
+	}, nil
+}
+
+func browserVisionSummary(action string, observation *VisionObservation) string {
+	title := strings.TrimSpace(observation.Title)
+	if title == "" {
+		title = strings.TrimSpace(observation.URL)
+	}
+	switch action {
+	case "browser.click":
+		return "Clicked in browser and captured the updated screen: " + title
+	case "browser.type":
+		return "Typed in browser and captured the updated screen: " + title
+	case "browser.press":
+		return "Pressed key in browser and captured the updated screen: " + title
+	default:
+		return "Captured browser screen: " + title
+	}
+}
+
+func writeVisionDocument(ctx context.Context, sessionID string, req VisionRequest) (VisionArtifact, error) {
+	dir, err := visionSessionDir(sessionID)
+	if err != nil {
+		return VisionArtifact{}, err
+	}
+	docDir := filepath.Join(dir, "documents")
+	if err := os.MkdirAll(docDir, 0o700); err != nil {
+		return VisionArtifact{}, err
+	}
+	name := safeVisionFileName(firstNonEmptyVision(req.FileName, req.Subject, "clanker-vision-document"), ".html")
+	content := strings.TrimSpace(firstNonEmptyVision(req.Content, req.Text, req.Instruction))
+	if content == "" {
+		return VisionArtifact{}, fmt.Errorf("document content is required")
+	}
+	title := strings.TrimSuffix(filepath.Base(name), filepath.Ext(name))
+	htmlPath := filepath.Join(docDir, name)
+	body := "<!doctype html><html><head><meta charset=\"utf-8\"><title>" + html.EscapeString(title) + "</title></head><body><h1>" + html.EscapeString(title) + "</h1><pre style=\"white-space:pre-wrap;font-family:Arial,sans-serif\">" + html.EscapeString(content) + "</pre></body></html>"
+	if err := os.WriteFile(htmlPath, []byte(body), 0o600); err != nil {
+		return VisionArtifact{}, err
+	}
+	if converted, ok := libreOfficeConvert(ctx, htmlPath, docDir, "docx"); ok {
+		return VisionArtifact{Kind: "document", FilePath: converted, Media: "application/vnd.openxmlformats-officedocument.wordprocessingml.document", Summary: "Wrote Word-compatible document: " + converted}, nil
+	}
+	return VisionArtifact{Kind: "document", FilePath: htmlPath, Media: "text/html", Summary: "Wrote HTML document draft: " + htmlPath}, nil
+}
+
+func writeVisionSheet(ctx context.Context, sessionID string, req VisionRequest) (VisionArtifact, error) {
+	dir, err := visionSessionDir(sessionID)
+	if err != nil {
+		return VisionArtifact{}, err
+	}
+	sheetDir := filepath.Join(dir, "spreadsheets")
+	if err := os.MkdirAll(sheetDir, 0o700); err != nil {
+		return VisionArtifact{}, err
+	}
+	name := safeVisionFileName(firstNonEmptyVision(req.FileName, "clanker-vision-sheet"), ".csv")
+	csvPath := filepath.Join(sheetDir, name)
+	file, err := os.OpenFile(csvPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+	if err != nil {
+		return VisionArtifact{}, err
+	}
+	writer := csv.NewWriter(file)
+	rows := req.Rows
+	if len(rows) == 0 {
+		rows = rowsFromVisionCSV(req.Content)
+	}
+	if len(rows) == 0 {
+		rows = [][]string{{"Task", "Status"}, {strings.TrimSpace(firstNonEmptyVision(req.Instruction, "Clanker Vision sheet")), "draft"}}
+	}
+	for _, row := range rows {
+		if err := writer.Write(row); err != nil {
+			file.Close()
+			return VisionArtifact{}, err
+		}
+	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		file.Close()
+		return VisionArtifact{}, err
+	}
+	if err := file.Close(); err != nil {
+		return VisionArtifact{}, err
+	}
+	if converted, ok := libreOfficeConvert(ctx, csvPath, sheetDir, "xlsx"); ok {
+		return VisionArtifact{Kind: "spreadsheet", FilePath: converted, Media: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", Summary: "Wrote Excel-compatible spreadsheet: " + converted}, nil
+	}
+	return VisionArtifact{Kind: "spreadsheet", FilePath: csvPath, Media: "text/csv", Summary: "Wrote CSV spreadsheet draft: " + csvPath}, nil
+}
+
+func writeVisionEmailDraft(sessionID string, req VisionRequest) (VisionArtifact, error) {
+	dir, err := visionSessionDir(sessionID)
+	if err != nil {
+		return VisionArtifact{}, err
+	}
+	draftDir := filepath.Join(dir, "email-drafts")
+	if err := os.MkdirAll(draftDir, 0o700); err != nil {
+		return VisionArtifact{}, err
+	}
+	subject := strings.TrimSpace(firstNonEmptyVision(req.Subject, "Clanker Vision draft"))
+	body := strings.TrimSpace(firstNonEmptyVision(req.Content, req.Text, req.Instruction))
+	if body == "" {
+		return VisionArtifact{}, fmt.Errorf("email draft content is required")
+	}
+	name := safeVisionFileName(subject, ".eml")
+	path := filepath.Join(draftDir, name)
+	to := strings.TrimSpace(req.To)
+	if to == "" {
+		to = "unspecified@example.invalid"
+	}
+	content := strings.Join([]string{
+		"To: " + to,
+		"Subject: " + subject,
+		"X-Clanker-Vision-Draft: true",
+		"",
+		body,
+		"",
+	}, "\r\n")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		return VisionArtifact{}, err
+	}
+	return VisionArtifact{Kind: "email-draft", FilePath: path, Media: "message/rfc822", Summary: "Saved email draft without sending: " + path}, nil
+}
+
+func libreOfficeConvert(ctx context.Context, inputPath, outDir, format string) (string, bool) {
+	lo, err := exec.LookPath("libreoffice")
+	if err != nil {
+		lo, err = exec.LookPath("soffice")
+	}
+	if err != nil {
+		return "", false
+	}
+	timeoutCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(timeoutCtx, lo, "--headless", "--convert-to", format, "--outdir", outDir, inputPath)
+	if err := cmd.Run(); err != nil {
+		return "", false
+	}
+	base := strings.TrimSuffix(filepath.Base(inputPath), filepath.Ext(inputPath)) + "." + format
+	converted := filepath.Join(outDir, base)
+	if _, err := os.Stat(converted); err == nil {
+		return converted, true
+	}
+	return "", false
+}
+
+func visionSessionDir(sessionID string) (string, error) {
+	base := filepath.Join(terminalWorkingDir(""), ".clanker-vision", "sessions", sanitizeVisionID(sessionID))
+	if err := os.MkdirAll(base, 0o700); err != nil {
+		return "", err
+	}
+	return base, nil
+}
+
+func sanitizeVisionID(raw string) string {
+	id := strings.ToLower(strings.TrimSpace(raw))
+	id = regexp.MustCompile(`[^a-z0-9._-]+`).ReplaceAllString(id, "-")
+	id = strings.Trim(id, ".-_")
+	if len(id) > 96 {
+		id = id[:96]
+	}
+	return id
+}
+
+func safeVisionFileName(raw string, ext string) string {
+	name := strings.ToLower(strings.TrimSpace(raw))
+	name = regexp.MustCompile(`[^a-z0-9._-]+`).ReplaceAllString(name, "-")
+	name = strings.Trim(name, ".-_")
+	if name == "" {
+		name = "clanker-vision"
+	}
+	if len(name) > 80 {
+		name = strings.Trim(name[:80], ".-_")
+	}
+	if filepath.Ext(name) == "" {
+		name += ext
+	}
+	return name
+}
+
+func rowsFromVisionCSV(raw string) [][]string {
+	text := strings.TrimSpace(raw)
+	if text == "" {
+		return nil
+	}
+	reader := csv.NewReader(strings.NewReader(text))
+	reader.FieldsPerRecord = -1
+	rows, err := reader.ReadAll()
+	if err != nil {
+		return [][]string{{"Content"}, {text}}
+	}
+	return rows
+}
+
+func firstNonEmptyVision(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func randomHex(bytesLen int) string {
+	buf := make([]byte, bytesLen)
+	if _, err := rand.Read(buf); err != nil {
+		return strconv.FormatInt(time.Now().UnixNano(), 16)
+	}
+	return hex.EncodeToString(buf)
+}
+
+const visionBrowserBridgePython = `
+import base64
+import json
+import os
+import shutil
+import sys
+import time
+
+def write_result(path, payload):
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(payload, f)
+
+def main():
+    input_path = sys.argv[1]
+    output_path = sys.argv[2]
+    try:
+        from playwright.sync_api import sync_playwright
+    except Exception as exc:
+        write_result(output_path, {"error": "Playwright is not installed in this Clanker Box image: %s" % exc})
+        return
+
+    with open(input_path, "r", encoding="utf-8") as f:
+        req = json.load(f)
+
+    action = req.get("action") or "browser.screenshot"
+    profile_dir = req.get("profileDir")
+    shot_dir = req.get("shotDir")
+    state_path = req.get("statePath")
+    os.makedirs(profile_dir, exist_ok=True)
+    os.makedirs(shot_dir, exist_ok=True)
+
+    state = {}
+    if state_path and os.path.exists(state_path):
+        try:
+            with open(state_path, "r", encoding="utf-8") as f:
+                state = json.load(f)
+        except Exception:
+            state = {}
+
+    url = (req.get("url") or state.get("url") or "about:blank").strip()
+    chromium = os.environ.get("CLANKER_BOX_CHROMIUM_PATH") or shutil.which("chromium") or shutil.which("chromium-browser") or shutil.which("google-chrome")
+    launch_args = ["--no-sandbox", "--disable-dev-shm-usage", "--disable-background-networking"]
+
+    with sync_playwright() as p:
+        context = p.chromium.launch_persistent_context(
+            profile_dir,
+            headless=os.environ.get("CLANKER_BOX_VISION_HEADLESS", "true").lower() != "false",
+            executable_path=chromium,
+            viewport={"width": 1280, "height": 800},
+            user_agent=os.environ.get("CLANKER_BOX_VISION_USER_AGENT", "ClankerVision/0.1"),
+            args=launch_args,
+        )
+        page = context.pages[0] if context.pages else context.new_page()
+        page.set_default_timeout(15000)
+        if action == "browser.open" or page.url == "about:blank":
+            page.goto(url, wait_until="domcontentloaded", timeout=30000)
+        elif url and url != "about:blank":
+            page.goto(url, wait_until="domcontentloaded", timeout=30000)
+
+        pointer = None
+        if action == "browser.click":
+            x = int(req.get("x") or 0)
+            y = int(req.get("y") or 0)
+            if x <= 0 or y <= 0:
+                selector = (req.get("selector") or "").strip()
+                if not selector:
+                    raise RuntimeError("browser.click needs x/y coordinates or a selector")
+                box = page.locator(selector).first.bounding_box()
+                if not box:
+                    raise RuntimeError("selector did not resolve to a visible element")
+                x = int(box["x"] + box["width"] / 2)
+                y = int(box["y"] + box["height"] / 2)
+            page.mouse.click(x, y)
+            pointer = {"x": x, "y": y, "label": "click"}
+        elif action == "browser.type":
+            x = int(req.get("x") or 0)
+            y = int(req.get("y") or 0)
+            selector = (req.get("selector") or "").strip()
+            text = req.get("text") or ""
+            if selector:
+                page.locator(selector).first.fill(text)
+                box = page.locator(selector).first.bounding_box()
+                if box:
+                    pointer = {"x": int(box["x"] + box["width"] / 2), "y": int(box["y"] + box["height"] / 2), "label": "type"}
+            else:
+                if x > 0 and y > 0:
+                    page.mouse.click(x, y)
+                    pointer = {"x": x, "y": y, "label": "type"}
+                page.keyboard.type(text)
+        elif action == "browser.press":
+            key = req.get("text") or "Enter"
+            page.keyboard.press(key)
+
+        try:
+            page.wait_for_load_state("networkidle", timeout=5000)
+        except Exception:
+            pass
+        time.sleep(0.2)
+
+        title = page.title()
+        final_url = page.url
+        shot_path = os.path.join(shot_dir, "screen-%d.jpg" % int(time.time() * 1000))
+        shot = page.screenshot(path=shot_path, type="jpeg", quality=70, full_page=False)
+        if not shot:
+            with open(shot_path, "rb") as f:
+                shot = f.read()
+        if state_path:
+            with open(state_path, "w", encoding="utf-8") as f:
+                json.dump({"url": final_url, "title": title}, f)
+        context.close()
+
+    write_result(output_path, {
+        "url": final_url,
+        "title": title,
+        "width": 1280,
+        "height": 800,
+        "screenshotMediaType": "image/jpeg",
+        "screenshotBase64": base64.b64encode(shot).decode("ascii"),
+        "screenshotPath": shot_path,
+        "pointer": pointer,
+    })
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:
+        write_result(sys.argv[2], {"error": str(exc)})
+`

--- a/internal/clankerbox/vision.go
+++ b/internal/clankerbox/vision.go
@@ -770,6 +770,78 @@ def write_result(path, payload):
     with open(path, "w", encoding="utf-8") as f:
         json.dump(payload, f)
 
+def executable_candidates(*names):
+    seen = set()
+    for name in names:
+        value = (name or "").strip()
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        if os.path.isabs(value) and os.path.exists(value):
+            yield value
+            continue
+        path = shutil.which(value)
+        if path:
+            yield path
+
+def launch_browser_context(p, profile_dir, launch_args):
+    headless = os.environ.get("CLANKER_BOX_VISION_HEADLESS", "true").lower() != "false"
+    user_agent = os.environ.get("CLANKER_BOX_VISION_USER_AGENT", "ClankerVision/0.1")
+    attempts = []
+    candidates = []
+    chromium_env = os.environ.get("CLANKER_BOX_BROWSER_PATH") or os.environ.get("CLANKER_BOX_CHROMIUM_PATH")
+    for executable in executable_candidates(
+        chromium_env,
+        "chromium",
+        "chromium-browser",
+        "google-chrome",
+        "google-chrome-stable",
+        "microsoft-edge",
+        "microsoft-edge-stable",
+        "brave-browser",
+        "vivaldi",
+        "opera",
+    ):
+        candidates.append(("chromium", p.chromium, executable, launch_args))
+    candidates.append(("playwright-chromium", p.chromium, None, launch_args))
+    firefox_env = os.environ.get("CLANKER_BOX_FIREFOX_PATH")
+    for executable in executable_candidates(
+        firefox_env,
+        "firefox",
+        "firefox-esr",
+        "librewolf",
+        "waterfox",
+        "floorp",
+        "zen-browser",
+    ):
+        candidates.append(("firefox", p.firefox, executable, []))
+    candidates.append(("playwright-firefox", p.firefox, None, []))
+    candidates.append(("playwright-webkit", p.webkit, None, []))
+    seen = set()
+    for name, launcher, executable, args in candidates:
+        key = (name, executable or "")
+        if key in seen:
+            continue
+        seen.add(key)
+        launch_profile = profile_dir if name.startswith("chromium") else "%s-%s" % (profile_dir, name)
+        os.makedirs(launch_profile, exist_ok=True)
+        try:
+            context = launcher.launch_persistent_context(
+                launch_profile,
+                headless=headless,
+                executable_path=executable,
+                viewport={"width": 1280, "height": 800},
+                user_agent=user_agent,
+                args=args,
+            )
+            return context, "%s%s" % (name, ":%s" % executable if executable else "")
+        except Exception as exc:
+            attempts.append("%s%s: %s" % (name, ":%s" % executable if executable else "", exc))
+    raise RuntimeError(
+        "No launchable browser was found for Clanker Vision. Install chromium/chromium-browser/google-chrome/firefox, set CLANKER_BOX_BROWSER_PATH or CLANKER_BOX_FIREFOX_PATH, or install Playwright managed browsers. Attempts: %s"
+        % " | ".join(attempts[:8])
+    )
+
 def main():
     input_path = sys.argv[1]
     output_path = sys.argv[2]
@@ -798,18 +870,10 @@ def main():
             state = {}
 
     url = (req.get("url") or state.get("url") or "about:blank").strip()
-    chromium = os.environ.get("CLANKER_BOX_CHROMIUM_PATH") or shutil.which("chromium") or shutil.which("chromium-browser") or shutil.which("google-chrome")
     launch_args = ["--no-sandbox", "--disable-dev-shm-usage", "--disable-background-networking"]
 
     with sync_playwright() as p:
-        context = p.chromium.launch_persistent_context(
-            profile_dir,
-            headless=os.environ.get("CLANKER_BOX_VISION_HEADLESS", "true").lower() != "false",
-            executable_path=chromium,
-            viewport={"width": 1280, "height": 800},
-            user_agent=os.environ.get("CLANKER_BOX_VISION_USER_AGENT", "ClankerVision/0.1"),
-            args=launch_args,
-        )
+        context, browser_label = launch_browser_context(p, profile_dir, launch_args)
         page = context.pages[0] if context.pages else context.new_page()
         page.set_default_timeout(15000)
         if action == "browser.open" or page.url == "about:blank":

--- a/internal/clankerbox/vision.go
+++ b/internal/clankerbox/vision.go
@@ -31,6 +31,7 @@ type VisionRequest struct {
 	Instruction string     `json:"instruction,omitempty"`
 	URL         string     `json:"url,omitempty"`
 	Selector    string     `json:"selector,omitempty"`
+	Target      string     `json:"target,omitempty"`
 	X           int        `json:"x,omitempty"`
 	Y           int        `json:"y,omitempty"`
 	Text        string     `json:"text,omitempty"`
@@ -67,26 +68,40 @@ type VisionEvent struct {
 	X         int    `json:"x,omitempty"`
 	Y         int    `json:"y,omitempty"`
 	FilePath  string `json:"filePath,omitempty"`
+	TracePath string `json:"tracePath,omitempty"`
 	CreatedAt string `json:"createdAt"`
 }
 
 type VisionObservation struct {
-	URL                 string         `json:"url,omitempty"`
-	Title               string         `json:"title,omitempty"`
-	PageText            string         `json:"pageText,omitempty"`
-	Width               int            `json:"width,omitempty"`
-	Height              int            `json:"height,omitempty"`
-	ScreenshotMediaType string         `json:"screenshotMediaType,omitempty"`
-	ScreenshotBase64    string         `json:"screenshotBase64,omitempty"`
-	Pointer             *VisionPointer `json:"pointer,omitempty"`
-	ScreenshotPath      string         `json:"screenshotPath,omitempty"`
-	ScreenshotRedacted  bool           `json:"screenshotRedacted,omitempty"`
+	URL                 string          `json:"url,omitempty"`
+	Title               string          `json:"title,omitempty"`
+	PageText            string          `json:"pageText,omitempty"`
+	Width               int             `json:"width,omitempty"`
+	Height              int             `json:"height,omitempty"`
+	ScreenshotMediaType string          `json:"screenshotMediaType,omitempty"`
+	ScreenshotBase64    string          `json:"screenshotBase64,omitempty"`
+	Pointer             *VisionPointer  `json:"pointer,omitempty"`
+	ScreenshotPath      string          `json:"screenshotPath,omitempty"`
+	ScreenshotRedacted  bool            `json:"screenshotRedacted,omitempty"`
+	TracePath           string          `json:"tracePath,omitempty"`
+	Elements            []VisionElement `json:"elements,omitempty"`
 }
 
 type VisionPointer struct {
 	X     int    `json:"x"`
 	Y     int    `json:"y"`
 	Label string `json:"label,omitempty"`
+}
+
+type VisionElement struct {
+	Role     string `json:"role,omitempty"`
+	Label    string `json:"label,omitempty"`
+	Text     string `json:"text,omitempty"`
+	Selector string `json:"selector,omitempty"`
+	X        int    `json:"x,omitempty"`
+	Y        int    `json:"y,omitempty"`
+	Width    int    `json:"width,omitempty"`
+	Height   int    `json:"height,omitempty"`
 }
 
 type VisionArtifact struct {
@@ -121,16 +136,18 @@ type visionSession struct {
 }
 
 type browserBridgeResult struct {
-	URL                 string         `json:"url"`
-	Title               string         `json:"title"`
-	PageText            string         `json:"pageText,omitempty"`
-	Width               int            `json:"width"`
-	Height              int            `json:"height"`
-	ScreenshotMediaType string         `json:"screenshotMediaType"`
-	ScreenshotBase64    string         `json:"screenshotBase64"`
-	ScreenshotPath      string         `json:"screenshotPath"`
-	Pointer             *VisionPointer `json:"pointer,omitempty"`
-	Error               string         `json:"error,omitempty"`
+	URL                 string          `json:"url"`
+	Title               string          `json:"title"`
+	PageText            string          `json:"pageText,omitempty"`
+	Width               int             `json:"width"`
+	Height              int             `json:"height"`
+	ScreenshotMediaType string          `json:"screenshotMediaType"`
+	ScreenshotBase64    string          `json:"screenshotBase64"`
+	ScreenshotPath      string          `json:"screenshotPath"`
+	Pointer             *VisionPointer  `json:"pointer,omitempty"`
+	TracePath           string          `json:"tracePath,omitempty"`
+	Elements            []VisionElement `json:"elements,omitempty"`
+	Error               string          `json:"error,omitempty"`
 }
 
 var (
@@ -213,7 +230,7 @@ func (s *VisionService) Handle(ctx context.Context, req VisionRequest) VisionRes
 		}
 		resp.Observation = observation
 		resp.Summary = browserVisionSummary(action, observation)
-		resp.Events = []VisionEvent{s.appendEvent(session.ID, VisionEvent{Type: "browser", Action: action, Status: "completed", Summary: resp.Summary, X: req.X, Y: req.Y, FilePath: observation.ScreenshotPath})}
+		resp.Events = []VisionEvent{s.appendEvent(session.ID, VisionEvent{Type: "browser", Action: action, Status: "completed", Summary: resp.Summary, X: req.X, Y: req.Y, FilePath: observation.ScreenshotPath, TracePath: observation.TracePath})}
 	case "office.write_doc":
 		artifact, err := writeVisionDocument(ctx, session.ID, req)
 		if err != nil {
@@ -500,6 +517,7 @@ func runVisionBrowserAction(ctx context.Context, sessionID, action string, req V
 		"action":      action,
 		"url":         strings.TrimSpace(req.URL),
 		"selector":    strings.TrimSpace(req.Selector),
+		"target":      strings.TrimSpace(req.Target),
 		"x":           req.X,
 		"y":           req.Y,
 		"text":        req.Text,
@@ -554,7 +572,7 @@ func runVisionBrowserAction(ctx context.Context, sessionID, action string, req V
 	if bridge.Error != "" {
 		return nil, fmt.Errorf("%s", bridge.Error)
 	}
-	return &VisionObservation{
+	observation := &VisionObservation{
 		URL:                 bridge.URL,
 		Title:               bridge.Title,
 		PageText:            bridge.PageText,
@@ -564,7 +582,45 @@ func runVisionBrowserAction(ctx context.Context, sessionID, action string, req V
 		ScreenshotBase64:    bridge.ScreenshotBase64,
 		ScreenshotPath:      bridge.ScreenshotPath,
 		Pointer:             bridge.Pointer,
-	}, nil
+		Elements:            bridge.Elements,
+	}
+	observation.TracePath = writeVisionBrowserTrace(dir, action, req, observation)
+	return observation, nil
+}
+
+func writeVisionBrowserTrace(dir, action string, req VisionRequest, observation *VisionObservation) string {
+	if observation == nil {
+		return ""
+	}
+	tracePath := filepath.Join(dir, "browser-trace.jsonl")
+	record := map[string]any{
+		"id":             "browser-trace-" + strconv.FormatInt(time.Now().UTC().UnixMilli(), 10),
+		"createdAt":      time.Now().UTC().Format(time.RFC3339Nano),
+		"action":         action,
+		"url":            observation.URL,
+		"title":          observation.Title,
+		"screenshotPath": observation.ScreenshotPath,
+		"pointer":        observation.Pointer,
+		"target":         strings.TrimSpace(req.Target),
+		"selector":       strings.TrimSpace(req.Selector),
+		"x":              req.X,
+		"y":              req.Y,
+		"elementCount":   len(observation.Elements),
+		"tracePath":      tracePath,
+	}
+	data, err := json.Marshal(record)
+	if err != nil {
+		return ""
+	}
+	file, err := os.OpenFile(tracePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return ""
+	}
+	defer file.Close()
+	if _, err := file.Write(append(data, '\n')); err != nil {
+		return ""
+	}
+	return tracePath
 }
 
 func browserVisionSummary(action string, observation *VisionObservation) string {
@@ -858,6 +914,124 @@ def launch_browser_context(p, profile_dir, launch_args):
         % " | ".join(attempts[:8])
     )
 
+def normalize_target(value):
+    return " ".join((value or "").lower().split())
+
+def collect_elements(page, limit=80):
+    try:
+        return page.evaluate(
+            """(limit) => {
+                const selectors = [
+                    "a",
+                    "button",
+                    "input",
+                    "textarea",
+                    "select",
+                    "summary",
+                    "[role='button']",
+                    "[role='link']",
+                    "[role='menuitem']",
+                    "[role='tab']",
+                    "[aria-label]",
+                    "[title]"
+                ].join(",");
+                const clean = (value) => String(value || "").replace(/\\s+/g, " ").trim();
+                const roleFor = (element) => {
+                    const explicitRole = clean(element.getAttribute("role"));
+                    if (explicitRole) return explicitRole;
+                    const tag = element.tagName.toLowerCase();
+                    if (tag === "a") return "link";
+                    if (tag === "button") return "button";
+                    if (tag === "input") return clean(element.getAttribute("type")) || "input";
+                    if (tag === "textarea") return "textbox";
+                    if (tag === "select") return "select";
+                    return tag;
+                };
+                const labelFor = (element) => {
+                    const tag = element.tagName.toLowerCase();
+                    return clean(element.getAttribute("aria-label"))
+                        || clean(element.innerText)
+                        || clean(element.value)
+                        || clean(element.getAttribute("title"))
+                        || clean(element.getAttribute("alt"))
+                        || clean(element.getAttribute("placeholder"))
+                        || clean(tag === "a" ? element.href : "");
+                };
+                const out = [];
+                const seen = new Set();
+                for (const element of Array.from(document.querySelectorAll(selectors))) {
+                    if (out.length >= limit) break;
+                    if (!(element instanceof HTMLElement)) continue;
+                    const style = window.getComputedStyle(element);
+                    if (style.visibility === "hidden" || style.display === "none" || Number(style.opacity || 1) === 0) continue;
+                    const rect = element.getBoundingClientRect();
+                    if (rect.width < 2 || rect.height < 2) continue;
+                    if (rect.bottom < 0 || rect.right < 0 || rect.top > window.innerHeight || rect.left > window.innerWidth) continue;
+                    const label = labelFor(element);
+                    if (!label) continue;
+                    const key = roleFor(element) + ":" + label + ":" + Math.round(rect.left) + ":" + Math.round(rect.top);
+                    if (seen.has(key)) continue;
+                    seen.add(key);
+                    const id = "clanker-vision-" + out.length;
+                    element.setAttribute("data-clanker-vision-id", id);
+                    out.push({
+                        role: roleFor(element),
+                        label,
+                        text: label,
+                        selector: '[data-clanker-vision-id="' + id + '"]',
+                        x: Math.round(rect.left + rect.width / 2),
+                        y: Math.round(rect.top + rect.height / 2),
+                        width: Math.round(rect.width),
+                        height: Math.round(rect.height)
+                    });
+                }
+                return out;
+            }""",
+            limit,
+        )
+    except Exception:
+        return []
+
+def element_for_target(elements, target):
+    value = normalize_target(target)
+    if not value or not elements:
+        return None
+    if value in ("that", "it", "that story", "the story", "first", "first story", "top", "top story", "first result", "top result"):
+        return elements[0]
+    ordinal_map = {
+        "second": 1,
+        "2nd": 1,
+        "third": 2,
+        "3rd": 2,
+        "fourth": 3,
+        "4th": 3,
+        "fifth": 4,
+        "5th": 4,
+    }
+    for marker, index in ordinal_map.items():
+        if marker in value and index < len(elements):
+            return elements[index]
+    best = None
+    best_score = 0
+    for element in elements:
+        label = normalize_target(element.get("label") or element.get("text") or "")
+        if not label:
+            continue
+        score = 0
+        if label == value:
+            score = 100
+        elif value in label or label in value:
+            score = 80
+        else:
+            target_words = set(value.split())
+            label_words = set(label.split())
+            if target_words and label_words:
+                score = int(100 * len(target_words & label_words) / max(len(target_words), len(label_words)))
+        if score > best_score:
+            best = element
+            best_score = score
+    return best if best_score >= 35 else None
+
 def main():
     input_path = sys.argv[1]
     output_path = sys.argv[2]
@@ -898,20 +1072,44 @@ def main():
             page.goto(url, wait_until="domcontentloaded", timeout=30000)
 
         pointer = None
-        if action == "browser.click":
-            x = int(req.get("x") or 0)
-            y = int(req.get("y") or 0)
-            if x <= 0 or y <= 0:
-                selector = (req.get("selector") or "").strip()
-                if not selector:
-                    raise RuntimeError("browser.click needs x/y coordinates or a selector")
-                box = page.locator(selector).first.bounding_box()
-                if not box:
-                    raise RuntimeError("selector did not resolve to a visible element")
-                x = int(box["x"] + box["width"] / 2)
-                y = int(box["y"] + box["height"] / 2)
-            page.mouse.click(x, y)
-            pointer = {"x": x, "y": y, "label": "click"}
+        elements_before_action = collect_elements(page)
+		if action == "browser.click":
+			x = int(req.get("x") or 0)
+			y = int(req.get("y") or 0)
+			selector = (req.get("selector") or "").strip()
+			target = (req.get("target") or "").strip()
+			pointer_label = "click"
+			if selector:
+				box = page.locator(selector).first.bounding_box()
+				if not box:
+					raise RuntimeError("selector did not resolve to a visible element")
+				x = int(box["x"] + box["width"] / 2)
+				y = int(box["y"] + box["height"] / 2)
+				pointer_label = selector
+			elif target:
+				matched = element_for_target(elements_before_action, target)
+				if matched:
+					selector = matched.get("selector") or ""
+					x = int(matched.get("x") or 0)
+					y = int(matched.get("y") or 0)
+					pointer_label = matched.get("label") or target
+				else:
+					locator = page.get_by_text(target, exact=False).first
+					box = locator.bounding_box()
+					if box:
+						x = int(box["x"] + box["width"] / 2)
+						y = int(box["y"] + box["height"] / 2)
+						pointer_label = target
+			if x <= 0 or y <= 0:
+				raise RuntimeError("browser.click needs x/y coordinates, a selector, or visible target text")
+			if selector:
+				try:
+					page.locator(selector).first.click(timeout=3000)
+                except Exception:
+                    page.mouse.click(x, y)
+            else:
+                page.mouse.click(x, y)
+            pointer = {"x": x, "y": y, "label": pointer_label}
         elif action == "browser.type":
             x = int(req.get("x") or 0)
             y = int(req.get("y") or 0)
@@ -952,6 +1150,7 @@ def main():
             page_text = "\n".join([line for line in lines if line])
             if len(page_text) > 12000:
                 page_text = page_text[:12000]
+        elements = collect_elements(page)
         shot_path = os.path.join(shot_dir, "screen-%d.jpg" % int(time.time() * 1000))
         shot = page.screenshot(path=shot_path, type="jpeg", quality=70, full_page=False)
         if not shot:
@@ -972,6 +1171,7 @@ def main():
         "screenshotBase64": base64.b64encode(shot).decode("ascii"),
         "screenshotPath": shot_path,
         "pointer": pointer,
+        "elements": elements,
     })
 
 if __name__ == "__main__":

--- a/internal/clankerbox/vision.go
+++ b/internal/clankerbox/vision.go
@@ -471,6 +471,21 @@ func visionConfirmationReason(req VisionRequest, action string) string {
 	return ""
 }
 
+func visionRuntimeDir() string {
+	return filepath.Join(terminalWorkingDir(""), ".clanker-vision", "runtime")
+}
+
+func visionRuntimePython() string {
+	if python := strings.TrimSpace(os.Getenv("CLANKER_BOX_VISION_PYTHON")); python != "" {
+		return python
+	}
+	candidate := filepath.Join(visionRuntimeDir(), ".venv", "bin", "python")
+	if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+		return candidate
+	}
+	return "python3"
+}
+
 func runVisionBrowserAction(ctx context.Context, sessionID, action string, req VisionRequest) (*VisionObservation, error) {
 	if action == "browser.open" {
 		if _, err := url.ParseRequestURI(strings.TrimSpace(req.URL)); err != nil {
@@ -508,13 +523,14 @@ func runVisionBrowserAction(ctx context.Context, sessionID, action string, req V
 	}
 	timeoutCtx, cancel := context.WithTimeout(ctx, 55*time.Second)
 	defer cancel()
-	python := strings.TrimSpace(os.Getenv("CLANKER_BOX_VISION_PYTHON"))
-	if python == "" {
-		python = "python3"
-	}
+	python := visionRuntimePython()
 	cmd := exec.CommandContext(timeoutCtx, python, scriptPath, inputPath, outputPath)
 	cmd.Dir = dir
-	cmd.Env = append(os.Environ(), "CLANKER_BOX_VISION_USER_AGENT="+visionUserAgent)
+	cmd.Env = append(
+		os.Environ(),
+		"CLANKER_BOX_VISION_USER_AGENT="+visionUserAgent,
+		"PLAYWRIGHT_BROWSERS_PATH="+filepath.Join(visionRuntimeDir(), "ms-playwright"),
+	)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -848,7 +864,7 @@ def main():
     try:
         from playwright.sync_api import sync_playwright
     except Exception as exc:
-        write_result(output_path, {"error": "Playwright is not installed in this Clanker Box image: %s" % exc})
+        write_result(output_path, {"error": "Playwright is not installed for Clanker Vision: %s. Run clanker box install clanker-vision to install the app-local browser runtime." % exc})
         return
 
     with open(input_path, "r", encoding="utf-8") as f:

--- a/internal/clankerbox/vision.go
+++ b/internal/clankerbox/vision.go
@@ -73,6 +73,7 @@ type VisionEvent struct {
 type VisionObservation struct {
 	URL                 string         `json:"url,omitempty"`
 	Title               string         `json:"title,omitempty"`
+	PageText            string         `json:"pageText,omitempty"`
 	Width               int            `json:"width,omitempty"`
 	Height              int            `json:"height,omitempty"`
 	ScreenshotMediaType string         `json:"screenshotMediaType,omitempty"`
@@ -122,6 +123,7 @@ type visionSession struct {
 type browserBridgeResult struct {
 	URL                 string         `json:"url"`
 	Title               string         `json:"title"`
+	PageText            string         `json:"pageText,omitempty"`
 	Width               int            `json:"width"`
 	Height              int            `json:"height"`
 	ScreenshotMediaType string         `json:"screenshotMediaType"`
@@ -539,6 +541,7 @@ func runVisionBrowserAction(ctx context.Context, sessionID, action string, req V
 	return &VisionObservation{
 		URL:                 bridge.URL,
 		Title:               bridge.Title,
+		PageText:            bridge.PageText,
 		Width:               bridge.Width,
 		Height:              bridge.Height,
 		ScreenshotMediaType: bridge.ScreenshotMediaType,
@@ -856,6 +859,19 @@ def main():
 
         title = page.title()
         final_url = page.url
+        page_text = ""
+        try:
+            raw_text = page.locator("body").inner_text(timeout=3000)
+        except Exception:
+            try:
+                raw_text = page.evaluate("() => document.body ? document.body.innerText : ''")
+            except Exception:
+                raw_text = ""
+        if raw_text:
+            lines = [" ".join(line.split()) for line in raw_text.splitlines()]
+            page_text = "\n".join([line for line in lines if line])
+            if len(page_text) > 12000:
+                page_text = page_text[:12000]
         shot_path = os.path.join(shot_dir, "screen-%d.jpg" % int(time.time() * 1000))
         shot = page.screenshot(path=shot_path, type="jpeg", quality=70, full_page=False)
         if not shot:
@@ -869,6 +885,7 @@ def main():
     write_result(output_path, {
         "url": final_url,
         "title": title,
+        "pageText": page_text,
         "width": 1280,
         "height": 800,
         "screenshotMediaType": "image/jpeg",


### PR DESCRIPTION
## Summary
- add the native `clanker-vision` Clanker Box runtime
- add constrained browser, office, email draft, install, status, and stop actions
- add visible pointer/screenshot metadata plus policy gates for credentials, send/submit/delete/install-like actions
- install Chromium, Playwright, and LibreOffice support in the Clanker Box image

## Tests
- `go test ./internal/clankerbox`
- `go test ./...`
- `git diff --check`
