### PR TITLE
Detect Vercel and Wrangler auth in platform config dirs

### DIFF
--- a/internal/onboarding/onboarding.go
+++ b/internal/onboarding/onboarding.go
@@ -786,7 +786,7 @@ func providerGuides() []providerGuide {
 			if hasAnyEnv("CLOUDFLARE_API_TOKEN", "CF_API_TOKEN", "CLOUDFLARE_ACCOUNT_ID") {
 				notes = append(notes, "cloudflare env")
 			}
-			if fileExists(homePath(".wrangler", "config", "default.toml")) {
+			if fileExistsAny(wranglerConfigPaths()...) {
 				notes = append(notes, "wrangler config")
 			}
 			return len(notes) > 0, len(notes) > 0, notes
@@ -866,7 +866,7 @@ func providerGuides() []providerGuide {
 			if hasAnyEnv("VERCEL_TOKEN") {
 				notes = append(notes, "vercel env")
 			}
-			if fileExists(homePath(".vercel", "auth.json")) {
+			if fileExistsAny(vercelAuthPaths()...) {
 				notes = append(notes, "vercel auth")
 			}
 			return len(notes) > 0, len(notes) > 0, notes
@@ -1129,6 +1129,72 @@ func fileExists(path string) bool {
 	}
 	st, err := os.Stat(path)
 	return err == nil && !st.IsDir()
+}
+
+func fileExistsAny(paths ...string) bool {
+	for _, path := range paths {
+		if fileExists(path) {
+			return true
+		}
+	}
+	return false
+}
+
+// vercelAuthPaths lists the auth.json locations used by the Vercel CLI: the
+// legacy ~/.vercel directory and the platform data directory newer releases
+// write to (macOS: ~/Library/Application Support/com.vercel.cli, Linux:
+// $XDG_DATA_HOME/com.vercel.cli, Windows: %AppData%/com.vercel.cli).
+func vercelAuthPaths() []string {
+	paths := []string{homePath(".vercel", "auth.json")}
+	switch runtime.GOOS {
+	case "darwin":
+		paths = append(paths, homePath("Library", "Application Support", "com.vercel.cli", "auth.json"))
+	case "windows":
+		if appData := strings.TrimSpace(os.Getenv("APPDATA")); appData != "" {
+			paths = append(paths, filepath.Join(appData, "com.vercel.cli", "auth.json"))
+		}
+	default:
+		paths = append(paths, filepath.Join(xdgDataHome(), "com.vercel.cli", "auth.json"))
+	}
+	return paths
+}
+
+// wranglerConfigPaths lists the global config locations used by Wrangler:
+// $WRANGLER_HOME when set, the legacy ~/.wrangler directory, and the platform
+// config directory newer releases use when ~/.wrangler is absent (macOS:
+// ~/Library/Preferences/.wrangler, Linux: $XDG_CONFIG_HOME/.wrangler,
+// Windows: %AppData%/.wrangler).
+func wranglerConfigPaths() []string {
+	paths := []string{}
+	if custom := strings.TrimSpace(os.Getenv("WRANGLER_HOME")); custom != "" {
+		paths = append(paths, filepath.Join(custom, "config", "default.toml"))
+	}
+	paths = append(paths, homePath(".wrangler", "config", "default.toml"))
+	switch runtime.GOOS {
+	case "darwin":
+		paths = append(paths, homePath("Library", "Preferences", ".wrangler", "config", "default.toml"))
+	case "windows":
+		if appData := strings.TrimSpace(os.Getenv("APPDATA")); appData != "" {
+			paths = append(paths, filepath.Join(appData, ".wrangler", "config", "default.toml"))
+		}
+	default:
+		paths = append(paths, filepath.Join(xdgConfigHome(), ".wrangler", "config", "default.toml"))
+	}
+	return paths
+}
+
+func xdgConfigHome() string {
+	if dir := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); dir != "" {
+		return dir
+	}
+	return homePath(".config")
+}
+
+func xdgDataHome() string {
+	if dir := strings.TrimSpace(os.Getenv("XDG_DATA_HOME")); dir != "" {
+		return dir
+	}
+	return homePath(".local", "share")
 }
 
 func truncate(value string, max int) string {

--- a/internal/onboarding/onboarding_test.go
+++ b/internal/onboarding/onboarding_test.go
@@ -2,6 +2,9 @@ package onboarding
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -81,5 +84,86 @@ func TestProviderGuidesRequireOfficialTencentAndSentryCLIs(t *testing.T) {
 	}
 	if normalizeToolID("sentry") != "sentry-cli" {
 		t.Fatal("sentry alias did not normalize to sentry-cli")
+	}
+}
+
+func writeTestFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestVercelAndWranglerPathsIncludePlatformConfigDirs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("WRANGLER_HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("XDG_DATA_HOME", "")
+
+	if fileExistsAny(vercelAuthPaths()...) {
+		t.Fatal("expected no vercel auth in fresh home")
+	}
+	if fileExistsAny(wranglerConfigPaths()...) {
+		t.Fatal("expected no wrangler config in fresh home")
+	}
+
+	var vercelAuth, wranglerConfig string
+	switch runtime.GOOS {
+	case "darwin":
+		vercelAuth = filepath.Join(home, "Library", "Application Support", "com.vercel.cli", "auth.json")
+		wranglerConfig = filepath.Join(home, "Library", "Preferences", ".wrangler", "config", "default.toml")
+	case "windows":
+		appData := filepath.Join(home, "AppData", "Roaming")
+		t.Setenv("APPDATA", appData)
+		vercelAuth = filepath.Join(appData, "com.vercel.cli", "auth.json")
+		wranglerConfig = filepath.Join(appData, ".wrangler", "config", "default.toml")
+	default:
+		vercelAuth = filepath.Join(home, ".local", "share", "com.vercel.cli", "auth.json")
+		wranglerConfig = filepath.Join(home, ".config", ".wrangler", "config", "default.toml")
+	}
+	writeTestFile(t, vercelAuth)
+	writeTestFile(t, wranglerConfig)
+
+	if !fileExistsAny(vercelAuthPaths()...) {
+		t.Fatalf("vercel auth at %s not detected", vercelAuth)
+	}
+	if !fileExistsAny(wranglerConfigPaths()...) {
+		t.Fatalf("wrangler config at %s not detected", wranglerConfig)
+	}
+}
+
+func TestVercelAndWranglerPathsKeepLegacyLocations(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("WRANGLER_HOME", "")
+
+	writeTestFile(t, filepath.Join(home, ".vercel", "auth.json"))
+	writeTestFile(t, filepath.Join(home, ".wrangler", "config", "default.toml"))
+
+	if !fileExistsAny(vercelAuthPaths()...) {
+		t.Fatal("legacy ~/.vercel/auth.json not detected")
+	}
+	if !fileExistsAny(wranglerConfigPaths()...) {
+		t.Fatal("legacy ~/.wrangler/config/default.toml not detected")
+	}
+}
+
+func TestWranglerConfigPathsHonorWranglerHome(t *testing.T) {
+	home := t.TempDir()
+	custom := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("WRANGLER_HOME", custom)
+
+	writeTestFile(t, filepath.Join(custom, "config", "default.toml"))
+
+	if !fileExistsAny(wranglerConfigPaths()...) {
+		t.Fatal("config under $WRANGLER_HOME not detected")
 	}
 }


### PR DESCRIPTION
`onboarding scan` was reporting Vercel and Cloudflare as not detected on my Mac even though both CLIs were installed and logged in. Root cause: the scan checks `~/.vercel/auth.json` and `~/.wrangler/config/default.toml`, but recent CLI releases only use those dirs if they already exist:

- Vercel CLI keeps auth in the platform data dir — macOS `~/Library/Application Support/com.vercel.cli/auth.json`, Linux `$XDG_DATA_HOME/com.vercel.cli/auth.json`
- Wrangler keeps global config in the platform config dir — macOS `~/Library/Preferences/.wrangler/config/default.toml`, Linux `$XDG_CONFIG_HOME/.wrangler/config/default.toml` — and honors `$WRANGLER_HOME`

So anyone who first logged in on a recent CLI version scans as unauthenticated, on macOS and Linux alike. This adds those locations as extra candidates next to the legacy paths — no behavior change for setups the scan already detects.

Before/after on macOS 15 arm64 with Vercel CLI 54.20.0 and wrangler 4.106.0, both logged in, no legacy dotfiles present:

```
# v0.0.9
{"id":"cloudflare","detected":false,"detectionNotes":null}
{"id":"vercel","detected":false,"detectionNotes":null}

# patched
{"id":"cloudflare","detected":true,"detectionNotes":["wrangler config"]}
{"id":"vercel","detected":true,"detectionNotes":["vercel auth"]}
```

Tests cover the platform paths per-OS, the legacy paths, and the `WRANGLER_HOME` override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)