### PR TITLE
feat(tencent): add CLS log search endpoint

### DIFF
--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -58,6 +58,7 @@ func (s *Server) registerRoutes() {
 
 	// Topology (Phase 7)
 	s.mux.HandleFunc("GET /api/v1/tencent/topology", s.handleTencentTopology)
+	s.mux.HandleFunc("GET /api/v1/tencent/cls/search", s.handleTencentCLSSearch)
 	s.mux.HandleFunc("GET /api/v1/tencent/scan/public-exposure", s.handleTencentPublicExposure)
 	s.mux.HandleFunc("GET /api/v1/tencent/scan/clb-exposure", s.handleTencentCLBExposure)
 	s.mux.HandleFunc("GET /api/v1/tencent/scan/idle-eips", s.handleTencentIdleEIPs)
@@ -278,6 +279,37 @@ func (s *Server) handleTencentTopology(w http.ResponseWriter, r *http.Request) {
 	}
 	region := strings.TrimSpace(r.URL.Query().Get("region"))
 	body, err := client.TopologyJSON(r.Context(), region)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "tencent_api_error", err.Error())
+		return
+	}
+	writeRawData(w, body)
+}
+
+// handleTencentCLSSearch searches a single CLS log topic and returns flattened
+// log entries. Query params: region, topic_id (required), query, limit, from,
+// to (from/to are epoch milliseconds; default = last hour).
+func (s *Server) handleTencentCLSSearch(w http.ResponseWriter, r *http.Request) {
+	client, err := s.tencentClient(r)
+	if err != nil {
+		writeTencentClientErr(w, err)
+		return
+	}
+	q := r.URL.Query()
+	topicID := strings.TrimSpace(q.Get("topic_id"))
+	if topicID == "" {
+		writeError(w, http.StatusBadRequest, "missing_topic_id", "topic_id query param is required")
+		return
+	}
+	region := strings.TrimSpace(q.Get("region"))
+	query := q.Get("query")
+	parse := func(key string) int64 {
+		if n, err := strconv.ParseInt(strings.TrimSpace(q.Get(key)), 10, 64); err == nil {
+			return n
+		}
+		return 0
+	}
+	body, err := client.CLSSearchLogJSON(r.Context(), region, topicID, query, parse("from"), parse("to"), parse("limit"))
 	if err != nil {
 		writeError(w, http.StatusBadGateway, "tencent_api_error", err.Error())
 		return

--- a/internal/tencent/observability.go
+++ b/internal/tencent/observability.go
@@ -1,10 +1,13 @@
 package tencent
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	cloudaudit "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cloudaudit/v20190319"
 	cls "github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cls/v20201016"
@@ -164,6 +167,101 @@ func listCLSTopics(c *Client, regions []string) error {
 	}
 	printWarnings(warnings)
 	return nil
+}
+
+// ── CLS log search (Cloud Log Service content) ──────────────────────────────
+
+// CLSLogEntry is one flattened SearchLog result for the console log viewer.
+type CLSLogEntry struct {
+	Time     int64  `json:"time"` // epoch milliseconds
+	Source   string `json:"source"`
+	FileName string `json:"filename"`
+	HostName string `json:"hostname"`
+	Content  string `json:"content"` // structured LogJson, or RawLog fallback
+}
+
+// CLSSearchResult is the JSON payload returned to the API for a topic search.
+type CLSSearchResult struct {
+	Region   string        `json:"region"`
+	TopicID  string        `json:"topic_id"`
+	Query    string        `json:"query"`
+	From     int64         `json:"from"`
+	To       int64         `json:"to"`
+	ListOver bool          `json:"list_over"`
+	Count    int           `json:"count"`
+	Results  []CLSLogEntry `json:"results"`
+}
+
+// CLSSearchLogJSON runs a CLS SearchLog against a single topic and returns a
+// flattened JSON string ({region, topic_id, results:[...]}). Time range is in
+// epoch milliseconds; from/to<=0 default to the last hour. An empty query
+// matches all logs ("*"). limit is clamped to [1,1000], default 200.
+func (c *Client) CLSSearchLogJSON(_ context.Context, region, topicID, query string, fromMs, toMs, limit int64) (string, error) {
+	if strings.TrimSpace(topicID) == "" {
+		return "", fmt.Errorf("topic_id is required")
+	}
+	if strings.TrimSpace(region) == "" {
+		region = c.creds.Region
+	}
+	client, err := newCLSClient(c, region)
+	if err != nil {
+		return "", fmt.Errorf("init cls client: %w", err)
+	}
+	if limit <= 0 || limit > 1000 {
+		limit = 200
+	}
+	if toMs <= 0 {
+		toMs = time.Now().UnixMilli()
+	}
+	if fromMs <= 0 {
+		fromMs = toMs - 3600*1000 // last hour
+	}
+	q := strings.TrimSpace(query)
+	if q == "" {
+		q = "*"
+	}
+	sort := "desc"
+
+	req := cls.NewSearchLogRequest()
+	req.TopicId = &topicID
+	req.From = &fromMs
+	req.To = &toMs
+	req.Query = &q
+	req.Sort = &sort
+	req.Limit = &limit
+
+	resp, err := client.SearchLog(req)
+	if err != nil {
+		return "", friendlyError(err)
+	}
+
+	out := CLSSearchResult{Region: region, TopicID: topicID, Query: query, From: fromMs, To: toMs, Results: []CLSLogEntry{}}
+	if resp != nil && resp.Response != nil {
+		out.ListOver = derefBool(resp.Response.ListOver)
+		for _, r := range resp.Response.Results {
+			if r == nil {
+				continue
+			}
+			content := derefString(r.LogJson)
+			if content == "" {
+				content = derefString(r.RawLog)
+			}
+			out.Results = append(out.Results, CLSLogEntry{
+				Time:     derefInt64(r.Time),
+				Source:   derefString(r.Source),
+				FileName: derefString(r.FileName),
+				HostName: derefString(r.HostName),
+				Content:  content,
+			})
+		}
+	}
+	out.Count = len(out.Results)
+
+	b, err := json.Marshal(out)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
 }
 
 func newCLSClient(c *Client, region string) (*cls.Client, error) {


### PR DESCRIPTION
## What

Adds an API route to read **Tencent Cloud Log Service (CLS) log content** — previously the API could only *list* CLS topics (`resources/cls`), not read the logs inside them.

## Endpoint

```
GET /api/v1/tencent/cls/search?region=&topic_id=&query=&limit=&from=&to=
```

- `topic_id` (required) — CLS topic to search
- `query` — CLS search query; blank matches all (`*`)
- `from`/`to` — epoch **milliseconds**; default = last hour
- `limit` — clamped to `[1, 1000]`, default `200`

Returns a flattened payload:

```json
{ "data": { "region": "...", "topic_id": "...", "count": 3, "list_over": false,
  "results": [ { "time": 1783400918010, "source": "...", "filename": "...",
                 "hostname": "...", "content": "{...log json...}" } ] } }
```

## Implementation

- `tencent.(*Client).CLSSearchLogJSON` — wraps the CLS `SearchLog` SDK call, sorts newest-first, and flattens `LogInfo` to `{time, source, filename, hostname, content}` (`content` = `LogJson`, falling back to `RawLog`).
- `handleTencentCLSSearch` — parses/validates query params (400 on missing `topic_id`) and reuses the existing `tencentClient` / `writeRawData` plumbing, mirroring `handleTencentTopology`.

No new dependencies (the `cls` SDK was already required). `gofmt -s` clean; `go build ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)