### PR TITLE
Add Oracle Cloud provider support

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -32,6 +32,7 @@ import (
 	"github.com/bgdnvk/clanker/internal/k8s"
 	"github.com/bgdnvk/clanker/internal/k8s/plan"
 	"github.com/bgdnvk/clanker/internal/maker"
+	"github.com/bgdnvk/clanker/internal/oracle"
 	"github.com/bgdnvk/clanker/internal/railway"
 	"github.com/bgdnvk/clanker/internal/resourcedb"
 	"github.com/bgdnvk/clanker/internal/routing"
@@ -46,10 +47,10 @@ import (
 // askCmd represents the ask command
 const defaultGeminiModel = "gemini-2.5-flash"
 
-func applyDiscoveryContextDefaults(includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel, includeVerda, includeRailway bool) (bool, bool, bool, bool, bool, bool, bool, bool, bool, bool) {
+func applyDiscoveryContextDefaults(includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeOracle, includeTerraform, includeVercel, includeVerda, includeRailway bool) (bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool) {
 	includeTerraform = true
-	if includeAWS || includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeHetzner || includeVercel || includeVerda || includeRailway {
-		return includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel, includeVerda, includeRailway
+	if includeAWS || includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeHetzner || includeOracle || includeVercel || includeVerda || includeRailway {
+		return includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeOracle, includeTerraform, includeVercel, includeVerda, includeRailway
 	}
 
 	switch routing.DefaultInfraProvider() {
@@ -63,6 +64,8 @@ func applyDiscoveryContextDefaults(includeAWS, includeGCP, includeAzure, include
 		includeDigitalOcean = true
 	case "hetzner":
 		includeHetzner = true
+	case "oracle":
+		includeOracle = true
 	case "vercel":
 		includeVercel = true
 	case "verda":
@@ -73,13 +76,13 @@ func applyDiscoveryContextDefaults(includeAWS, includeGCP, includeAzure, include
 		includeAWS = true
 	}
 
-	return includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel, includeVerda, includeRailway
+	return includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeOracle, includeTerraform, includeVercel, includeVerda, includeRailway
 }
 
 var askCmd = &cobra.Command{
 	Use:   "ask [question]",
 	Short: "Ask AI about your cloud infrastructure or GitHub repository",
-	Long: `Ask natural language questions about your AWS or GCP infrastructure or GitHub repository.
+	Long: `Ask natural language questions about your cloud infrastructure or GitHub repository.
 	
 Examples:
   clanker ask "What EC2 instances are running?"
@@ -115,6 +118,7 @@ Examples:
 		includeCloudflare, _ := cmd.Flags().GetBool("cloudflare")
 		includeDigitalOcean, _ := cmd.Flags().GetBool("digitalocean")
 		includeHetzner, _ := cmd.Flags().GetBool("hetzner")
+		includeOracle, _ := cmd.Flags().GetBool("oracle")
 		includeVercel, _ := cmd.Flags().GetBool("vercel")
 		includeFlyio, _ := cmd.Flags().GetBool("flyio")
 		includeRailway, _ := cmd.Flags().GetBool("railway")
@@ -342,6 +346,18 @@ Examples:
 				})
 			}
 
+			if strings.EqualFold(strings.TrimSpace(makerPlan.Provider), "oracle") {
+				profile := oracle.ResolveProfile()
+				return maker.ExecuteOraclePlan(ctx, makerPlan, maker.ExecOptions{
+					OracleProfile:       profile,
+					OracleCompartmentID: oracle.ResolveCompartmentID(),
+					OracleTenancyOCID:   oracle.ResolveTenancyOCID(profile),
+					Writer:              os.Stdout,
+					Destroyer:           destroyer,
+					Debug:               debug,
+				})
+			}
+
 			if strings.EqualFold(strings.TrimSpace(makerPlan.Provider), "vercel") {
 				vcToken, vcTeamID, vcErr := resolveVercelToken(ctx, debug)
 				if vcErr != nil {
@@ -547,6 +563,7 @@ Examples:
 			explicitCloudflare := cmd.Flags().Changed("cloudflare") && includeCloudflare
 			explicitDigitalOcean := cmd.Flags().Changed("digitalocean") && includeDigitalOcean
 			explicitHetzner := cmd.Flags().Changed("hetzner") && includeHetzner
+			explicitOracle := cmd.Flags().Changed("oracle") && includeOracle
 			explicitAzure := cmd.Flags().Changed("azure") && includeAzure
 			explicitVercel := cmd.Flags().Changed("vercel") && includeVercel
 			explicitRailway := cmd.Flags().Changed("railway") && includeRailway
@@ -568,6 +585,9 @@ Examples:
 			if explicitHetzner {
 				explicitCount++
 			}
+			if explicitOracle {
+				explicitCount++
+			}
 			if explicitAzure {
 				explicitCount++
 			}
@@ -584,9 +604,12 @@ Examples:
 				explicitCount++
 			}
 			if explicitCount > 1 {
-				return fmt.Errorf("cannot use multiple provider flags (--aws, --gcp, --azure, --cloudflare, --digitalocean, --hetzner, --vercel, --railway, --verda, --tencent) together with --maker")
+				return fmt.Errorf("cannot use multiple provider flags (--aws, --gcp, --azure, --cloudflare, --digitalocean, --hetzner, --oracle, --vercel, --railway, --verda, --tencent) together with --maker")
 			}
 			switch {
+			case explicitOracle:
+				makerProvider = "oracle"
+				makerProviderReason = "explicit"
 			case explicitHetzner:
 				makerProvider = "hetzner"
 				makerProviderReason = "explicit"
@@ -628,6 +651,9 @@ Examples:
 				} else if svcCtx.Hetzner {
 					makerProvider = "hetzner"
 					makerProviderReason = "inferred"
+				} else if svcCtx.Oracle {
+					makerProvider = "oracle"
+					makerProviderReason = "inferred"
 				} else if svcCtx.Azure {
 					makerProvider = "azure"
 					makerProviderReason = "inferred"
@@ -661,6 +687,8 @@ Examples:
 				prompt = maker.DigitalOceanPlanPromptWithMode(question, destroyer)
 			case "hetzner":
 				prompt = maker.HetznerPlanPromptWithMode(question, destroyer)
+			case "oracle":
+				prompt = maker.OraclePlanPromptWithMode(question, destroyer)
 			case "azure":
 				prompt = maker.AzurePlanPromptWithMode(question, destroyer)
 			case "gcp":
@@ -733,9 +761,9 @@ Examples:
 
 			plan.Provider = makerProvider
 
-			// Handle GCP, Azure, Cloudflare, Digital Ocean, Hetzner, Vercel, Verda, and Railway plans (output directly, no enrichment)
+			// Handle GCP, Azure, Cloudflare, Digital Ocean, Hetzner, Oracle, Vercel, Verda, and Railway plans (output directly, no enrichment)
 			providerLower := strings.ToLower(strings.TrimSpace(plan.Provider))
-			if providerLower == "gcp" || providerLower == "azure" || providerLower == "cloudflare" || providerLower == "digitalocean" || providerLower == "hetzner" || providerLower == "vercel" || providerLower == "verda" || providerLower == "railway" || providerLower == "tencent" {
+			if providerLower == "gcp" || providerLower == "azure" || providerLower == "cloudflare" || providerLower == "digitalocean" || providerLower == "hetzner" || providerLower == "oracle" || providerLower == "vercel" || providerLower == "verda" || providerLower == "railway" || providerLower == "tencent" {
 				if plan.CreatedAt.IsZero() {
 					plan.CreatedAt = time.Now().UTC()
 				}
@@ -825,13 +853,14 @@ Format as a professional compliance table suitable for government security docum
 
 		// Discovery mode enables comprehensive infrastructure analysis
 		if discovery {
-			includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel, includeVerda, includeRailway = applyDiscoveryContextDefaults(
+			includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeOracle, includeTerraform, includeVercel, includeVerda, includeRailway = applyDiscoveryContextDefaults(
 				includeAWS,
 				includeGCP,
 				includeAzure,
 				includeCloudflare,
 				includeDigitalOcean,
 				includeHetzner,
+				includeOracle,
 				includeTerraform,
 				includeVercel,
 				includeVerda,
@@ -870,6 +899,11 @@ Format as a professional compliance table suitable for government security docum
 			return handleHetznerQuery(context.Background(), question, debug)
 		}
 
+		// Handle explicit --oracle flag
+		if includeOracle && !makerMode {
+			return handleOracleQuery(context.Background(), question, debug)
+		}
+
 		// Handle explicit --vercel flag
 		if includeVercel && !makerMode {
 			return handleVercelQuery(context.Background(), question, debug)
@@ -895,7 +929,7 @@ Format as a professional compliance table suitable for government security docum
 			return handleTencentQuery(context.Background(), question, debug)
 		}
 
-		if !includeAWS && !includeGitHub && !includeTerraform && !includeGCP && !includeAzure && !includeCloudflare && !includeDigitalOcean && !includeHetzner && !includeVercel && !includeFlyio && !includeRailway && !includeVerda && !includeDB {
+		if !includeAWS && !includeGitHub && !includeTerraform && !includeGCP && !includeAzure && !includeCloudflare && !includeDigitalOcean && !includeHetzner && !includeOracle && !includeVercel && !includeFlyio && !includeRailway && !includeVerda && !includeDB {
 			routingQuestion := questionForRouting(question)
 
 			// First, do quick keyword check for explicit terms
@@ -904,8 +938,8 @@ Format as a professional compliance table suitable for government security docum
 			includeGitHub = svcCtx.GitHub
 
 			if debug {
-				fmt.Printf("Keyword inference: AWS=%v, GitHub=%v, Terraform=%v, K8s=%v, GCP=%v, Cloudflare=%v\n",
-					svcCtx.AWS, svcCtx.GitHub, svcCtx.Terraform, svcCtx.K8s, svcCtx.GCP, svcCtx.Cloudflare)
+				fmt.Printf("Keyword inference: AWS=%v, GitHub=%v, Terraform=%v, K8s=%v, GCP=%v, Cloudflare=%v, Oracle=%v\n",
+					svcCtx.AWS, svcCtx.GitHub, svcCtx.Terraform, svcCtx.K8s, svcCtx.GCP, svcCtx.Cloudflare, svcCtx.Oracle)
 			}
 
 			// For ambiguous queries (multiple services detected or Cloudflare detected),
@@ -927,8 +961,8 @@ Format as a professional compliance table suitable for government security docum
 					routing.ApplyLLMClassification(&svcCtx, llmService)
 
 					if debug {
-						fmt.Printf("LLM override: AWS=%v, K8s=%v, GCP=%v, Azure=%v, Cloudflare=%v\n",
-							svcCtx.AWS, svcCtx.K8s, svcCtx.GCP, svcCtx.Azure, svcCtx.Cloudflare)
+						fmt.Printf("LLM override: AWS=%v, K8s=%v, GCP=%v, Azure=%v, Cloudflare=%v, Oracle=%v\n",
+							svcCtx.AWS, svcCtx.K8s, svcCtx.GCP, svcCtx.Azure, svcCtx.Cloudflare, svcCtx.Oracle)
 					}
 				}
 			}
@@ -964,6 +998,11 @@ Format as a professional compliance table suitable for government security docum
 			// Handle Hetzner queries
 			if svcCtx.Hetzner {
 				return handleHetznerQuery(context.Background(), routingQuestion, debug)
+			}
+
+			// Handle Oracle Cloud queries
+			if svcCtx.Oracle {
+				return handleOracleQuery(context.Background(), routingQuestion, debug)
 			}
 
 			// Handle Vercel queries
@@ -1473,6 +1512,7 @@ func init() {
 	askCmd.Flags().Bool("cloudflare", false, "Include Cloudflare infrastructure context")
 	askCmd.Flags().Bool("digitalocean", false, "Include Digital Ocean infrastructure context")
 	askCmd.Flags().Bool("hetzner", false, "Include Hetzner Cloud infrastructure context")
+	askCmd.Flags().Bool("oracle", false, "Include Oracle Cloud Infrastructure context")
 	askCmd.Flags().Bool("vercel", false, "Include Vercel context")
 	askCmd.Flags().Bool("flyio", false, "Include Fly.io context")
 	askCmd.Flags().Bool("railway", false, "Include Railway context")
@@ -1510,7 +1550,7 @@ func init() {
 	askCmd.Flags().String("minimax-model", "", "MiniMax model to use (overrides config)")
 	askCmd.Flags().String("github-model", "", "GitHub Models model to use (overrides config)")
 	askCmd.Flags().Bool("agent-trace", false, "Show detailed coordinator agent lifecycle logs (overrides config)")
-	askCmd.Flags().Bool("maker", false, "Generate an AWS, GCP, Azure, Cloudflare, Digital Ocean, Hetzner, Vercel, Railway, or Verda plan (JSON) for infrastructure changes")
+	askCmd.Flags().Bool("maker", false, "Generate an AWS, GCP, Azure, Cloudflare, Digital Ocean, Hetzner, Oracle, Vercel, Railway, or Verda plan (JSON) for infrastructure changes")
 	askCmd.Flags().Bool("destroyer", false, "Allow destructive operations when using --maker (requires explicit confirmation in UI/workflow)")
 	askCmd.Flags().Bool("apply", false, "Apply an approved maker plan (reads from stdin unless --plan-file is provided)")
 	askCmd.Flags().String("plan-file", "", "Optional path to maker plan JSON file for --apply")
@@ -2492,6 +2532,64 @@ Hetzner Cloud Context:
 User Question: %s
 
 Provide a clear, concise answer based on the data above. If the data doesn't contain enough information to fully answer the question, say so and suggest what additional information might be needed.`, hetznerContext, question)
+
+	response, err := aiClient.AskPrompt(ctx, prompt)
+	if err != nil {
+		return fmt.Errorf("failed to get AI response: %w", err)
+	}
+
+	fmt.Println(response)
+	return nil
+}
+
+// handleOracleQuery delegates an Oracle Cloud Infrastructure query to the OCI CLI client.
+func handleOracleQuery(ctx context.Context, question string, debug bool) error {
+	if debug {
+		fmt.Println("Delegating query to Oracle Cloud Infrastructure agent...")
+	}
+
+	client, err := oracle.NewClient(oracle.ResolveProfile(), oracle.ResolveCompartmentID(), oracle.ResolveTenancyOCID(oracle.ResolveProfile()), debug)
+	if err != nil {
+		return fmt.Errorf("failed to create Oracle Cloud client: %w", err)
+	}
+
+	oracleContext, err := client.GetRelevantContext(ctx, question)
+	if err != nil {
+		return fmt.Errorf("failed to get Oracle Cloud context: %w", err)
+	}
+
+	provider := viper.GetString("ai.default_provider")
+	if provider == "" {
+		provider = "openai"
+	}
+
+	var apiKey string
+	switch provider {
+	case "gemini", "gemini-api":
+		apiKey = ""
+	case "openai":
+		apiKey = resolveOpenAIKey("")
+	case "anthropic":
+		apiKey = resolveAnthropicKey("")
+	case "cohere":
+		apiKey = resolveCohereKey("")
+	case "deepseek":
+		apiKey = resolveDeepSeekKey("")
+	case "minimax":
+		apiKey = resolveMiniMaxKey("")
+	default:
+		apiKey = viper.GetString("ai.api_key")
+	}
+
+	aiClient := ai.NewClient(provider, apiKey, debug, provider)
+	prompt := fmt.Sprintf(`You are an Oracle Cloud Infrastructure expert. Answer the user's question based on the following OCI context data.
+
+Oracle Cloud Context:
+%s
+
+User Question: %s
+
+Provide a clear, concise answer based on the data above. Cite compartment OCIDs, resource OCIDs, regions, and lifecycle states when relevant. If the data is insufficient, say which OCI CLI command or missing IAM policy would surface it.`, oracleContext, question)
 
 	response, err := aiClient.AskPrompt(ctx, prompt)
 	if err != nil {

--- a/cmd/ask_test.go
+++ b/cmd/ask_test.go
@@ -80,12 +80,12 @@ func TestCreateAIClient_AppliesK8sModelOverride(t *testing.T) {
 func TestApplyDiscoveryContextDefaults_UsesConfiguredHetzner(t *testing.T) {
 	useDefaultInfraProvider(t, "hetzner")
 
-	includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel, includeVerda, includeRailway := applyDiscoveryContextDefaults(false, false, false, false, false, false, false, false, false, false)
+	includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeOracle, includeTerraform, includeVercel, includeVerda, includeRailway := applyDiscoveryContextDefaults(false, false, false, false, false, false, false, false, false, false, false)
 
 	if includeAWS {
 		t.Fatal("expected discovery defaults not to force AWS when Hetzner is configured")
 	}
-	if includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeVercel || includeVerda || includeRailway {
+	if includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeOracle || includeVercel || includeVerda || includeRailway {
 		t.Fatal("expected discovery defaults to select only the configured provider")
 	}
 	if !includeHetzner {
@@ -99,9 +99,9 @@ func TestApplyDiscoveryContextDefaults_UsesConfiguredHetzner(t *testing.T) {
 func TestApplyDiscoveryContextDefaults_PreservesExplicitProviderSelection(t *testing.T) {
 	useDefaultInfraProvider(t, "hetzner")
 
-	includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel, includeVerda, includeRailway := applyDiscoveryContextDefaults(false, false, false, false, false, true, false, false, false, false)
+	includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeOracle, includeTerraform, includeVercel, includeVerda, includeRailway := applyDiscoveryContextDefaults(false, false, false, false, false, true, false, false, false, false, false)
 
-	if includeAWS || includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeVercel || includeVerda || includeRailway {
+	if includeAWS || includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeOracle || includeVercel || includeVerda || includeRailway {
 		t.Fatal("expected explicit provider selection to be preserved without adding other providers")
 	}
 	if !includeHetzner {
@@ -115,12 +115,12 @@ func TestApplyDiscoveryContextDefaults_PreservesExplicitProviderSelection(t *tes
 func TestApplyDiscoveryContextDefaults_UsesConfiguredVercel(t *testing.T) {
 	useDefaultInfraProvider(t, "vercel")
 
-	includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel, includeVerda, includeRailway := applyDiscoveryContextDefaults(false, false, false, false, false, false, false, false, false, false)
+	includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeOracle, includeTerraform, includeVercel, includeVerda, includeRailway := applyDiscoveryContextDefaults(false, false, false, false, false, false, false, false, false, false, false)
 
 	if includeAWS {
 		t.Fatal("expected discovery defaults not to force AWS when Vercel is configured")
 	}
-	if includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeHetzner || includeVerda || includeRailway {
+	if includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeHetzner || includeOracle || includeVerda || includeRailway {
 		t.Fatal("expected discovery defaults to select only the configured provider")
 	}
 	if !includeVercel {
@@ -131,15 +131,34 @@ func TestApplyDiscoveryContextDefaults_UsesConfiguredVercel(t *testing.T) {
 	}
 }
 
+func TestApplyDiscoveryContextDefaults_UsesConfiguredOracle(t *testing.T) {
+	useDefaultInfraProvider(t, "oracle")
+
+	includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeOracle, includeTerraform, includeVercel, includeVerda, includeRailway := applyDiscoveryContextDefaults(false, false, false, false, false, false, false, false, false, false, false)
+
+	if includeAWS {
+		t.Fatal("expected discovery defaults not to force AWS when Oracle is configured")
+	}
+	if includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeHetzner || includeVercel || includeVerda || includeRailway {
+		t.Fatal("expected discovery defaults to select only the configured provider")
+	}
+	if !includeOracle {
+		t.Fatal("expected discovery defaults to enable Oracle when configured")
+	}
+	if !includeTerraform {
+		t.Fatal("expected discovery defaults to enable Terraform context")
+	}
+}
+
 func TestApplyDiscoveryContextDefaults_UsesConfiguredVerda(t *testing.T) {
 	useDefaultInfraProvider(t, "verda")
 
-	includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel, includeVerda, includeRailway := applyDiscoveryContextDefaults(false, false, false, false, false, false, false, false, false, false)
+	includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeOracle, includeTerraform, includeVercel, includeVerda, includeRailway := applyDiscoveryContextDefaults(false, false, false, false, false, false, false, false, false, false, false)
 
 	if includeAWS {
 		t.Fatal("expected discovery defaults not to force AWS when Verda is configured")
 	}
-	if includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeHetzner || includeVercel || includeRailway {
+	if includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeHetzner || includeOracle || includeVercel || includeRailway {
 		t.Fatal("expected discovery defaults to select only the configured provider")
 	}
 	if !includeVerda {
@@ -153,12 +172,12 @@ func TestApplyDiscoveryContextDefaults_UsesConfiguredVerda(t *testing.T) {
 func TestApplyDiscoveryContextDefaults_UsesConfiguredRailway(t *testing.T) {
 	useDefaultInfraProvider(t, "railway")
 
-	includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeTerraform, includeVercel, includeVerda, includeRailway := applyDiscoveryContextDefaults(false, false, false, false, false, false, false, false, false, false)
+	includeAWS, includeGCP, includeAzure, includeCloudflare, includeDigitalOcean, includeHetzner, includeOracle, includeTerraform, includeVercel, includeVerda, includeRailway := applyDiscoveryContextDefaults(false, false, false, false, false, false, false, false, false, false, false)
 
 	if includeAWS {
 		t.Fatal("expected discovery defaults not to force AWS when Railway is configured")
 	}
-	if includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeHetzner || includeVercel || includeVerda {
+	if includeGCP || includeAzure || includeCloudflare || includeDigitalOcean || includeHetzner || includeOracle || includeVercel || includeVerda {
 		t.Fatal("expected discovery defaults to select only the configured provider")
 	}
 	if !includeRailway {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -219,6 +219,12 @@ codebase:
 # hetzner:
 #   api_token: ""           # Hetzner Cloud API token (or set HCLOUD_TOKEN)
 
+# Oracle Cloud Infrastructure (for 'clanker oracle ...' and 'clanker ask --oracle ...'):
+# oracle:
+#   profile: DEFAULT        # OCI CLI profile (or set OCI_CLI_PROFILE)
+#   tenancy_ocid: ""        # Root tenancy OCID for compartment discovery (or set OCI_TENANCY_OCID)
+#   compartment_id: ""      # Optional target compartment OCID (or set OCI_COMPARTMENT_ID)
+
 # General settings
 timeout: 30  # Timeout for AI requests in seconds
 

--- a/cmd/mcp_cloud_providers.go
+++ b/cmd/mcp_cloud_providers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bgdnvk/clanker/internal/digitalocean"
 	"github.com/bgdnvk/clanker/internal/gcp"
 	"github.com/bgdnvk/clanker/internal/hetzner"
+	"github.com/bgdnvk/clanker/internal/oracle"
 	"github.com/mark3labs/mcp-go/mcp"
 	mcptransport "github.com/mark3labs/mcp-go/server"
 )
@@ -60,6 +61,12 @@ var cloudProviderMCPConfigs = []cloudProviderMCPConfig{
 		Command:      "hetzner",
 		ResourceHelp: "servers, load-balancers, volumes, networks, firewalls, floating-ips, primary-ips, ssh-keys, images, isos, certificates, placement-groups, server-types, locations, datacenters",
 	},
+	{
+		Key:          "oracle",
+		DisplayName:  "Oracle Cloud Infrastructure",
+		Command:      "oracle",
+		ResourceHelp: "compartments, instances, instance-pools, images, boot-volumes, volumes, volume-backups, vcns, subnets, route-tables, security-lists, nsgs, internet-gateways, nat-gateways, service-gateways, load-balancers, network-load-balancers, buckets, file-systems, mount-targets, databases, autonomous-databases, mysql-systems, oke-clusters, node-pools, functions, container-repositories, api-gateways, dns-zones, vaults, secrets, streams, queues, alarms, log-groups, events-rules",
+	},
 }
 
 func registerCloudProviderMCPTools(server *mcptransport.MCPServer) {
@@ -86,6 +93,7 @@ func registerCloudMCPCatalogTool(server *mcptransport.MCPServer) {
 					{"provider": "cloudflare", "ask_tool": "clanker_cloudflare_ask", "list_tool": "clanker_cloudflare_list"},
 					{"provider": "digitalocean", "ask_tool": "clanker_digitalocean_ask", "list_tool": "clanker_digitalocean_list"},
 					{"provider": "hetzner", "ask_tool": "clanker_hetzner_ask", "list_tool": "clanker_hetzner_list"},
+					{"provider": "oracle", "ask_tool": "clanker_oracle_ask", "list_tool": "clanker_oracle_list"},
 				},
 				"official_remote_mcps": []map[string]string{
 					{"provider": "Cloudflare", "name": "Cloudflare API MCP server", "transport": "streamable-http", "endpoint": "https://mcp.cloudflare.com/mcp", "docs": "https://developers.cloudflare.com/agents/model-context-protocol/cloudflare/servers-for-cloudflare/"},
@@ -103,6 +111,7 @@ func registerCloudMCPCatalogTool(server *mcptransport.MCPServer) {
 					{"provider": "Google Cloud", "name": "Google Cloud remote MCP servers", "transport": "streamable-http", "endpoint": "https://docs.cloud.google.com/mcp", "docs": "https://docs.cloud.google.com/mcp"},
 					{"provider": "Microsoft Learn", "name": "Microsoft Learn MCP Server", "transport": "streamable-http", "endpoint": "https://learn.microsoft.com/api/mcp", "docs": "https://learn.microsoft.com/en-us/training/support/mcp"},
 					{"provider": "DigitalOcean", "name": "DigitalOcean MCP services", "transport": "remote MCP", "endpoint": "https://docs.digitalocean.com/reference/mcp/mcp-tools/", "docs": "https://docs.digitalocean.com/reference/mcp/mcp-tools/"},
+					{"provider": "Oracle Cloud", "name": "Oracle Cloud Infrastructure CLI", "transport": "local CLI", "endpoint": "oci", "docs": "https://docs.oracle.com/en-us/iaas/Content/API/Concepts/cliconcepts.htm"},
 				},
 			})
 		},
@@ -121,6 +130,9 @@ func registerCloudProviderAskTool(server *mcptransport.MCPServer, cfg cloudProvi
 			mcp.WithString("subscription", mcp.Description("Azure subscription ID.")),
 			mcp.WithString("account_id", mcp.Description("Cloudflare account ID.")),
 			mcp.WithString("token", mcp.Description("Provider API token for Cloudflare, DigitalOcean, or Hetzner.")),
+			mcp.WithString("oci_profile", mcp.Description("OCI CLI profile name for Oracle Cloud Infrastructure.")),
+			mcp.WithString("compartment_id", mcp.Description("OCI compartment OCID for Oracle Cloud Infrastructure.")),
+			mcp.WithString("tenancy_ocid", mcp.Description("OCI tenancy OCID for Oracle Cloud Infrastructure.")),
 			mcp.WithBoolean("debug", mcp.Description("Enable provider debug output.")),
 			mcp.WithReadOnlyHintAnnotation(true),
 		),
@@ -147,6 +159,9 @@ func registerCloudProviderListTool(server *mcptransport.MCPServer, cfg cloudProv
 			mcp.WithString("namespace", mcp.Description("Cloudflare AI Search namespace for namespace-scoped resources.")),
 			mcp.WithString("region", mcp.Description("DigitalOcean Gradient region for region-scoped resources.")),
 			mcp.WithString("project_id", mcp.Description("DigitalOcean project ID for project-scoped resources.")),
+			mcp.WithString("oci_profile", mcp.Description("OCI CLI profile name for Oracle Cloud Infrastructure.")),
+			mcp.WithString("compartment_id", mcp.Description("OCI compartment OCID for Oracle Cloud Infrastructure.")),
+			mcp.WithString("tenancy_ocid", mcp.Description("OCI tenancy OCID for Oracle Cloud Infrastructure.")),
 			mcp.WithReadOnlyHintAnnotation(true),
 		),
 		func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -245,6 +260,24 @@ func collectMCPCloudProviderContext(ctx context.Context, req mcp.CallToolRequest
 			return "", fmt.Errorf("failed to create Hetzner client: %w", err)
 		}
 		return client.GetRelevantContext(ctx, question)
+	case "oracle":
+		profile := strParam(req, "oci_profile")
+		if profile == "" {
+			profile = oracle.ResolveProfile()
+		}
+		compartmentID := strParam(req, "compartment_id")
+		if compartmentID == "" {
+			compartmentID = oracle.ResolveCompartmentID()
+		}
+		tenancyOCID := strParam(req, "tenancy_ocid")
+		if tenancyOCID == "" {
+			tenancyOCID = oracle.ResolveTenancyOCID(profile)
+		}
+		client, err := oracle.NewClient(profile, compartmentID, tenancyOCID, debug)
+		if err != nil {
+			return "", fmt.Errorf("failed to create Oracle Cloud client: %w", err)
+		}
+		return client.GetRelevantContext(ctx, question)
 	default:
 		return "", fmt.Errorf("unsupported provider: %s", provider)
 	}
@@ -259,6 +292,7 @@ func mcpCloudProviderContextQuestion(provider, question string) string {
 		"cloudflare":   "zones workers pages kv d1 r2 queues vectorize hyperdrive ai gateway logs datasets evaluations provider configs ai search namespaces browser rendering images stream secrets store pipelines durable objects turnstile tunnels workflows logpush dns waf firewall rules page rules account roles members",
 		"digitalocean": "droplets autoscale kubernetes databases spaces app platform serverless functions serverless inference dedicated inference registries gradient agents gradient models gradient knowledge bases load balancers cdns volumes nfs vpcs vpc peerings nat gateways domains firewalls reserved ips certificates images snapshots sizes regions ssh keys tags monitoring uptime security scans projects",
 		"hetzner":      "servers load balancers volumes networks firewalls floating ips primary ips ssh keys images isos certificates placement groups server types locations datacenters",
+		"oracle":       "compartments compute instances instance pools images boot volumes block volumes vcns subnets route tables security lists network security groups internet gateways nat gateways service gateways load balancers network load balancers object storage buckets file systems db systems autonomous databases mysql oke clusters node pools functions container repositories api gateways dns zones vault secrets streams queues alarms log groups events rules",
 	}
 	if base == "" {
 		return hints[provider]
@@ -309,6 +343,10 @@ func handleMCPCloudProviderList(ctx context.Context, req mcp.CallToolRequest, cf
 	case "digitalocean":
 		args = mcpAppendIf(args, "--region", strParam(req, "region"))
 		args = mcpAppendIf(args, "--project-id", strParam(req, "project_id"))
+	case "oracle":
+		args = mcpAppendIf(args, "--profile", strParam(req, "oci_profile"))
+		args = mcpAppendIf(args, "--compartment-id", strParam(req, "compartment_id"))
+		args = mcpAppendIf(args, "--tenancy-ocid", strParam(req, "tenancy_ocid"))
 	}
 
 	result, err := runClankerCommand(ctx, commandArgs{Args: args})

--- a/cmd/mcp_cloud_providers_test.go
+++ b/cmd/mcp_cloud_providers_test.go
@@ -13,8 +13,8 @@ func TestMCPCloudProviderTools_RegistrationDoesNotPanic(t *testing.T) {
 }
 
 func TestMCPCloudProviderTools_ConfigCoverage(t *testing.T) {
-	if len(cloudProviderMCPConfigs) != 6 {
-		t.Fatalf("expected 6 cloud provider MCP configs, got %d", len(cloudProviderMCPConfigs))
+	if len(cloudProviderMCPConfigs) != 7 {
+		t.Fatalf("expected 7 cloud provider MCP configs, got %d", len(cloudProviderMCPConfigs))
 	}
 
 	found := map[string]bool{}
@@ -24,7 +24,7 @@ func TestMCPCloudProviderTools_ConfigCoverage(t *testing.T) {
 			t.Errorf("provider %s has empty resource help", cfg.Key)
 		}
 	}
-	for _, key := range []string{"aws", "gcp", "azure", "cloudflare", "digitalocean", "hetzner"} {
+	for _, key := range []string{"aws", "gcp", "azure", "cloudflare", "digitalocean", "hetzner", "oracle"} {
 		if !found[key] {
 			t.Errorf("missing provider MCP config for %s", key)
 		}
@@ -63,6 +63,7 @@ func TestMCPCloudProviderContextQuestion_IncludesLatestCoverageHints(t *testing.
 		"gcp":          {"cloud asset inventory", "vertex ai", "alloydb", "workflows"},
 		"azure":        {"resource graph", "container apps", "azure ai search", "private endpoints"},
 		"hetzner":      {"placement groups", "server types", "isos"},
+		"oracle":       {"compartments", "oke", "vault", "queues"},
 	}
 
 	for provider, expected := range tests {

--- a/cmd/onboarding.go
+++ b/cmd/onboarding.go
@@ -17,7 +17,7 @@ var onboardingCmd = &cobra.Command{
 	Long: `Scan this machine for provider CLIs and credentials Clanker Cloud can use.
 
 The JSON output is designed for Clanker Cloud and MCP agents so first-run setup
-can detect AWS, GCP, Azure, Cloudflare, DigitalOcean, Hetzner, Kubernetes,
+can detect AWS, GCP, Azure, Oracle Cloud, Cloudflare, DigitalOcean, Hetzner, Kubernetes,
 GitHub, and Terraform tooling before asking the user to install anything.`,
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bgdnvk/clanker/internal/hetzner"
 	"github.com/bgdnvk/clanker/internal/linear"
 	"github.com/bgdnvk/clanker/internal/notion"
+	"github.com/bgdnvk/clanker/internal/oracle"
 	"github.com/bgdnvk/clanker/internal/railway"
 	"github.com/bgdnvk/clanker/internal/sentry"
 	"github.com/bgdnvk/clanker/internal/tencent"
@@ -139,6 +140,10 @@ func init() {
 	// Register Hetzner static commands
 	hetznerCmd := hetzner.CreateHetznerCommands()
 	rootCmd.AddCommand(hetznerCmd)
+
+	// Register Oracle Cloud Infrastructure static commands
+	oracleCmd := oracle.CreateOracleCommands()
+	rootCmd.AddCommand(oracleCmd)
 
 	// Register Vercel static commands. Natural-language queries go through
 	// `clanker ask --vercel "..."` — the canonical path that resolves

--- a/internal/maker/exec.go
+++ b/internal/maker/exec.go
@@ -253,6 +253,11 @@ type ExecOptions struct {
 	TencentSecretKey string
 	TencentRegion    string
 
+	// Oracle Cloud Infrastructure options
+	OracleProfile       string
+	OracleCompartmentID string
+	OracleTenancyOCID   string
+
 	CheckpointKey            string
 	DisableDurableCheckpoint bool
 

--- a/internal/maker/exec_oracle.go
+++ b/internal/maker/exec_oracle.go
@@ -1,0 +1,111 @@
+package maker
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/bgdnvk/clanker/internal/oracle"
+)
+
+// ExecuteOraclePlan executes an Oracle Cloud Infrastructure plan through the OCI CLI.
+func ExecuteOraclePlan(ctx context.Context, plan *Plan, opts ExecOptions) error {
+	if plan == nil {
+		return fmt.Errorf("nil plan")
+	}
+	if opts.Writer == nil {
+		return fmt.Errorf("missing output writer")
+	}
+
+	client, err := oracle.NewClient(opts.OracleProfile, opts.OracleCompartmentID, opts.OracleTenancyOCID, opts.Debug)
+	if err != nil {
+		return err
+	}
+
+	bindings := make(map[string]string)
+	if client.CompartmentID() != "" {
+		bindings["COMPARTMENT_OCID"] = client.CompartmentID()
+		bindings["OCI_COMPARTMENT_ID"] = client.CompartmentID()
+	}
+	if client.TenancyOCID() != "" {
+		bindings["TENANCY_OCID"] = client.TenancyOCID()
+		bindings["OCI_TENANCY_OCID"] = client.TenancyOCID()
+	}
+
+	for idx, cmdSpec := range plan.Commands {
+		if err := validateOracleCommand(cmdSpec.Args, opts.Destroyer); err != nil {
+			return fmt.Errorf("command %d rejected: %w", idx+1, err)
+		}
+
+		args := make([]string, 0, len(cmdSpec.Args))
+		args = append(args, cmdSpec.Args...)
+		args = applyPlanBindings(args, bindings)
+
+		if hasUnresolvedPlaceholders(args) {
+			return fmt.Errorf("command %d has unresolved placeholders after substitutions", idx+1)
+		}
+		if len(args) == 0 || !strings.EqualFold(strings.TrimSpace(args[0]), "oci") {
+			return fmt.Errorf("command %d rejected: expected oci command", idx+1)
+		}
+
+		_, _ = fmt.Fprintf(opts.Writer, "[maker] running %d/%d: oci %s\n", idx+1, len(plan.Commands), strings.Join(args[1:], " "))
+		out, runErr := runOCICommandStreaming(ctx, client, args[1:], opts.Writer)
+		if runErr != nil {
+			return fmt.Errorf("oracle command %d failed: %w", idx+1, runErr)
+		}
+
+		learnPlanBindingsFromProduces(cmdSpec.Produces, out, bindings)
+	}
+
+	return nil
+}
+
+func validateOracleCommand(args []string, allowDestructive bool) error {
+	if len(args) == 0 {
+		return fmt.Errorf("empty args")
+	}
+	first := strings.ToLower(strings.TrimSpace(args[0]))
+	if first != "oci" {
+		blockedCommands := []string{
+			"aws", "gcloud", "az", "kubectl", "helm", "eksctl", "kubeadm",
+			"python", "node", "npm", "npx",
+			"bash", "sh", "zsh", "fish",
+			"terraform", "tofu", "make",
+			"wrangler", "cloudflared", "curl",
+			"doctl", "hcloud",
+		}
+		for _, blocked := range blockedCommands {
+			if first == blocked || strings.HasPrefix(first, blocked) {
+				return fmt.Errorf("non-oci command is not allowed: %q", args[0])
+			}
+		}
+		return fmt.Errorf("non-oci command is not allowed: %q", args[0])
+	}
+
+	for _, a := range args {
+		lower := strings.ToLower(a)
+		if strings.Contains(lower, ";") || strings.Contains(lower, "|") || strings.Contains(lower, "&&") || strings.Contains(lower, "||") {
+			return fmt.Errorf("shell operators are not allowed")
+		}
+		if !allowDestructive {
+			for _, verb := range []string{"delete", "remove", "terminate", "destroy"} {
+				if strings.Contains(lower, verb) {
+					return fmt.Errorf("destructive operation blocked (use --destroyer to allow): %s", a)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func runOCICommandStreaming(ctx context.Context, client *oracle.Client, args []string, w io.Writer) (string, error) {
+	out, err := client.RunOCI(ctx, args...)
+	if strings.TrimSpace(out) != "" {
+		_, _ = fmt.Fprint(w, out)
+		if !strings.HasSuffix(out, "\n") {
+			_, _ = fmt.Fprintln(w)
+		}
+	}
+	return out, err
+}

--- a/internal/maker/exec_oracle_test.go
+++ b/internal/maker/exec_oracle_test.go
@@ -1,0 +1,21 @@
+package maker
+
+import "testing"
+
+func TestValidateOracleCommand(t *testing.T) {
+	if err := validateOracleCommand([]string{"oci", "compute", "instance", "list", "--compartment-id", "ocid1.compartment.oc1..x"}, false); err != nil {
+		t.Fatalf("valid list command rejected: %v", err)
+	}
+	if err := validateOracleCommand([]string{"aws", "ec2", "describe-instances"}, false); err == nil {
+		t.Fatal("expected non-oci command to be rejected")
+	}
+	if err := validateOracleCommand([]string{"oci", "compute", "instance", "terminate", "--instance-id", "ocid1.instance.oc1..x"}, false); err == nil {
+		t.Fatal("expected destructive command to be rejected without destroyer")
+	}
+	if err := validateOracleCommand([]string{"oci", "compute", "instance", "terminate", "--instance-id", "ocid1.instance.oc1..x"}, true); err != nil {
+		t.Fatalf("destructive command with destroyer rejected: %v", err)
+	}
+	if err := validateOracleCommand([]string{"oci", "compute", "instance", "list", "&&", "echo", "bad"}, true); err == nil {
+		t.Fatal("expected shell operator to be rejected")
+	}
+}

--- a/internal/maker/oracle_prompts.go
+++ b/internal/maker/oracle_prompts.go
@@ -1,0 +1,127 @@
+package maker
+
+import "fmt"
+
+func OraclePlanPrompt(question string) string {
+	return OraclePlanPromptWithMode(question, false)
+}
+
+func OraclePlanPromptWithMode(question string, destroyer bool) string {
+	destructiveRule := "- Avoid any destructive operations (delete/remove/terminate/destroy)."
+	if destroyer {
+		destructiveRule = "- Destructive operations are allowed ONLY if the user explicitly asked for deletion."
+	}
+
+	return fmt.Sprintf(`You are an infrastructure maker planner for Oracle Cloud Infrastructure (OCI).
+
+Your job: produce a concrete, minimal OCI CLI execution plan to satisfy the user request.
+
+Constraints:
+- Output ONLY valid JSON.
+- Use this schema exactly:
+{
+  "version": 1,
+  "createdAt": "RFC3339 timestamp",
+  "provider": "oracle",
+  "question": "original user question",
+  "summary": "short summary of what will be created/changed",
+  "commands": [
+    {
+      "args": ["oci", "service", "resource", "action", "..."],
+      "reason": "why this command is needed",
+      "produces": {
+        "OPTIONAL_BINDING_NAME": "$.data.id"
+      }
+    }
+  ],
+  "notes": ["optional notes"]
+}
+
+Rules for commands:
+- The "commands" array MUST contain at least 1 command.
+- Provide args as an array; do NOT provide a single string.
+- Commands MUST be OCI CLI only. Every command args MUST start with "oci".
+- Do NOT include any non-oci programs (no aws/gcloud/az/doctl/hcloud/python/node/bash/curl/terraform/etc).
+- Do NOT include shell operators, pipes, redirects, or subshells.
+- Prefer idempotent read-before-write operations where possible.
+- Add "--output", "json" to commands whose output should feed later bindings.
+- If a command operates in a compartment, include "--compartment-id", "<COMPARTMENT_OCID>" unless an earlier command produces that value.
+- If Object Storage bucket commands are needed, first resolve the namespace with ["oci","os","ns","get","--output","json"].
+- If the user request is ambiguous or missing required details, output a DISCOVERY-ONLY plan:
+  - Still output a NON-EMPTY commands array.
+  - Use READ-ONLY commands to gather missing inputs.
+
+%s
+
+Placeholders and bindings:
+- You MAY use placeholder tokens like "<COMPARTMENT_OCID>", "<VCN_ID>", "<SUBNET_ID>", "<INSTANCE_ID>", or "<NAMESPACE>".
+- If you use ANY placeholder other than "<COMPARTMENT_OCID>", ensure an earlier command includes "produces" mapping when feasible.
+- OCI CLI JSON responses usually put payloads under $.data. Use "$.data.id" for create responses and "$.data[0].id" for first list item.
+
+Common OCI operations:
+
+List accessible compartments:
+{
+  "args": ["oci", "iam", "compartment", "list", "--access-level", "ACCESSIBLE", "--compartment-id", "<TENANCY_OCID>", "--compartment-id-in-subtree", "true", "--all", "--output", "json"],
+  "reason": "Discover accessible OCI compartments",
+  "produces": { "COMPARTMENT_OCID": "$.data[0].id" }
+}
+
+List compute instances:
+{
+  "args": ["oci", "compute", "instance", "list", "--compartment-id", "<COMPARTMENT_OCID>", "--all", "--output", "json"],
+  "reason": "List OCI compute instances"
+}
+
+Create a VCN:
+{
+  "args": ["oci", "network", "vcn", "create", "--compartment-id", "<COMPARTMENT_OCID>", "--cidr-block", "10.0.0.0/16", "--display-name", "clanker-vcn", "--output", "json"],
+  "reason": "Create a virtual cloud network",
+  "produces": { "VCN_ID": "$.data.id" }
+}
+
+Create a subnet:
+{
+  "args": ["oci", "network", "subnet", "create", "--compartment-id", "<COMPARTMENT_OCID>", "--vcn-id", "<VCN_ID>", "--cidr-block", "10.0.1.0/24", "--display-name", "clanker-subnet", "--output", "json"],
+  "reason": "Create a subnet in the VCN",
+  "produces": { "SUBNET_ID": "$.data.id" }
+}
+
+List shapes and images before launching compute:
+{
+  "args": ["oci", "compute", "shape", "list", "--compartment-id", "<COMPARTMENT_OCID>", "--all", "--output", "json"],
+  "reason": "Find valid compute shapes"
+}
+{
+  "args": ["oci", "compute", "image", "list", "--compartment-id", "<COMPARTMENT_OCID>", "--operating-system", "Canonical Ubuntu", "--all", "--output", "json"],
+  "reason": "Find an Ubuntu image OCID"
+}
+
+Launch a compute instance:
+{
+  "args": ["oci", "compute", "instance", "launch", "--compartment-id", "<COMPARTMENT_OCID>", "--availability-domain", "<AVAILABILITY_DOMAIN>", "--shape", "VM.Standard.E4.Flex", "--subnet-id", "<SUBNET_ID>", "--image-id", "<IMAGE_OCID>", "--display-name", "clanker-instance", "--output", "json"],
+  "reason": "Launch an OCI compute instance",
+  "produces": { "INSTANCE_ID": "$.data.id" }
+}
+
+Object Storage bucket:
+{
+  "args": ["oci", "os", "ns", "get", "--output", "json"],
+  "reason": "Resolve the tenancy Object Storage namespace",
+  "produces": { "NAMESPACE": "$.data" }
+}
+{
+  "args": ["oci", "os", "bucket", "create", "--namespace-name", "<NAMESPACE>", "--compartment-id", "<COMPARTMENT_OCID>", "--name", "clanker-bucket", "--output", "json"],
+  "reason": "Create an Object Storage bucket",
+  "produces": { "BUCKET_NAME": "$.data.name" }
+}
+
+OKE clusters:
+{
+  "args": ["oci", "ce", "cluster", "list", "--compartment-id", "<COMPARTMENT_OCID>", "--all", "--output", "json"],
+  "reason": "List Oracle Kubernetes Engine clusters"
+}
+
+User request:
+%q`, destructiveRule, question)
+}

--- a/internal/maker/plan.go
+++ b/internal/maker/plan.go
@@ -168,6 +168,8 @@ func inferProviderFromCommands(cmds []Command) string {
 			return "cloudflare"
 		case "hcloud":
 			return "hetzner"
+		case "oci":
+			return "oracle"
 		case "doctl":
 			return "digitalocean"
 		case "gcloud":

--- a/internal/onboarding/onboarding.go
+++ b/internal/onboarding/onboarding.go
@@ -205,6 +205,19 @@ func Guides() map[string]ToolGuide {
 			},
 			DocsURL: "https://github.com/hetznercloud/cli",
 		},
+		"oci": {
+			ID:            "oci",
+			Tool:          "Oracle Cloud Infrastructure CLI",
+			Binary:        "oci",
+			Providers:     []string{"Oracle Cloud", "OCI", "OKE"},
+			VerifyCommand: "oci --version",
+			InstallCommands: map[string][]string{
+				"darwin":  {"bash -c \"$(curl -L https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh)\""},
+				"linux":   {"bash -c \"$(curl -L https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh)\""},
+				"windows": {"python -m pip install oci-cli"},
+			},
+			DocsURL: "https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/cliinstall.htm",
+		},
 		"kubectl": {
 			ID:            "kubectl",
 			Tool:          "kubectl",
@@ -564,6 +577,16 @@ func AuthGuides() map[string]AuthGuide {
 			EnvVars:       []string{"HCLOUD_TOKEN", "HETZNER_API_TOKEN"},
 			DocsURL:       "https://github.com/hetznercloud/cli",
 		},
+		"oracle": {
+			ID:            "oracle",
+			Provider:      "Oracle Cloud Infrastructure",
+			Purpose:       "Configure an OCI CLI profile with an API signing key, then provide the tenancy or compartment OCID Clanker should inspect.",
+			LoginCommands: []string{"oci setup config", "oci iam compartment list --access-level ACCESSIBLE --compartment-id <tenancy-ocid> --compartment-id-in-subtree true --all"},
+			EnvVars:       []string{"OCI_CLI_PROFILE", "OCI_CLI_CONFIG_FILE", "OCI_TENANCY_OCID", "OCI_COMPARTMENT_ID"},
+			DocsURL:       "https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/cliconfigure.htm",
+			TokenURL:      "https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm",
+			Notes:         []string{"Clanker uses local OCI CLI profiles; do not paste OCI private keys into chat."},
+		},
 		"kubernetes": {
 			ID:            "kubernetes",
 			Provider:      "Kubernetes",
@@ -788,6 +811,16 @@ func providerGuides() []providerGuide {
 			}
 			return len(notes) > 0, len(notes) > 0, notes
 		}},
+		{ID: "oracle", Name: "Oracle Cloud", RequiredTools: []string{"oci"}, Detect: func() (bool, bool, []string) {
+			notes := []string{}
+			if hasAnyEnv("OCI_CLI_PROFILE", "OCI_CLI_CONFIG_FILE", "OCI_TENANCY_OCID", "OCI_TENANCY_ID", "OCI_COMPARTMENT_ID") {
+				notes = append(notes, "oracle env")
+			}
+			if fileExists(homePath(".oci", "config")) {
+				notes = append(notes, "oci config")
+			}
+			return len(notes) > 0, len(notes) > 0, notes
+		}},
 		{ID: "kubernetes", Name: "Kubernetes", RequiredTools: []string{"kubectl"}, Detect: func() (bool, bool, []string) {
 			notes := []string{}
 			if hasAnyEnv("KUBECONFIG") {
@@ -958,6 +991,8 @@ func normalizeToolID(raw string) string {
 		return "doctl"
 	case "hetzner":
 		return "hcloud"
+	case "oracle", "oracle cloud", "oracle-cloud", "oracle cloud infrastructure", "oracle-cloud-infrastructure", "oci-cli":
+		return "oci"
 	case "railway":
 		return "railway"
 	case "supabase":

--- a/internal/onboarding/onboarding_test.go
+++ b/internal/onboarding/onboarding_test.go
@@ -7,9 +7,9 @@ import (
 )
 
 func TestScanIncludesOfficialAuthGuides(t *testing.T) {
-	result := Scan(context.Background(), ScanOptions{WantedProviders: []string{"aws", "gcp", "azure", "railway", "supabase", "flyio", "tencent", "verda", "sentry", "linear", "notion"}})
+	result := Scan(context.Background(), ScanOptions{WantedProviders: []string{"aws", "gcp", "azure", "oracle", "railway", "supabase", "flyio", "tencent", "verda", "sentry", "linear", "notion"}})
 
-	for _, id := range []string{"aws", "gcp", "azure", "railway", "supabase", "flyio", "tencent", "verda", "sentry", "linear", "notion"} {
+	for _, id := range []string{"aws", "gcp", "azure", "oracle", "railway", "supabase", "flyio", "tencent", "verda", "sentry", "linear", "notion"} {
 		guide, ok := result.AuthGuides[id]
 		if !ok {
 			t.Fatalf("missing auth guide for %s", id)
@@ -44,6 +44,7 @@ func TestGuidesPreferOfficialVendorDocs(t *testing.T) {
 		"gcloud":     "https://docs.cloud.google.com/",
 		"az":         "https://learn.microsoft.com/",
 		"doctl":      "https://docs.digitalocean.com/",
+		"oci":        "https://docs.oracle.com/",
 		"railway":    "https://docs.railway.com/",
 		"supabase":   "https://supabase.com/docs/",
 		"flyctl":     "https://fly.io/docs/",
@@ -66,7 +67,7 @@ func TestProviderGuidesRequireOfficialTencentAndSentryCLIs(t *testing.T) {
 	for _, guide := range providerGuides() {
 		found[guide.ID] = guide.RequiredTools
 	}
-	for id, want := range map[string]string{"tencent": "tccli", "sentry": "sentry-cli"} {
+	for id, want := range map[string]string{"oracle": "oci", "tencent": "tccli", "sentry": "sentry-cli"} {
 		tools := found[id]
 		if len(tools) != 1 || tools[0] != want {
 			t.Fatalf("%s required tools = %#v, want [%s]", id, tools, want)
@@ -74,6 +75,9 @@ func TestProviderGuidesRequireOfficialTencentAndSentryCLIs(t *testing.T) {
 	}
 	if normalizeToolID("tencent cloud") != "tccli" {
 		t.Fatal("tencent cloud alias did not normalize to tccli")
+	}
+	if normalizeToolID("oracle cloud infrastructure") != "oci" {
+		t.Fatal("oracle cloud infrastructure alias did not normalize to oci")
 	}
 	if normalizeToolID("sentry") != "sentry-cli" {
 		t.Fatal("sentry alias did not normalize to sentry-cli")

--- a/internal/oracle/client.go
+++ b/internal/oracle/client.go
@@ -1,0 +1,367 @@
+package oracle
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+const defaultProfile = "DEFAULT"
+
+// Client wraps the official Oracle Cloud Infrastructure CLI.
+type Client struct {
+	profile       string
+	compartmentID string
+	tenancyOCID   string
+	debug         bool
+}
+
+type ConfigProfile struct {
+	Name        string
+	TenancyOCID string
+	UserOCID    string
+	Fingerprint string
+	KeyFile     string
+	Region      string
+}
+
+func CLIInstalled() bool {
+	_, err := exec.LookPath("oci")
+	return err == nil
+}
+
+func ResolveProfile() string {
+	if profile := strings.TrimSpace(viper.GetString("oracle.profile")); profile != "" {
+		return profile
+	}
+	if profile := strings.TrimSpace(os.Getenv("OCI_CLI_PROFILE")); profile != "" {
+		return profile
+	}
+	return defaultProfile
+}
+
+func ResolveCompartmentID() string {
+	for _, value := range []string{
+		viper.GetString("oracle.compartment_id"),
+		os.Getenv("OCI_COMPARTMENT_ID"),
+		os.Getenv("OCI_TENANCY_OCID"),
+		os.Getenv("OCI_TENANCY_ID"),
+	} {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func ResolveTenancyOCID(profile string) string {
+	for _, value := range []string{
+		viper.GetString("oracle.tenancy_ocid"),
+		viper.GetString("oracle.tenancy_id"),
+		os.Getenv("OCI_TENANCY_OCID"),
+		os.Getenv("OCI_TENANCY_ID"),
+	} {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	if cfg, ok := ReadConfigProfile(profile); ok {
+		return cfg.TenancyOCID
+	}
+	return ""
+}
+
+func NewClient(profile, compartmentID, tenancyOCID string, debug bool) (*Client, error) {
+	if !CLIInstalled() {
+		return nil, fmt.Errorf("oci CLI not found in PATH (install from https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/cliinstall.htm)")
+	}
+	profile = strings.TrimSpace(profile)
+	if profile == "" {
+		profile = ResolveProfile()
+	}
+	compartmentID = strings.TrimSpace(compartmentID)
+	if compartmentID == "" {
+		compartmentID = ResolveCompartmentID()
+	}
+	tenancyOCID = strings.TrimSpace(tenancyOCID)
+	if tenancyOCID == "" {
+		tenancyOCID = ResolveTenancyOCID(profile)
+	}
+	if compartmentID == "" {
+		compartmentID = tenancyOCID
+	}
+	return &Client{
+		profile:       profile,
+		compartmentID: compartmentID,
+		tenancyOCID:   tenancyOCID,
+		debug:         debug,
+	}, nil
+}
+
+func (c *Client) Profile() string {
+	return c.profile
+}
+
+func (c *Client) CompartmentID() string {
+	return c.compartmentID
+}
+
+func (c *Client) TenancyOCID() string {
+	return c.tenancyOCID
+}
+
+func (c *Client) RunOCI(ctx context.Context, args ...string) (string, error) {
+	fullArgs := []string{}
+	if strings.TrimSpace(c.profile) != "" {
+		fullArgs = append(fullArgs, "--profile", c.profile)
+	}
+	fullArgs = append(fullArgs, args...)
+	if !hasFlag(fullArgs, "--output") {
+		fullArgs = append(fullArgs, "--output", "json")
+	}
+
+	backoffs := []time.Duration{200 * time.Millisecond, 500 * time.Millisecond, 1200 * time.Millisecond}
+	var lastErr error
+	var lastStderr string
+	for attempt := 0; attempt < len(backoffs); attempt++ {
+		cmd := exec.CommandContext(ctx, "oci", fullArgs...)
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		if c.debug {
+			fmt.Printf("[oracle] oci %s\n", strings.Join(args, " "))
+		}
+		err := cmd.Run()
+		if err == nil {
+			return stdout.String(), nil
+		}
+		lastErr = err
+		lastStderr = strings.TrimSpace(stderr.String())
+		if ctx.Err() != nil || !isRetryableOCIError(lastStderr) {
+			break
+		}
+		time.Sleep(backoffs[attempt])
+	}
+	if lastErr == nil {
+		return "", fmt.Errorf("oci command failed")
+	}
+	return "", fmt.Errorf("oci command failed: %w, stderr: %s%s", lastErr, lastStderr, ociErrorHint(lastStderr))
+}
+
+func (c *Client) GetRelevantContext(ctx context.Context, question string) (string, error) {
+	questionLower := strings.ToLower(strings.TrimSpace(question))
+	resources := resourcesForQuestion(questionLower)
+	if len(resources) == 0 {
+		resources = []string{"compartments", "instances", "vcns", "subnets", "load-balancers", "buckets", "oke-clusters", "databases"}
+	}
+
+	var out strings.Builder
+	var warnings []string
+	for _, resource := range resources {
+		result, err := c.ListResource(ctx, resource)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("%s: %v", resource, err))
+			continue
+		}
+		if len(result.Data) == 0 && strings.TrimSpace(result.Raw) == "" {
+			continue
+		}
+		out.WriteString(result.Title)
+		out.WriteString(":\n")
+		if len(result.Data) > 0 {
+			body, _ := json.MarshalIndent(map[string]any{"data": result.Data}, "", "  ")
+			out.Write(body)
+		} else {
+			out.WriteString(result.Raw)
+		}
+		out.WriteString("\n")
+	}
+	if len(warnings) > 0 {
+		out.WriteString("Oracle Cloud Warnings:\n")
+		for i, warn := range warnings {
+			if i >= 8 {
+				out.WriteString("- (additional warnings omitted)\n")
+				break
+			}
+			out.WriteString("- ")
+			out.WriteString(warn)
+			out.WriteString("\n")
+		}
+	}
+	if strings.TrimSpace(out.String()) == "" {
+		return "No Oracle Cloud Infrastructure data available (missing OCI CLI profile, permissions, compartments, or resources).", nil
+	}
+	return out.String(), nil
+}
+
+func resourcesForQuestion(questionLower string) []string {
+	if questionLower == "" {
+		return nil
+	}
+	var resources []string
+	for _, def := range resourceDefinitions {
+		for _, key := range def.Keys {
+			if strings.Contains(questionLower, key) {
+				resources = append(resources, def.Name)
+				break
+			}
+		}
+	}
+	return uniqueSorted(resources)
+}
+
+func hasFlag(args []string, flag string) bool {
+	for _, arg := range args {
+		if strings.EqualFold(strings.TrimSpace(arg), flag) {
+			return true
+		}
+	}
+	return false
+}
+
+func isRetryableOCIError(stderr string) bool {
+	lower := strings.ToLower(stderr)
+	return strings.Contains(lower, "429") ||
+		strings.Contains(lower, "too many requests") ||
+		(strings.Contains(lower, "rate") && strings.Contains(lower, "limit")) ||
+		strings.Contains(lower, "timeout") ||
+		strings.Contains(lower, "timed out") ||
+		strings.Contains(lower, "temporarily unavailable") ||
+		strings.Contains(lower, "internal server error") ||
+		strings.Contains(lower, "connection reset") ||
+		strings.Contains(lower, "connection refused")
+}
+
+func ociErrorHint(stderr string) string {
+	lower := strings.ToLower(stderr)
+	switch {
+	case strings.Contains(lower, "not authenticated") || strings.Contains(lower, "auth") || strings.Contains(lower, "401"):
+		return " (hint: run `oci setup config`, check OCI_CLI_PROFILE, and verify the API signing key/fingerprint)"
+	case strings.Contains(lower, "notauthorizedornotfound") || strings.Contains(lower, "not authorized") || strings.Contains(lower, "403"):
+		return " (hint: the OCI principal needs inspect/read permissions for the target compartment)"
+	case strings.Contains(lower, "compartment"):
+		return " (hint: pass --compartment-id or configure oracle.compartment_id / OCI_COMPARTMENT_ID)"
+	case strings.Contains(lower, "config") || strings.Contains(lower, ".oci"):
+		return " (hint: create ~/.oci/config with `oci setup config` or set OCI_CLI_CONFIG_FILE)"
+	default:
+		return ""
+	}
+}
+
+func configPath() string {
+	if path := strings.TrimSpace(os.Getenv("OCI_CLI_CONFIG_FILE")); path != "" {
+		return path
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".oci", "config")
+}
+
+func ReadConfigProfile(profile string) (ConfigProfile, bool) {
+	profile = strings.TrimSpace(profile)
+	if profile == "" {
+		profile = defaultProfile
+	}
+	path := configPath()
+	if path == "" {
+		return ConfigProfile{}, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ConfigProfile{}, false
+	}
+	current := ""
+	values := map[string]map[string]string{}
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, ";") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "[") && strings.Contains(trimmed, "]") {
+			current = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "["), "]"))
+			if current != "" && values[current] == nil {
+				values[current] = map[string]string{}
+			}
+			continue
+		}
+		if current == "" {
+			continue
+		}
+		parts := strings.SplitN(trimmed, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.ToLower(strings.TrimSpace(parts[0]))
+		value := strings.TrimSpace(parts[1])
+		values[current][key] = value
+	}
+	v, ok := values[profile]
+	if !ok {
+		return ConfigProfile{}, false
+	}
+	return ConfigProfile{
+		Name:        profile,
+		TenancyOCID: v["tenancy"],
+		UserOCID:    v["user"],
+		Fingerprint: v["fingerprint"],
+		KeyFile:     v["key_file"],
+		Region:      v["region"],
+	}, true
+}
+
+func ConfigProfiles() []ConfigProfile {
+	path := configPath()
+	if path == "" {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	names := []string{}
+	seen := map[string]bool{}
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") && strings.Contains(trimmed, "]") {
+			name := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "["), "]"))
+			if name != "" && !seen[name] {
+				seen[name] = true
+				names = append(names, name)
+			}
+		}
+	}
+	sort.Strings(names)
+	profiles := make([]ConfigProfile, 0, len(names))
+	for _, name := range names {
+		if cfg, ok := ReadConfigProfile(name); ok {
+			profiles = append(profiles, cfg)
+		}
+	}
+	return profiles
+}
+
+func uniqueSorted(in []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(in))
+	for _, value := range in {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/oracle/client_test.go
+++ b/internal/oracle/client_test.go
@@ -1,0 +1,51 @@
+package oracle
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadConfigProfileUsesOCIConfigFile(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config")
+	if err := os.WriteFile(configPath, []byte(`[DEFAULT]
+user=ocid1.user.oc1..default
+fingerprint=aa:bb
+key_file=/tmp/default.pem
+tenancy=ocid1.tenancy.oc1..default
+region=us-ashburn-1
+
+[WORK]
+user=ocid1.user.oc1..work
+fingerprint=cc:dd
+key_file=/tmp/work.pem
+tenancy=ocid1.tenancy.oc1..work
+region=eu-frankfurt-1
+`), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	t.Setenv("OCI_CLI_CONFIG_FILE", configPath)
+
+	cfg, ok := ReadConfigProfile("WORK")
+	if !ok {
+		t.Fatal("expected WORK profile")
+	}
+	if cfg.Name != "WORK" {
+		t.Fatalf("Name = %q, want WORK", cfg.Name)
+	}
+	if cfg.TenancyOCID != "ocid1.tenancy.oc1..work" {
+		t.Fatalf("TenancyOCID = %q", cfg.TenancyOCID)
+	}
+	if cfg.Region != "eu-frankfurt-1" {
+		t.Fatalf("Region = %q", cfg.Region)
+	}
+
+	profiles := ConfigProfiles()
+	if len(profiles) != 2 {
+		t.Fatalf("profiles len = %d, want 2: %+v", len(profiles), profiles)
+	}
+	if profiles[0].Name != "DEFAULT" || profiles[1].Name != "WORK" {
+		t.Fatalf("profiles sorted names = %+v", profiles)
+	}
+}

--- a/internal/oracle/static_commands.go
+++ b/internal/oracle/static_commands.go
@@ -1,0 +1,288 @@
+package oracle
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type ResourceDefinition struct {
+	Name             string
+	Title            string
+	Aliases          []string
+	Args             []string
+	Scope            string
+	Keys             []string
+	NeedsNamespace   bool
+	NeedsCompartment bool
+}
+
+type ListResult struct {
+	Title    string           `json:"title"`
+	Resource string           `json:"resource"`
+	Data     []map[string]any `json:"data,omitempty"`
+	Raw      string           `json:"raw,omitempty"`
+	Warnings []string         `json:"warnings,omitempty"`
+}
+
+const (
+	scopeTenancy     = "tenancy"
+	scopeCompartment = "compartment"
+)
+
+var resourceDefinitions = []ResourceDefinition{
+	{Name: "compartments", Title: "Oracle Cloud Compartments", Aliases: []string{"compartment"}, Scope: scopeTenancy, Args: []string{"iam", "compartment", "list", "--access-level", "ACCESSIBLE", "--compartment-id-in-subtree", "true", "--all"}, Keys: []string{"compartment", "compartments", "tenancy"}},
+	{Name: "instances", Title: "Oracle Cloud Compute Instances", Aliases: []string{"instance", "compute", "vms", "vm"}, Scope: scopeCompartment, Args: []string{"compute", "instance", "list", "--all"}, Keys: []string{"instance", "instances", "compute", "vm", "virtual machine"}},
+	{Name: "instance-pools", Title: "Oracle Cloud Instance Pools", Aliases: []string{"instance-pool", "pools"}, Scope: scopeCompartment, Args: []string{"compute-management", "instance-pool", "list", "--all"}, Keys: []string{"instance pool", "instance pools", "autoscale", "autoscaling"}},
+	{Name: "images", Title: "Oracle Cloud Compute Images", Aliases: []string{"image"}, Scope: scopeCompartment, Args: []string{"compute", "image", "list", "--all"}, Keys: []string{"image", "images", "custom image"}},
+	{Name: "boot-volumes", Title: "Oracle Cloud Boot Volumes", Aliases: []string{"boot-volume"}, Scope: scopeCompartment, Args: []string{"bv", "boot-volume", "list", "--all"}, Keys: []string{"boot volume", "boot volumes"}},
+	{Name: "volumes", Title: "Oracle Cloud Block Volumes", Aliases: []string{"volume", "block-volumes", "block-volume"}, Scope: scopeCompartment, Args: []string{"bv", "volume", "list", "--all"}, Keys: []string{"volume", "volumes", "block volume", "block storage", "disk"}},
+	{Name: "volume-backups", Title: "Oracle Cloud Volume Backups", Aliases: []string{"volume-backup", "backups"}, Scope: scopeCompartment, Args: []string{"bv", "backup", "list", "--all"}, Keys: []string{"volume backup", "volume backups", "backup", "backups"}},
+	{Name: "vcns", Title: "Oracle Cloud VCNs", Aliases: []string{"vcn", "networks", "network"}, Scope: scopeCompartment, Args: []string{"network", "vcn", "list", "--all"}, Keys: []string{"vcn", "vcns", "network", "networks", "virtual cloud network"}},
+	{Name: "subnets", Title: "Oracle Cloud Subnets", Aliases: []string{"subnet"}, Scope: scopeCompartment, Args: []string{"network", "subnet", "list", "--all"}, Keys: []string{"subnet", "subnets"}},
+	{Name: "route-tables", Title: "Oracle Cloud Route Tables", Aliases: []string{"route-table", "routes"}, Scope: scopeCompartment, Args: []string{"network", "route-table", "list", "--all"}, Keys: []string{"route table", "route tables", "routes"}},
+	{Name: "security-lists", Title: "Oracle Cloud Security Lists", Aliases: []string{"security-list"}, Scope: scopeCompartment, Args: []string{"network", "security-list", "list", "--all"}, Keys: []string{"security list", "security lists"}},
+	{Name: "nsgs", Title: "Oracle Cloud Network Security Groups", Aliases: []string{"nsg", "network-security-groups", "network-security-group"}, Scope: scopeCompartment, Args: []string{"network", "nsg", "list", "--all"}, Keys: []string{"nsg", "network security group", "network security groups"}},
+	{Name: "internet-gateways", Title: "Oracle Cloud Internet Gateways", Aliases: []string{"internet-gateway", "igw"}, Scope: scopeCompartment, Args: []string{"network", "internet-gateway", "list", "--all"}, Keys: []string{"internet gateway", "internet gateways", "igw"}},
+	{Name: "nat-gateways", Title: "Oracle Cloud NAT Gateways", Aliases: []string{"nat-gateway"}, Scope: scopeCompartment, Args: []string{"network", "nat-gateway", "list", "--all"}, Keys: []string{"nat gateway", "nat gateways"}},
+	{Name: "service-gateways", Title: "Oracle Cloud Service Gateways", Aliases: []string{"service-gateway"}, Scope: scopeCompartment, Args: []string{"network", "service-gateway", "list", "--all"}, Keys: []string{"service gateway", "service gateways"}},
+	{Name: "load-balancers", Title: "Oracle Cloud Load Balancers", Aliases: []string{"load-balancer", "lbs", "lb"}, Scope: scopeCompartment, Args: []string{"lb", "load-balancer", "list", "--all"}, Keys: []string{"load balancer", "load balancers", "lb", "lbs"}},
+	{Name: "network-load-balancers", Title: "Oracle Cloud Network Load Balancers", Aliases: []string{"network-load-balancer", "nlbs", "nlb"}, Scope: scopeCompartment, Args: []string{"nlb", "network-load-balancer", "list", "--all"}, Keys: []string{"network load balancer", "network load balancers", "nlb", "nlbs"}},
+	{Name: "buckets", Title: "Oracle Cloud Object Storage Buckets", Aliases: []string{"bucket", "object-storage"}, Scope: scopeCompartment, Args: []string{"os", "bucket", "list", "--all"}, Keys: []string{"bucket", "buckets", "object storage"}, NeedsNamespace: true},
+	{Name: "file-systems", Title: "Oracle Cloud File Systems", Aliases: []string{"file-system", "fss"}, Scope: scopeCompartment, Args: []string{"fs", "file-system", "list", "--all"}, Keys: []string{"file system", "file systems", "fss", "filesystem"}},
+	{Name: "mount-targets", Title: "Oracle Cloud Mount Targets", Aliases: []string{"mount-target"}, Scope: scopeCompartment, Args: []string{"fs", "mount-target", "list", "--all"}, Keys: []string{"mount target", "mount targets"}},
+	{Name: "databases", Title: "Oracle Cloud DB Systems", Aliases: []string{"db-systems", "db-system", "database"}, Scope: scopeCompartment, Args: []string{"db", "system", "list", "--all"}, Keys: []string{"database", "databases", "db system", "db systems"}},
+	{Name: "autonomous-databases", Title: "Oracle Cloud Autonomous Databases", Aliases: []string{"autonomous-database", "adb"}, Scope: scopeCompartment, Args: []string{"db", "autonomous-database", "list", "--all"}, Keys: []string{"autonomous database", "autonomous databases", "adb"}},
+	{Name: "mysql-systems", Title: "Oracle Cloud MySQL DB Systems", Aliases: []string{"mysql", "mysql-db-systems"}, Scope: scopeCompartment, Args: []string{"mysql", "db-system", "list", "--all"}, Keys: []string{"mysql", "mysql db system", "mysql db systems"}},
+	{Name: "oke-clusters", Title: "Oracle Kubernetes Engine Clusters", Aliases: []string{"oke", "clusters", "cluster", "kubernetes"}, Scope: scopeCompartment, Args: []string{"ce", "cluster", "list", "--all"}, Keys: []string{"oke", "kubernetes", "cluster", "clusters", "container engine"}},
+	{Name: "node-pools", Title: "Oracle Kubernetes Engine Node Pools", Aliases: []string{"node-pool", "oke-node-pools"}, Scope: scopeCompartment, Args: []string{"ce", "node-pool", "list", "--all"}, Keys: []string{"node pool", "node pools"}},
+	{Name: "functions", Title: "Oracle Cloud Functions Applications", Aliases: []string{"fn", "function-apps", "applications"}, Scope: scopeCompartment, Args: []string{"fn", "application", "list", "--all"}, Keys: []string{"function", "functions", "fn", "serverless"}},
+	{Name: "container-repositories", Title: "Oracle Cloud Container Repositories", Aliases: []string{"container-repository", "repos", "repositories", "ocir"}, Scope: scopeCompartment, Args: []string{"artifacts", "container", "repository", "list", "--all"}, Keys: []string{"container repository", "container repositories", "ocir", "registry", "image registry"}},
+	{Name: "api-gateways", Title: "Oracle Cloud API Gateways", Aliases: []string{"api-gateway", "gateways"}, Scope: scopeCompartment, Args: []string{"api-gateway", "gateway", "list", "--all"}, Keys: []string{"api gateway", "api gateways", "gateway", "gateways"}},
+	{Name: "dns-zones", Title: "Oracle Cloud DNS Zones", Aliases: []string{"dns", "zones", "zone"}, Scope: scopeCompartment, Args: []string{"dns", "zone", "list", "--all"}, Keys: []string{"dns", "zone", "zones"}},
+	{Name: "vaults", Title: "Oracle Cloud Vaults", Aliases: []string{"vault"}, Scope: scopeCompartment, Args: []string{"vault", "vault", "list", "--all"}, Keys: []string{"vault", "vaults", "kms"}},
+	{Name: "secrets", Title: "Oracle Cloud Vault Secrets", Aliases: []string{"secret"}, Scope: scopeCompartment, Args: []string{"vault", "secret", "list", "--all"}, Keys: []string{"secret", "secrets"}},
+	{Name: "streams", Title: "Oracle Cloud Streams", Aliases: []string{"stream", "streaming"}, Scope: scopeCompartment, Args: []string{"streaming", "admin", "stream", "list", "--all"}, Keys: []string{"stream", "streams", "streaming"}},
+	{Name: "queues", Title: "Oracle Cloud Queues", Aliases: []string{"queue"}, Scope: scopeCompartment, Args: []string{"queue", "queue-admin", "queue", "list", "--all"}, Keys: []string{"queue", "queues"}},
+	{Name: "alarms", Title: "Oracle Cloud Monitoring Alarms", Aliases: []string{"alarm", "monitoring"}, Scope: scopeCompartment, Args: []string{"monitoring", "alarm", "list", "--all"}, Keys: []string{"alarm", "alarms", "monitoring"}},
+	{Name: "log-groups", Title: "Oracle Cloud Log Groups", Aliases: []string{"log-group", "logs", "logging"}, Scope: scopeCompartment, Args: []string{"logging", "log-group", "list", "--all"}, Keys: []string{"log group", "log groups", "logs", "logging"}},
+	{Name: "events-rules", Title: "Oracle Cloud Events Rules", Aliases: []string{"events", "rules", "event-rules"}, Scope: scopeCompartment, Args: []string{"events", "rule", "list", "--all"}, Keys: []string{"event", "events", "rule", "rules"}},
+}
+
+func CreateOracleCommands() *cobra.Command {
+	oracleCmd := &cobra.Command{
+		Use:     "oracle",
+		Short:   "Query Oracle Cloud Infrastructure directly",
+		Long:    "Query your Oracle Cloud Infrastructure without AI interpretation. Uses the official OCI CLI and local OCI config profiles.",
+		Aliases: []string{"oci"},
+	}
+
+	listCmd := &cobra.Command{
+		Use:   "list [resource]",
+		Short: "List Oracle Cloud resources",
+		Long:  oracleListHelp(),
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			profile, _ := cmd.Flags().GetString("profile")
+			compartmentID, _ := cmd.Flags().GetString("compartment-id")
+			tenancyOCID, _ := cmd.Flags().GetString("tenancy-ocid")
+			client, err := NewClient(profile, compartmentID, tenancyOCID, viper.GetBool("debug"))
+			if err != nil {
+				return err
+			}
+			result, err := client.ListResource(context.Background(), args[0])
+			if err != nil {
+				return err
+			}
+			body, err := json.MarshalIndent(result, "", "  ")
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(body))
+			return nil
+		},
+	}
+	listCmd.Flags().String("profile", "", "OCI CLI profile name (default: oracle.profile, OCI_CLI_PROFILE, or DEFAULT)")
+	listCmd.Flags().String("compartment-id", "", "OCI compartment OCID to query (default: oracle.compartment_id, OCI_COMPARTMENT_ID, or tenancy OCID)")
+	listCmd.Flags().String("tenancy-ocid", "", "OCI tenancy OCID for compartment discovery (default: oracle.tenancy_ocid, OCI_TENANCY_OCID, or ~/.oci/config tenancy)")
+	oracleCmd.AddCommand(listCmd)
+
+	profilesCmd := &cobra.Command{
+		Use:   "profiles",
+		Short: "List local OCI config profiles",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			body, err := json.MarshalIndent(map[string]any{"profiles": ConfigProfiles()}, "", "  ")
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(body))
+			return nil
+		},
+	}
+	oracleCmd.AddCommand(profilesCmd)
+
+	return oracleCmd
+}
+
+func oracleListHelp() string {
+	var b strings.Builder
+	b.WriteString("List Oracle Cloud resources of a specific type.\n\nSupported resources:\n")
+	for _, def := range resourceDefinitions {
+		b.WriteString("  ")
+		b.WriteString(def.Name)
+		if len(def.Aliases) > 0 {
+			b.WriteString(" (aliases: ")
+			b.WriteString(strings.Join(def.Aliases, ", "))
+			b.WriteString(")")
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func lookupResourceDefinition(resource string) (ResourceDefinition, bool) {
+	resource = strings.ToLower(strings.TrimSpace(resource))
+	for _, def := range resourceDefinitions {
+		if resource == def.Name {
+			return def, true
+		}
+		for _, alias := range def.Aliases {
+			if resource == alias {
+				return def, true
+			}
+		}
+	}
+	return ResourceDefinition{}, false
+}
+
+func (c *Client) ListResource(ctx context.Context, resource string) (ListResult, error) {
+	def, ok := lookupResourceDefinition(resource)
+	if !ok {
+		return ListResult{}, fmt.Errorf("unknown Oracle Cloud resource type: %s", strings.TrimSpace(resource))
+	}
+	result := ListResult{Title: def.Title, Resource: def.Name}
+
+	if def.Scope == scopeTenancy {
+		tenancyID := strings.TrimSpace(c.tenancyOCID)
+		if tenancyID == "" {
+			tenancyID = strings.TrimSpace(c.compartmentID)
+		}
+		if tenancyID == "" {
+			return result, fmt.Errorf("Oracle tenancy OCID is required for %s (set oracle.tenancy_ocid, OCI_TENANCY_OCID, or configure ~/.oci/config)", def.Name)
+		}
+		args := append([]string{}, def.Args...)
+		args = append(args, "--compartment-id", tenancyID)
+		raw, err := c.RunOCI(ctx, args...)
+		if err != nil {
+			return result, err
+		}
+		result.Raw = raw
+		result.Data = parseOCIDataArray(raw, "")
+		return result, nil
+	}
+
+	compartments, warnings := c.compartments(ctx)
+	result.Warnings = append(result.Warnings, warnings...)
+	namespace := ""
+	if def.NeedsNamespace {
+		ns, err := c.objectStorageNamespace(ctx)
+		if err != nil {
+			return result, err
+		}
+		namespace = ns
+	}
+
+	for _, compartmentID := range compartments {
+		args := append([]string{}, def.Args...)
+		if def.NeedsCompartment || def.Scope == scopeCompartment {
+			args = append(args, "--compartment-id", compartmentID)
+		}
+		if def.NeedsNamespace {
+			args = append(args, "--namespace-name", namespace)
+		}
+		raw, err := c.RunOCI(ctx, args...)
+		if err != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("%s in %s: %v", def.Name, shortOCID(compartmentID), err))
+			continue
+		}
+		result.Data = append(result.Data, parseOCIDataArray(raw, compartmentID)...)
+		if strings.TrimSpace(result.Raw) == "" {
+			result.Raw = raw
+		}
+	}
+	return result, nil
+}
+
+func (c *Client) compartments(ctx context.Context) ([]string, []string) {
+	if compartmentID := strings.TrimSpace(c.compartmentID); compartmentID != "" && compartmentID != strings.TrimSpace(c.tenancyOCID) {
+		return []string{compartmentID}, nil
+	}
+	tenancyID := strings.TrimSpace(c.tenancyOCID)
+	if tenancyID == "" {
+		tenancyID = strings.TrimSpace(c.compartmentID)
+	}
+	if tenancyID == "" {
+		return nil, []string{"missing tenancy OCID; set --compartment-id or oracle.tenancy_ocid/OCI_TENANCY_OCID"}
+	}
+	ids := []string{tenancyID}
+	raw, err := c.RunOCI(ctx, "iam", "compartment", "list", "--compartment-id", tenancyID, "--access-level", "ACCESSIBLE", "--compartment-id-in-subtree", "true", "--all", "--lifecycle-state", "ACTIVE")
+	if err != nil {
+		return ids, []string{fmt.Sprintf("could not list child compartments: %v", err)}
+	}
+	for _, item := range parseOCIDataArray(raw, "") {
+		if id := stringValue(item, "id"); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return uniqueSorted(ids), nil
+}
+
+func (c *Client) objectStorageNamespace(ctx context.Context) (string, error) {
+	raw, err := c.RunOCI(ctx, "os", "ns", "get")
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve OCI Object Storage namespace: %w", err)
+	}
+	var payload struct {
+		Data string `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(raw), &payload); err == nil && strings.TrimSpace(payload.Data) != "" {
+		return strings.TrimSpace(payload.Data), nil
+	}
+	return "", fmt.Errorf("failed to parse OCI Object Storage namespace")
+}
+
+func parseOCIDataArray(raw string, compartmentID string) []map[string]any {
+	var payload struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return nil
+	}
+	items := make([]map[string]any, 0, len(payload.Data))
+	for _, item := range payload.Data {
+		if strings.TrimSpace(compartmentID) != "" {
+			item["compartmentId"] = compartmentID
+		}
+		items = append(items, item)
+	}
+	return items
+}
+
+func stringValue(m map[string]any, key string) string {
+	if value, ok := m[key]; ok {
+		return strings.TrimSpace(fmt.Sprint(value))
+	}
+	return ""
+}
+
+func shortOCID(id string) string {
+	id = strings.TrimSpace(id)
+	if len(id) <= 18 {
+		return id
+	}
+	return id[:18] + "..."
+}

--- a/internal/oracle/static_commands_test.go
+++ b/internal/oracle/static_commands_test.go
@@ -1,0 +1,32 @@
+package oracle
+
+import "testing"
+
+func TestLookupResourceDefinitionAliases(t *testing.T) {
+	def, ok := lookupResourceDefinition("oke")
+	if !ok {
+		t.Fatal("expected OKE alias to resolve")
+	}
+	if def.Name != "oke-clusters" {
+		t.Fatalf("alias resolved to %q, want oke-clusters", def.Name)
+	}
+
+	bucket, ok := lookupResourceDefinition("object-storage")
+	if !ok {
+		t.Fatal("expected object-storage alias to resolve")
+	}
+	if !bucket.NeedsNamespace {
+		t.Fatal("object storage buckets must require namespace lookup")
+	}
+}
+
+func TestResourcesForQuestion(t *testing.T) {
+	got := resourcesForQuestion("show oracle oke clusters and object storage buckets")
+	want := map[string]bool{"oke-clusters": true, "buckets": true}
+	for _, name := range got {
+		delete(want, name)
+	}
+	if len(want) > 0 {
+		t.Fatalf("missing resource matches: %+v in %v", want, got)
+	}
+}

--- a/internal/routing/routing.go
+++ b/internal/routing/routing.go
@@ -24,6 +24,7 @@ type ServiceContext struct {
 	Cloudflare   bool
 	DigitalOcean bool
 	Hetzner      bool
+	Oracle       bool
 	Vercel       bool
 	Flyio        bool
 	Railway      bool
@@ -44,7 +45,7 @@ type Classification struct {
 func DefaultInfraProvider() string {
 	p := strings.ToLower(strings.TrimSpace(viper.GetString("infra.default_provider")))
 	switch p {
-	case "aws", "gcp", "azure", "cloudflare", "digitalocean", "hetzner", "vercel", "flyio", "railway", "verda":
+	case "aws", "gcp", "azure", "cloudflare", "digitalocean", "hetzner", "oracle", "vercel", "flyio", "railway", "verda":
 		return p
 	default:
 		return "aws"
@@ -61,6 +62,7 @@ func applyConfiguredDefaultContext(ctx *ServiceContext) {
 	ctx.Cloudflare = false
 	ctx.DigitalOcean = false
 	ctx.Hetzner = false
+	ctx.Oracle = false
 	ctx.Vercel = false
 	ctx.Flyio = false
 	ctx.Railway = false
@@ -78,6 +80,8 @@ func applyConfiguredDefaultContext(ctx *ServiceContext) {
 		ctx.DigitalOcean = true
 	case "hetzner":
 		ctx.Hetzner = true
+	case "oracle":
+		ctx.Oracle = true
 	case "vercel":
 		ctx.Vercel = true
 	case "flyio":
@@ -342,6 +346,30 @@ func InferContext(question string) ServiceContext {
 		"hetzner iso",
 	}
 
+	oracleKeywords := []string{
+		"oracle cloud",
+		"oracle cloud infrastructure",
+		"oci",
+		"oci cli",
+		"oracle tenancy",
+		"oracle compartment",
+		"compartment ocid",
+		"tenancy ocid",
+		"oracle compute",
+		"oci compute",
+		"oracle vcn",
+		"oci vcn",
+		"oracle object storage",
+		"oci object storage",
+		"oracle autonomous database",
+		"autonomous database",
+		"oracle load balancer",
+		"oracle kubernetes engine",
+		"oke",
+		"oracle functions",
+		"ocir",
+	}
+
 	vercelKeywords := []string{
 		// Only match when Vercel is explicitly referenced — we do not want to
 		// catch generic "deploy" / "preview" / "edge function" phrasing.
@@ -499,6 +527,13 @@ func InferContext(question string) ServiceContext {
 		}
 	}
 
+	for _, keyword := range oracleKeywords {
+		if contains(questionLower, keyword) {
+			ctx.Oracle = true
+			break
+		}
+	}
+
 	for _, keyword := range vercelKeywords {
 		if contains(questionLower, keyword) {
 			ctx.Vercel = true
@@ -537,7 +572,7 @@ func InferContext(question string) ServiceContext {
 
 	// Default to the configured provider if nothing is detected.
 	// AWS keeps GitHub enabled for backward compatibility.
-	if !ctx.AWS && !ctx.GitHub && !ctx.Terraform && !ctx.K8s && !ctx.GCP && !ctx.Azure && !ctx.Cloudflare && !ctx.DigitalOcean && !ctx.Hetzner && !ctx.Vercel && !ctx.Flyio && !ctx.Verda && !ctx.IAM {
+	if !ctx.AWS && !ctx.GitHub && !ctx.Terraform && !ctx.K8s && !ctx.GCP && !ctx.Azure && !ctx.Cloudflare && !ctx.DigitalOcean && !ctx.Hetzner && !ctx.Oracle && !ctx.Vercel && !ctx.Flyio && !ctx.Verda && !ctx.IAM {
 		applyConfiguredDefaultContext(&ctx)
 	}
 
@@ -560,6 +595,7 @@ Available services:
 - azure: Microsoft Azure (VMs, AKS, App Service, Storage, Key Vault, Cosmos DB, VNets, etc.)
 - digitalocean: Digital Ocean (Droplets, DOKS, Managed Databases, Spaces, App Platform, Load Balancers, VPCs, etc.)
 - hetzner: Hetzner Cloud (Servers, Load Balancers, Volumes, Networks, Firewalls, Floating IPs, Primary IPs, etc.)
+- oracle: Oracle Cloud Infrastructure / OCI (Compute instances, VCNs, Object Storage buckets, OKE, DB Systems, Autonomous Database, Load Balancers, Vault, Streams, Queues)
 - vercel: Vercel projects, deployments, domains, env vars, edge functions, KV/Blob/Postgres/Edge Config, analytics
 - flyio: Fly.io apps, machines (VMs), volumes, secrets, IPs, certificates, regions, Postgres clusters (managed + unmanaged), Upstash Redis, Tigris object storage, WireGuard peers, flyctl, fly.toml
 - verda: Verda Cloud / DataCrunch GPU instances, Instant Clusters, volumes (incl. SFS), serverless containers & jobs, SSH keys, startup scripts, container registry
@@ -574,15 +610,16 @@ IMPORTANT RULES:
 4. If the query mentions AWS services (EC2, Lambda, S3, CloudFront, Route53, etc.) but NOT IAM-specific topics, classify as "aws"
 5. Only classify as "digitalocean" if the query EXPLICITLY mentions Digital Ocean, doctl, droplets, DOKS, or Digital Ocean-specific products
 6. Only classify as "hetzner" if the query EXPLICITLY mentions Hetzner, hcloud, or Hetzner-specific products
-7. Only classify as "vercel" if the query EXPLICITLY mentions Vercel, vercel.app, a Vercel deployment/project, or Vercel-specific products (Edge Config, Vercel KV / Blob / Postgres)
-8. Only classify as "flyio" if the query EXPLICITLY mentions Fly.io, flyctl, fly.toml, a Fly machine/app/volume, or Fly-managed Postgres/Redis/Tigris (do NOT route generic "machine" or "deploy" questions to flyio)
-9. Only classify as "railway" if the query EXPLICITLY mentions Railway, railway.app, a Railway project/service/deployment/volume/environment, Nixpacks, or a railway.json/railway.toml file
-10. Only classify as "verda" if the query EXPLICITLY mentions Verda, DataCrunch, Verda clusters/instances, or an Instant Cluster (Verda's managed cluster product)
-11. If uncertain, classify as "%s" (the configured default cloud provider)
+7. Only classify as "oracle" if the query EXPLICITLY mentions Oracle Cloud, OCI, OKE, OCIR, an Oracle tenancy/compartment/OCID, or Oracle-specific products
+8. Only classify as "vercel" if the query EXPLICITLY mentions Vercel, vercel.app, a Vercel deployment/project, or Vercel-specific products (Edge Config, Vercel KV / Blob / Postgres)
+9. Only classify as "flyio" if the query EXPLICITLY mentions Fly.io, flyctl, fly.toml, a Fly machine/app/volume, or Fly-managed Postgres/Redis/Tigris (do NOT route generic "machine" or "deploy" questions to flyio)
+10. Only classify as "railway" if the query EXPLICITLY mentions Railway, railway.app, a Railway project/service/deployment/volume/environment, Nixpacks, or a railway.json/railway.toml file
+11. Only classify as "verda" if the query EXPLICITLY mentions Verda, DataCrunch, Verda clusters/instances, or an Instant Cluster (Verda's managed cluster product)
+12. If uncertain, classify as "%s" (the configured default cloud provider)
 
 Respond with ONLY a JSON object:
 {
-	"service": "cloudflare|aws|iam|k8s|gcp|azure|digitalocean|hetzner|vercel|flyio|railway|verda|github|terraform|general",
+	"service": "cloudflare|aws|iam|k8s|gcp|azure|digitalocean|hetzner|oracle|vercel|flyio|railway|verda|github|terraform|general",
     "confidence": "high|medium|low",
     "reason": "brief explanation of why this classification"
 }`, question, defaultProvider, defaultProvider)
@@ -681,6 +718,9 @@ func NeedsLLMClassification(ctx ServiceContext) bool {
 	if ctx.Hetzner {
 		count++
 	}
+	if ctx.Oracle {
+		count++
+	}
 	if ctx.Vercel {
 		count++
 	}
@@ -702,174 +742,78 @@ func NeedsLLMClassification(ctx ServiceContext) bool {
 	// 2. Cloudflare was inferred (verify it's actually Cloudflare-related)
 	// 3. Digital Ocean was inferred (verify it's actually DO-related)
 	// 4. Hetzner was inferred (verify it's actually Hetzner-related)
-	// 5. Vercel was inferred (verify it's actually Vercel-related)
-	// 6. Fly.io was inferred (verify it's actually Fly-related)
-	// 7. Verda was inferred (verify it's actually Verda-related)
-	// 8. IAM was inferred (verify it's actually IAM-related for disambiguation)
-	return count > 1 || ctx.Cloudflare || ctx.DigitalOcean || ctx.Hetzner || ctx.Vercel || ctx.Flyio || ctx.Railway || ctx.Verda || ctx.IAM
+	// 5. Oracle was inferred (verify it's actually OCI-related)
+	// 6. Vercel was inferred (verify it's actually Vercel-related)
+	// 7. Fly.io was inferred (verify it's actually Fly-related)
+	// 8. Verda was inferred (verify it's actually Verda-related)
+	// 9. IAM was inferred (verify it's actually IAM-related for disambiguation)
+	return count > 1 || ctx.Cloudflare || ctx.DigitalOcean || ctx.Hetzner || ctx.Oracle || ctx.Vercel || ctx.Flyio || ctx.Railway || ctx.Verda || ctx.IAM
 }
 
 // ApplyLLMClassification updates the ServiceContext based on LLM classification result
 func ApplyLLMClassification(ctx *ServiceContext, llmService string) {
+	clearInfraProviders := func() {
+		ctx.AWS = false
+		ctx.K8s = false
+		ctx.GCP = false
+		ctx.Azure = false
+		ctx.Cloudflare = false
+		ctx.DigitalOcean = false
+		ctx.Hetzner = false
+		ctx.Oracle = false
+		ctx.Vercel = false
+		ctx.Flyio = false
+		ctx.Railway = false
+		ctx.Verda = false
+		ctx.IAM = false
+	}
+
 	switch llmService {
 	case "cloudflare":
+		clearInfraProviders()
 		ctx.Cloudflare = true
-		ctx.K8s = false
-		ctx.GCP = false
-		ctx.Azure = false
-		ctx.AWS = false
-		ctx.DigitalOcean = false
-		ctx.Hetzner = false
-		ctx.Vercel = false
-		ctx.Flyio = false
-		ctx.Railway = false
-		ctx.Verda = false
-		ctx.IAM = false
 	case "k8s":
+		clearInfraProviders()
 		ctx.K8s = true
-		ctx.Cloudflare = false
-		ctx.GCP = false
-		ctx.Azure = false
-		ctx.DigitalOcean = false
-		ctx.Hetzner = false
-		ctx.Vercel = false
-		ctx.Flyio = false
-		ctx.Railway = false
-		ctx.Verda = false
-		ctx.IAM = false
 	case "gcp":
+		clearInfraProviders()
 		ctx.GCP = true
-		ctx.Cloudflare = false
-		ctx.K8s = false
-		ctx.Azure = false
-		ctx.DigitalOcean = false
-		ctx.Hetzner = false
-		ctx.Vercel = false
-		ctx.Flyio = false
-		ctx.Railway = false
-		ctx.Verda = false
-		ctx.IAM = false
 	case "azure":
+		clearInfraProviders()
 		ctx.Azure = true
-		ctx.GCP = false
-		ctx.Cloudflare = false
-		ctx.K8s = false
-		ctx.AWS = false
-		ctx.DigitalOcean = false
-		ctx.Hetzner = false
-		ctx.Vercel = false
-		ctx.Flyio = false
-		ctx.Railway = false
-		ctx.Verda = false
-		ctx.IAM = false
 	case "digitalocean":
+		clearInfraProviders()
 		ctx.DigitalOcean = true
-		ctx.AWS = false
-		ctx.GCP = false
-		ctx.Cloudflare = false
-		ctx.K8s = false
-		ctx.Azure = false
-		ctx.Hetzner = false
-		ctx.Vercel = false
-		ctx.Flyio = false
-		ctx.Railway = false
-		ctx.Verda = false
-		ctx.IAM = false
 	case "hetzner":
+		clearInfraProviders()
 		ctx.Hetzner = true
-		ctx.AWS = false
-		ctx.GCP = false
-		ctx.Cloudflare = false
-		ctx.K8s = false
-		ctx.Azure = false
-		ctx.DigitalOcean = false
-		ctx.Vercel = false
-		ctx.Flyio = false
-		ctx.Railway = false
-		ctx.Verda = false
-		ctx.IAM = false
+	case "oracle":
+		clearInfraProviders()
+		ctx.Oracle = true
 	case "vercel":
+		clearInfraProviders()
 		ctx.Vercel = true
-		ctx.AWS = false
-		ctx.GCP = false
-		ctx.Cloudflare = false
-		ctx.K8s = false
-		ctx.Azure = false
-		ctx.DigitalOcean = false
-		ctx.Hetzner = false
-		ctx.Flyio = false
-		ctx.Verda = false
-		ctx.IAM = false
 	case "flyio":
+		clearInfraProviders()
 		ctx.Flyio = true
-		ctx.AWS = false
-		ctx.GCP = false
-		ctx.Cloudflare = false
-		ctx.K8s = false
-		ctx.Azure = false
-		ctx.DigitalOcean = false
-		ctx.Hetzner = false
-		ctx.Vercel = false
-		ctx.Verda = false
-		ctx.Railway = false
-		ctx.IAM = false
 	case "verda":
+		clearInfraProviders()
 		ctx.Verda = true
-		ctx.AWS = false
-		ctx.GCP = false
-		ctx.Cloudflare = false
-		ctx.K8s = false
-		ctx.Azure = false
-		ctx.DigitalOcean = false
-		ctx.Hetzner = false
-		ctx.Vercel = false
-		ctx.Flyio = false
-		ctx.Railway = false
-		ctx.IAM = false
 	case "railway":
+		clearInfraProviders()
 		ctx.Railway = true
-		ctx.AWS = false
-		ctx.GCP = false
-		ctx.Cloudflare = false
-		ctx.K8s = false
-		ctx.Azure = false
-		ctx.DigitalOcean = false
-		ctx.Hetzner = false
-		ctx.Vercel = false
-		ctx.Flyio = false
-		ctx.Verda = false
-		ctx.IAM = false
 	case "aws":
+		clearInfraProviders()
 		ctx.AWS = true
-		ctx.Cloudflare = false
-		ctx.K8s = false
-		ctx.GCP = false
-		ctx.Azure = false
-		ctx.DigitalOcean = false
-		ctx.Hetzner = false
-		ctx.Vercel = false
-		ctx.Flyio = false
-		ctx.Railway = false
-		ctx.Verda = false
-		ctx.IAM = false
 	case "iam":
+		clearInfraProviders()
 		ctx.IAM = true
-		ctx.AWS = false
-		ctx.Cloudflare = false
-		ctx.K8s = false
-		ctx.GCP = false
-		ctx.Azure = false
-		ctx.DigitalOcean = false
-		ctx.Hetzner = false
-		ctx.Vercel = false
-		ctx.Flyio = false
-		ctx.Railway = false
-		ctx.Verda = false
 	case "terraform":
 		ctx.Terraform = true
 		ctx.Cloudflare = false
 		ctx.DigitalOcean = false
 		ctx.Hetzner = false
+		ctx.Oracle = false
 		ctx.Vercel = false
 		ctx.Flyio = false
 		ctx.Railway = false
@@ -879,6 +823,7 @@ func ApplyLLMClassification(ctx *ServiceContext, llmService string) {
 		ctx.Cloudflare = false
 		ctx.DigitalOcean = false
 		ctx.Hetzner = false
+		ctx.Oracle = false
 		ctx.Vercel = false
 		ctx.Flyio = false
 		ctx.Railway = false
@@ -889,6 +834,7 @@ func ApplyLLMClassification(ctx *ServiceContext, llmService string) {
 		ctx.Cloudflare = false
 		ctx.DigitalOcean = false
 		ctx.Hetzner = false
+		ctx.Oracle = false
 		ctx.Vercel = false
 		ctx.Flyio = false
 		ctx.Railway = false
@@ -907,6 +853,8 @@ func ApplyLLMClassification(ctx *ServiceContext, llmService string) {
 			ctx.DigitalOcean = true
 		case "hetzner":
 			ctx.Hetzner = true
+		case "oracle":
+			ctx.Oracle = true
 		case "vercel":
 			ctx.Vercel = true
 		case "flyio":

--- a/internal/routing/routing_flyio_test.go
+++ b/internal/routing/routing_flyio_test.go
@@ -46,7 +46,7 @@ func TestApplyLLMClassification_Flyio(t *testing.T) {
 }
 
 func TestApplyLLMClassification_OtherProvidersResetFlyio(t *testing.T) {
-	for _, target := range []string{"aws", "gcp", "azure", "cloudflare", "digitalocean", "hetzner", "vercel", "railway", "verda", "iam"} {
+	for _, target := range []string{"aws", "gcp", "azure", "cloudflare", "digitalocean", "hetzner", "oracle", "vercel", "railway", "verda", "iam"} {
 		ctx := &ServiceContext{Flyio: true}
 		ApplyLLMClassification(ctx, target)
 		if ctx.Flyio {

--- a/internal/routing/routing_test.go
+++ b/internal/routing/routing_test.go
@@ -376,6 +376,20 @@ func TestApplyLLMClassification_GeneralUsesConfiguredDefault(t *testing.T) {
 	}
 }
 
+func TestApplyLLMClassification_GeneralUsesConfiguredOracleDefault(t *testing.T) {
+	useDefaultProvider(t, "oracle")
+
+	ctx := ServiceContext{}
+	ApplyLLMClassification(&ctx, "general")
+
+	if !ctx.Oracle {
+		t.Error("general classification should use configured Oracle default")
+	}
+	if ctx.AWS {
+		t.Error("general classification should not force AWS when Oracle is configured")
+	}
+}
+
 func TestApplyLLMClassification_GeneralPreservesGitHubContext(t *testing.T) {
 	useDefaultProvider(t, "hetzner")
 
@@ -492,7 +506,7 @@ func TestApplyLLMClassification_OtherProvidersClearVerda(t *testing.T) {
 	useDefaultProvider(t, "")
 	// Each sibling provider case should clear Verda so a keyword-inferred Verda
 	// doesn't leak into an LLM-picked different provider.
-	for _, svc := range []string{"cloudflare", "k8s", "gcp", "azure", "digitalocean", "hetzner", "vercel", "aws", "iam"} {
+	for _, svc := range []string{"cloudflare", "k8s", "gcp", "azure", "digitalocean", "hetzner", "oracle", "vercel", "aws", "iam"} {
 		t.Run(svc, func(t *testing.T) {
 			ctx := ServiceContext{Verda: true}
 			ApplyLLMClassification(&ctx, svc)
@@ -505,14 +519,14 @@ func TestApplyLLMClassification_OtherProvidersClearVerda(t *testing.T) {
 
 func TestApplyLLMClassification_Verda(t *testing.T) {
 	useDefaultProvider(t, "")
-	ctx := ServiceContext{AWS: true, Cloudflare: true, DigitalOcean: true, Hetzner: true, Vercel: true, IAM: true}
+	ctx := ServiceContext{AWS: true, Cloudflare: true, DigitalOcean: true, Hetzner: true, Oracle: true, Vercel: true, IAM: true}
 	ApplyLLMClassification(&ctx, "verda")
 	if !ctx.Verda {
 		t.Error("Verda should be set")
 	}
 	// Per the existing ApplyLLMClassification convention, the Verda case
 	// clears cloud providers + IAM but preserves GitHub/Terraform.
-	if ctx.AWS || ctx.Cloudflare || ctx.DigitalOcean || ctx.Hetzner || ctx.Vercel || ctx.IAM {
+	if ctx.AWS || ctx.Cloudflare || ctx.DigitalOcean || ctx.Hetzner || ctx.Oracle || ctx.Vercel || ctx.IAM {
 		t.Error("other cloud providers should be cleared when LLM picks verda")
 	}
 }


### PR DESCRIPTION
## Summary
- add an Oracle Cloud Infrastructure provider backed by the official OCI CLI
- add `clanker oracle` / `clanker oci` list and profile commands for OCI resources, compartments, OKE, Object Storage, networking, databases, vaults, logs, and more
- wire Oracle into ask routing, default discovery, MCP provider tools, onboarding, config hints, and maker plan/apply execution
- add unit coverage for OCI config parsing, Oracle resource lookup, and maker command validation

## Verification
- `go test ./...`
- `go run . oracle --help`
- `go run . oracle list --help`
- `go run . ask --help`