### PR TITLE
feat: add secure Clanker Apps lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,36 @@ clanker cf list --help
 
 ## Usage
 
+### Clanker Apps
+
+Clanker Apps are account-scoped, immutable static deployments. Creating an app
+or deployment keeps it private; `activate` is the separate step that makes a
+reviewed deployment public.
+
+```bash
+export CLANKER_CLOUD_API_KEY="..."
+
+clanker cloud apps create "Team CRM" --description "Shared contact workspace"
+clanker cloud apps deploy APP_ID --html-file ./index.html
+clanker cloud apps deployments APP_ID
+clanker cloud apps activate APP_ID DEPLOYMENT_ID
+clanker cloud apps unpublish APP_ID
+clanker cloud apps delete APP_ID
+```
+
+Create and deploy generate a valid idempotency key automatically. Pass
+`--idempotency-key` when you need the same stable key across manual retries.
+
+One-shot sandbox tasks require an account key, then dispose their compute and
+persistent sandbox storage before returning. If cleanup fails, the command
+prints the sandbox id and an exact `sandboxes delete` retry command. Use
+`--keep-sandbox` only for intentional debugging work:
+
+```bash
+clanker cloud sandboxes run "inspect this repository and summarize it"
+clanker cloud sandboxes run --keep-sandbox "prepare a debugging workspace"
+```
+
 ### MCP
 
 Clanker also exposes its own MCP surface as a CLI command.

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -12,7 +12,7 @@ import (
 
 var cloudCmd = &cobra.Command{
 	Use:   "cloud",
-	Short: "Work with the local Clanker Cloud desktop app",
+	Short: "Work with Clanker Cloud and the local desktop app",
 }
 
 var cloudDoctorCmd = &cobra.Command{

--- a/cmd/cloud_apps.go
+++ b/cmd/cloud_apps.go
@@ -1,0 +1,341 @@
+package cmd
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/bgdnvk/clanker/internal/clankercloud"
+	"github.com/spf13/cobra"
+)
+
+const maxCLIAppInputBytes = 8 << 20
+
+type appCreateFlags struct {
+	description    string
+	projectID      string
+	metadataJSON   string
+	idempotencyKey string
+}
+
+type appDeploymentFlags struct {
+	html            string
+	htmlFile        string
+	filesJSON       string
+	entrypoint      string
+	spa             bool
+	dataSummaryJSON string
+	exposureJSON    string
+	idempotencyKey  string
+}
+
+func newCloudAppsCmd() *cobra.Command {
+	var apiBaseURL string
+	var apiKey string
+	client := func() *clankercloud.AppsClient {
+		return clankercloud.NewAppsClient(clankercloud.AppsClientOptions{
+			BaseURL:    apiBaseURL,
+			AccountKey: apiKey,
+		})
+	}
+
+	cmd := &cobra.Command{
+		Use:     "apps",
+		Aliases: []string{"app"},
+		Short:   "Create, publish, roll back, unpublish, and delete Clanker Apps",
+		Long: strings.TrimSpace(`Manage account-scoped Clanker Apps and immutable deployments.
+
+Creating an app or deployment is private. Use activate only after reviewing the deployment you want to share publicly.`),
+	}
+	cmd.PersistentFlags().StringVar(&apiBaseURL, "api-base-url", "", "Clanker Cloud API base URL (HTTPS, or loopback HTTP for development)")
+	cmd.PersistentFlags().StringVar(&apiKey, "api-key", "", "Clanker Cloud account API key (prefer CLANKER_CLOUD_API_KEY)")
+
+	cmd.AddCommand(newCloudAppsListCmd(client))
+	cmd.AddCommand(newCloudAppsCreateCmd(client))
+	cmd.AddCommand(newCloudAppsGetCmd(client))
+	cmd.AddCommand(newCloudAppsDeleteCmd(client))
+	cmd.AddCommand(newCloudAppsDeploymentsCmd(client))
+	cmd.AddCommand(newCloudAppsDeployCmd(client))
+	cmd.AddCommand(newCloudAppsActivateCmd(client))
+	cmd.AddCommand(newCloudAppsUnpublishCmd(client))
+	return cmd
+}
+
+func newCloudAppsListCmd(client func() *clankercloud.AppsClient) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List account-owned apps",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			result, err := client().ListApps(cmd.Context())
+			return printAppsResult(result, err)
+		},
+	}
+}
+
+func newCloudAppsCreateCmd(client func() *clankercloud.AppsClient) *cobra.Command {
+	var flags appCreateFlags
+	cmd := &cobra.Command{
+		Use:   "create NAME",
+		Short: "Create a private app draft",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			metadata, err := readAppJSONObject(flags.metadataJSON)
+			if err != nil {
+				return fmt.Errorf("decode app metadata: %w", err)
+			}
+			idempotencyKey, err := resolveCLIAppIdempotencyKey(flags.idempotencyKey, "create")
+			if err != nil {
+				return err
+			}
+			result, err := client().CreateApp(cmd.Context(), clankercloud.AppCreateRequest{
+				Name:           strings.TrimSpace(args[0]),
+				Description:    strings.TrimSpace(flags.description),
+				ProjectID:      strings.TrimSpace(flags.projectID),
+				Metadata:       metadata,
+				IdempotencyKey: idempotencyKey,
+			})
+			return printAppsResult(result, err)
+		},
+	}
+	cmd.Flags().StringVar(&flags.description, "description", "", "optional app description")
+	cmd.Flags().StringVar(&flags.projectID, "project-id", "", "optional Clanker Cloud project id")
+	cmd.Flags().StringVar(&flags.metadataJSON, "metadata-json", "", "JSON object with non-secret app metadata, or @path")
+	cmd.Flags().StringVar(&flags.idempotencyKey, "idempotency-key", "", "stable 8-128 character retry key (generated automatically when omitted)")
+	return cmd
+}
+
+func newCloudAppsGetCmd(client func() *clankercloud.AppsClient) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get APP_ID",
+		Short: "Inspect an app",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := client().GetApp(cmd.Context(), args[0])
+			return printAppsResult(result, err)
+		},
+	}
+}
+
+func newCloudAppsDeleteCmd(client func() *clankercloud.AppsClient) *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete APP_ID",
+		Short: "Delete an app and its retained deployments",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := client().DeleteApp(cmd.Context(), args[0])
+			return printAppsResult(result, err)
+		},
+	}
+}
+
+func newCloudAppsDeploymentsCmd(client func() *clankercloud.AppsClient) *cobra.Command {
+	return &cobra.Command{
+		Use:     "deployments APP_ID",
+		Aliases: []string{"versions"},
+		Short:   "List immutable deployments for an app",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := client().ListDeployments(cmd.Context(), args[0])
+			return printAppsResult(result, err)
+		},
+	}
+}
+
+func newCloudAppsDeployCmd(client func() *clankercloud.AppsClient) *cobra.Command {
+	var flags appDeploymentFlags
+	cmd := &cobra.Command{
+		Use:   "deploy APP_ID",
+		Short: "Create a private immutable deployment",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			input, err := flags.input()
+			if err != nil {
+				return err
+			}
+			idempotencyKey, err := resolveCLIAppIdempotencyKey(flags.idempotencyKey, "deploy")
+			if err != nil {
+				return err
+			}
+			result, err := client().CreateDeployment(cmd.Context(), args[0], clankercloud.AppDeploymentCreateRequest{
+				AppDeploymentInput: input,
+				IdempotencyKey:     idempotencyKey,
+			})
+			return printAppsResult(result, err)
+		},
+	}
+	flags.addArtifactFlags(cmd)
+	return cmd
+}
+
+func newCloudAppsActivateCmd(client func() *clankercloud.AppsClient) *cobra.Command {
+	return &cobra.Command{
+		Use:     "activate APP_ID DEPLOYMENT_ID",
+		Aliases: []string{"publish", "rollback"},
+		Short:   "Make one reviewed deployment public",
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := client().ActivateDeployment(cmd.Context(), args[0], args[1])
+			return printAppsResult(result, err)
+		},
+	}
+}
+
+func newCloudAppsUnpublishCmd(client func() *clankercloud.AppsClient) *cobra.Command {
+	return &cobra.Command{
+		Use:   "unpublish APP_ID",
+		Short: "Remove public access while retaining app deployments",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			result, err := client().UnpublishApp(cmd.Context(), args[0])
+			return printAppsResult(result, err)
+		},
+	}
+}
+
+func (flags *appDeploymentFlags) addArtifactFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&flags.html, "html", "", "single-file HTML content")
+	cmd.Flags().StringVar(&flags.htmlFile, "html-file", "", "read single-file HTML content from this path")
+	cmd.Flags().StringVar(&flags.filesJSON, "files-json", "", "JSON array of app files, or @path to a JSON file")
+	cmd.Flags().StringVar(&flags.entrypoint, "entrypoint", "index.html", "deployment entrypoint")
+	cmd.Flags().BoolVar(&flags.spa, "spa", false, "serve the entrypoint for unknown paths")
+	cmd.Flags().StringVar(&flags.dataSummaryJSON, "data-summary-json", "", "JSON object describing included data, or @path")
+	cmd.Flags().StringVar(&flags.exposureJSON, "exposure-json", "", "JSON object describing reviewed public data exposure, or @path")
+	cmd.Flags().StringVar(&flags.idempotencyKey, "idempotency-key", "", "stable 8-128 character retry key (generated automatically when omitted)")
+}
+
+func (flags appDeploymentFlags) input() (clankercloud.AppDeploymentInput, error) {
+	if strings.TrimSpace(flags.html) != "" && strings.TrimSpace(flags.htmlFile) != "" {
+		return clankercloud.AppDeploymentInput{}, fmt.Errorf("--html and --html-file cannot be used together")
+	}
+
+	html := flags.html
+	if path := strings.TrimSpace(flags.htmlFile); path != "" {
+		content, err := readBoundedAppFile(path)
+		if err != nil {
+			return clankercloud.AppDeploymentInput{}, fmt.Errorf("read app HTML: %w", err)
+		}
+		html = string(content)
+	}
+	if len(html) > maxCLIAppInputBytes {
+		return clankercloud.AppDeploymentInput{}, fmt.Errorf("inline app HTML exceeds %d bytes", maxCLIAppInputBytes)
+	}
+
+	var files []clankercloud.AppFile
+	if raw := strings.TrimSpace(flags.filesJSON); raw != "" {
+		data, err := readAppJSONArgument(raw)
+		if err != nil {
+			return clankercloud.AppDeploymentInput{}, fmt.Errorf("read app files JSON: %w", err)
+		}
+		if err := json.Unmarshal(data, &files); err != nil {
+			return clankercloud.AppDeploymentInput{}, fmt.Errorf("decode app files JSON: %w", err)
+		}
+	}
+	if (html != "") == (len(files) > 0) {
+		return clankercloud.AppDeploymentInput{}, fmt.Errorf("provide exactly one of --html/--html-file or --files-json")
+	}
+
+	dataSummary, err := readAppJSONObject(flags.dataSummaryJSON)
+	if err != nil {
+		return clankercloud.AppDeploymentInput{}, fmt.Errorf("decode data summary: %w", err)
+	}
+	exposure, err := readAppJSONObject(flags.exposureJSON)
+	if err != nil {
+		return clankercloud.AppDeploymentInput{}, fmt.Errorf("decode exposure summary: %w", err)
+	}
+
+	return clankercloud.AppDeploymentInput{
+		HTML:          html,
+		Files:         files,
+		Entrypoint:    strings.TrimSpace(flags.entrypoint),
+		SPA:           flags.spa,
+		DataSummary:   dataSummary,
+		NetworkPolicy: "none",
+		Exposure:      exposure,
+	}, nil
+}
+
+func resolveCLIAppIdempotencyKey(raw string, operation string) (string, error) {
+	if strings.TrimSpace(raw) != "" {
+		return clankercloud.ValidateAppIdempotencyKey(raw)
+	}
+	random := make([]byte, 16)
+	if _, err := rand.Read(random); err != nil {
+		return "", fmt.Errorf("generate app idempotency key: %w", err)
+	}
+	prefix := strings.Trim(strings.ToLower(strings.TrimSpace(operation)), "-")
+	if prefix == "" {
+		prefix = "request"
+	}
+	return clankercloud.ValidateAppIdempotencyKey("cli-" + prefix + "-" + hex.EncodeToString(random))
+}
+
+func readAppJSONObject(raw string) (map[string]any, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	data, err := readAppJSONArgument(raw)
+	if err != nil {
+		return nil, err
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return nil, err
+	}
+	if decoded == nil {
+		return nil, fmt.Errorf("expected a JSON object")
+	}
+	return decoded, nil
+}
+
+func readAppJSONArgument(raw string) ([]byte, error) {
+	trimmed := strings.TrimSpace(raw)
+	if strings.HasPrefix(trimmed, "@") {
+		path := strings.TrimSpace(strings.TrimPrefix(trimmed, "@"))
+		if path == "" {
+			return nil, fmt.Errorf("JSON @path is empty")
+		}
+		return readBoundedAppFile(path)
+	}
+	if len(trimmed) > maxCLIAppInputBytes {
+		return nil, fmt.Errorf("inline JSON exceeds %d bytes", maxCLIAppInputBytes)
+	}
+	return []byte(trimmed), nil
+}
+
+func readBoundedAppFile(path string) ([]byte, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("%s is a directory", path)
+	}
+	if info.Size() > maxCLIAppInputBytes {
+		return nil, fmt.Errorf("%s exceeds %d bytes", path, maxCLIAppInputBytes)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if len(content) > maxCLIAppInputBytes {
+		return nil, fmt.Errorf("%s exceeds %d bytes", path, maxCLIAppInputBytes)
+	}
+	return content, nil
+}
+
+func printAppsResult(result *clankercloud.AppsAPIResult, err error) error {
+	if err != nil {
+		return err
+	}
+	if err := printJSON(result); err != nil {
+		return err
+	}
+	return clankercloud.AppsResultStatusError(result)
+}
+
+func init() {
+	cloudCmd.AddCommand(newCloudAppsCmd())
+}

--- a/cmd/cloud_apps_test.go
+++ b/cmd/cloud_apps_test.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bgdnvk/clanker/internal/clankercloud"
+)
+
+func TestCloudAppsCreateGeneratesCanonicalIdempotencyHeader(t *testing.T) {
+	var idempotencyKey string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		idempotencyKey = r.Header.Get("Idempotency-Key")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"ok":true,"app":{"id":"app_0123456789abcdefabcd","status":"draft"}}`))
+	}))
+	defer server.Close()
+
+	client := func() *clankercloud.AppsClient {
+		return clankercloud.NewAppsClient(clankercloud.AppsClientOptions{
+			BaseURL:    server.URL + "/api",
+			AccountKey: "account-token",
+			HTTPClient: server.Client(),
+		})
+	}
+	command := newCloudAppsCreateCmd(client)
+	command.SetArgs([]string{"Team CRM"})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("create command: %v", err)
+	}
+	if _, err := clankercloud.ValidateAppIdempotencyKey(idempotencyKey); err != nil {
+		t.Fatalf("generated Idempotency-Key %q: %v", idempotencyKey, err)
+	}
+	if !strings.HasPrefix(idempotencyKey, "cli-create-") {
+		t.Fatalf("generated Idempotency-Key = %q, want cli-create prefix", idempotencyKey)
+	}
+}
+
+func TestResolveCLIAppIdempotencyKeyPreservesValidExplicitKey(t *testing.T) {
+	const explicit = "manual-retry-key"
+	got, err := resolveCLIAppIdempotencyKey(explicit, "create")
+	if err != nil {
+		t.Fatalf("resolve explicit key: %v", err)
+	}
+	if got != explicit {
+		t.Fatalf("resolved key = %q, want %q", got, explicit)
+	}
+}
+
+func TestAppDeploymentFlagsRequireOneSourceAndPreserveEmptyFiles(t *testing.T) {
+	both := appDeploymentFlags{
+		html:      "<h1>hello</h1>",
+		filesJSON: `[{"path":"index.html","content":"hello"}]`,
+	}
+	if _, err := both.input(); err == nil {
+		t.Fatal("deployment flags accepted both HTML and files")
+	}
+
+	emptyFile := appDeploymentFlags{
+		filesJSON:  `[{"path":"index.html","content":""}]`,
+		entrypoint: "index.html",
+	}
+	input, err := emptyFile.input()
+	if err != nil {
+		t.Fatalf("decode empty file: %v", err)
+	}
+	if len(input.Files) != 1 || input.Files[0].Content == nil || *input.Files[0].Content != "" {
+		t.Fatalf("empty file was not preserved: %#v", input.Files)
+	}
+}

--- a/cmd/cloud_sandboxes.go
+++ b/cmd/cloud_sandboxes.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -27,7 +29,7 @@ func newCloudSandboxesCmd() *cobra.Command {
 		Use:     "sandboxes",
 		Aliases: []string{"sandbox"},
 		Short:   "Create and operate hosted Clanker Cloud sandboxes",
-		Long: strings.TrimSpace(`Create anonymous or account-owned Clanker Cloud sandboxes, then run commands or send task messages.
+		Long: strings.TrimSpace(`Create account-owned Clanker Cloud sandboxes, then run commands or send task messages. The run command also requires account ownership so a failed automatic cleanup can always be retried.
 
 The public sandbox API defaults to https://clankercloud.ai/api. Set CLANKER_CLOUD_API_KEY for account-owned sandboxes and CLANKER_SANDBOX_TOKEN for per-sandbox commands.`),
 	}
@@ -54,7 +56,11 @@ func newCloudSandboxesCreateCmd(client func() *clankercloud.SandboxClient) *cobr
 		Use:   "create",
 		Short: "Create a hosted sandbox",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			result, err := client().Create(cmd.Context(), clankercloud.SandboxCreateRequest{Name: name, Agent: agent, Region: region})
+			sandboxClient := client()
+			if sandboxClient.AccountKey() == "" {
+				return fmt.Errorf("CLANKER_CLOUD_API_KEY is required so the sandbox remains account-owned and cleanup can always be retried")
+			}
+			result, err := sandboxClient.Create(cmd.Context(), clankercloud.SandboxCreateRequest{Name: name, Agent: agent, Region: region})
 			return printSandboxResult(result, err)
 		},
 	}
@@ -101,6 +107,7 @@ func newCloudSandboxesDeleteCmd(client func() *clankercloud.SandboxClient) *cobr
 
 func newCloudSandboxesCommandCmd(client func() *clankercloud.SandboxClient) *cobra.Command {
 	var timeoutSeconds int
+	var workingDir string
 	cmd := &cobra.Command{
 		Use:   "command SANDBOX_ID COMMAND...",
 		Short: "Run a shell command in a sandbox",
@@ -108,6 +115,7 @@ func newCloudSandboxesCommandCmd(client func() *clankercloud.SandboxClient) *cob
 		RunE: func(cmd *cobra.Command, args []string) error {
 			payload := clankercloud.SandboxCommandRequest{
 				Command:        strings.Join(args[1:], " "),
+				WorkingDir:     workingDir,
 				TimeoutSeconds: timeoutSeconds,
 			}
 			result, err := client().Command(cmd.Context(), args[0], payload)
@@ -115,6 +123,7 @@ func newCloudSandboxesCommandCmd(client func() *clankercloud.SandboxClient) *cob
 		},
 	}
 	cmd.Flags().IntVar(&timeoutSeconds, "timeout-seconds", 0, "optional command timeout in seconds")
+	cmd.Flags().StringVar(&workingDir, "working-dir", "", "sandbox working directory (for example /workspace or /data)")
 	return cmd
 }
 
@@ -141,9 +150,10 @@ func newCloudSandboxesRunCmd(apiBaseURL *string, apiKey *string, sandboxToken *s
 	var name string
 	var agentName string
 	var region string
+	var keepSandbox bool
 	cmd := &cobra.Command{
 		Use:   "run TASK...",
-		Short: "Create a sandbox and send it a task message",
+		Short: "Run a task in an account-owned temporary sandbox",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			task := strings.TrimSpace(strings.Join(args, " "))
@@ -152,58 +162,83 @@ func newCloudSandboxesRunCmd(apiBaseURL *string, apiKey *string, sandboxToken *s
 				AccountKey:   derefString(apiKey),
 				SandboxToken: derefString(sandboxToken),
 			})
-			created, err := client.Create(cmd.Context(), clankercloud.SandboxCreateRequest{Name: name, Agent: agentName, Region: region})
-			if err != nil {
-				return err
+			if client.AccountKey() == "" {
+				return fmt.Errorf("CLANKER_CLOUD_API_KEY is required so the temporary sandbox remains manageable if automatic cleanup fails")
 			}
-			if !clankercloud.SandboxResultOK(created) {
-				_ = printJSON(created)
-				return clankercloud.SandboxResultStatusError(created)
-			}
-
-			sandboxID := clankercloud.ExtractSandboxID(created.Body)
-			token := clankercloud.ExtractSandboxToken(created.Body)
-			if sandboxID == "" {
-				_ = printJSON(created)
-				return fmt.Errorf("create response did not include a sandbox id")
-			}
-			if token == "" {
-				token = client.SandboxToken()
-			}
-			if token == "" {
-				token = client.AccountKey()
-			}
-			runClient := clankercloud.NewSandboxClient(clankercloud.SandboxClientOptions{
-				BaseURL:      derefString(apiBaseURL),
-				AccountKey:   derefString(apiKey),
-				SandboxToken: token,
-			})
-			message, err := runClient.Message(cmd.Context(), sandboxID, clankercloud.SandboxMessageRequest{
+			result, runErr := executeSandboxRun(cmd.Context(), client, clankercloud.SandboxCreateRequest{
+				Name:   name,
+				Agent:  agentName,
+				Region: region,
+			}, clankercloud.SandboxMessageRequest{
 				Role:    "user",
 				Content: task,
 				Metadata: map[string]any{
 					"source": "clanker-cli",
 					"mode":   "sandboxes.run",
 				},
-			})
-			if err != nil {
-				return err
-			}
-			out := map[string]any{
-				"created": created,
-				"message": message,
-			}
-			if !clankercloud.SandboxResultOK(message) {
-				_ = printJSON(out)
-				return clankercloud.SandboxResultStatusError(message)
-			}
-			return printJSON(out)
+			}, keepSandbox)
+			return errors.Join(printJSON(result), runErr)
 		},
 	}
 	cmd.Flags().StringVar(&name, "name", "agent-runner", "sandbox name")
 	cmd.Flags().StringVar(&agentName, "agent", "clanker-cli", "sandbox agent image")
 	cmd.Flags().StringVar(&region, "region", "earth", "sandbox region")
+	cmd.Flags().BoolVar(&keepSandbox, "keep-sandbox", false, "keep the account-owned sandbox after the task for debugging (default: dispose it)")
 	return cmd
+}
+
+func executeSandboxRun(
+	ctx context.Context,
+	client *clankercloud.SandboxClient,
+	createRequest clankercloud.SandboxCreateRequest,
+	messageRequest clankercloud.SandboxMessageRequest,
+	keepSandbox bool,
+) (map[string]any, error) {
+	out := map[string]any{}
+	if client == nil || client.AccountKey() == "" {
+		return out, fmt.Errorf("Clanker Cloud account API key is required for a manageable one-shot sandbox")
+	}
+	created, createErr := client.Create(ctx, createRequest)
+	if created != nil {
+		out["created"] = created
+	}
+	if createErr != nil {
+		return out, createErr
+	}
+	if !clankercloud.SandboxResultOK(created) {
+		return out, clankercloud.SandboxResultStatusError(created)
+	}
+
+	sandboxID := clankercloud.ExtractSandboxID(created.Body)
+	if sandboxID == "" {
+		return out, fmt.Errorf("create response did not include a sandbox id")
+	}
+	out["sandboxId"] = sandboxID
+
+	message, messageErr := client.Message(ctx, sandboxID, messageRequest)
+	if message != nil {
+		out["message"] = message
+	}
+	if messageErr == nil && !clankercloud.SandboxResultOK(message) {
+		messageErr = clankercloud.SandboxResultStatusError(message)
+	}
+
+	if keepSandbox {
+		out["sandboxRetained"] = true
+		return out, messageErr
+	}
+
+	disposal, disposalErr := client.Dispose(ctx, sandboxID)
+	if disposal != nil {
+		out["disposal"] = disposal
+		out["alreadyDisposed"] = disposal.Status == 404 && clankercloud.SandboxResultOK(disposal)
+	}
+	out["disposed"] = disposalErr == nil && clankercloud.SandboxResultOK(disposal)
+	if disposalErr != nil {
+		out["cleanupRequired"] = true
+		out["cleanupHint"] = fmt.Sprintf("Retry cleanup with: clanker cloud sandboxes delete %s", sandboxID)
+	}
+	return out, errors.Join(messageErr, disposalErr)
 }
 
 func printSandboxResult(result any, err error) error {

--- a/cmd/cloud_sandboxes_test.go
+++ b/cmd/cloud_sandboxes_test.go
@@ -1,0 +1,338 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bgdnvk/clanker/internal/clankercloud"
+)
+
+func TestExecuteSandboxRunDisposesAfterSuccess(t *testing.T) {
+	var messageCalls atomic.Int32
+	var deleteCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case "POST /api/sandboxes":
+			_, _ = w.Write([]byte(`{"box":{"id":"box_123"},"sandboxToken":"runtime-secret"}`))
+		case "POST /api/sandboxes/box_123/messages":
+			messageCalls.Add(1)
+			if got := r.Header.Get("X-API-Key"); got != "runtime-secret" {
+				t.Errorf("message token = %q, want cached sandbox token", got)
+			}
+			_, _ = w.Write([]byte(`{"ok":true,"message":"done"}`))
+		case "DELETE /api/sandboxes/box_123":
+			deleteCalls.Add(1)
+			if got := r.Header.Get("X-API-Key"); got != "runtime-secret" {
+				t.Errorf("delete token = %q, want cached sandbox token", got)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := clankercloud.NewSandboxClient(clankercloud.SandboxClientOptions{
+		BaseURL:    server.URL + "/api",
+		AccountKey: "account-token",
+		HTTPClient: server.Client(),
+	})
+	result, err := executeSandboxRun(
+		context.Background(),
+		client,
+		clankercloud.SandboxCreateRequest{Name: "temporary"},
+		clankercloud.SandboxMessageRequest{Content: "build it"},
+		false,
+	)
+	if err != nil {
+		t.Fatalf("executeSandboxRun: %v", err)
+	}
+	if result["disposed"] != true {
+		t.Fatalf("result = %#v, want disposed=true", result)
+	}
+	if messageCalls.Load() != 1 || deleteCalls.Load() != 1 {
+		t.Fatalf("message calls=%d delete calls=%d, want 1 each", messageCalls.Load(), deleteCalls.Load())
+	}
+	created, ok := result["created"].(*clankercloud.SandboxAPIResult)
+	if !ok {
+		t.Fatalf("created result type = %T", result["created"])
+	}
+	if strings.Contains(strings.ToLower(toJSONForTest(created)), "runtime-secret") {
+		t.Fatalf("created result exposed sandbox token: %#v", created)
+	}
+}
+
+func TestExecuteSandboxRunDisposesAfterMessageFailure(t *testing.T) {
+	var deleteCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case "POST /api/sandboxes":
+			_, _ = w.Write([]byte(`{"box":{"id":"box_123"},"sandboxToken":"runtime-secret"}`))
+		case "POST /api/sandboxes/box_123/messages":
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"agent failed"}`))
+		case "DELETE /api/sandboxes/box_123":
+			deleteCalls.Add(1)
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"ok":false,"error":"sandbox not found"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := clankercloud.NewSandboxClient(clankercloud.SandboxClientOptions{
+		BaseURL:    server.URL + "/api",
+		AccountKey: "account-token",
+		HTTPClient: server.Client(),
+	})
+	result, err := executeSandboxRun(
+		context.Background(),
+		client,
+		clankercloud.SandboxCreateRequest{Name: "temporary"},
+		clankercloud.SandboxMessageRequest{Content: "build it"},
+		false,
+	)
+	if err == nil || !strings.Contains(err.Error(), "status 500") {
+		t.Fatalf("executeSandboxRun error = %v, want message status error", err)
+	}
+	if result["disposed"] != true || result["alreadyDisposed"] != true {
+		t.Fatalf("result = %#v, want idempotent disposal metadata", result)
+	}
+	if deleteCalls.Load() != 1 {
+		t.Fatalf("delete calls=%d, want 1", deleteCalls.Load())
+	}
+}
+
+func TestExecuteSandboxRunKeepSandboxOptOut(t *testing.T) {
+	var deleteCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case "POST /api/sandboxes":
+			_, _ = w.Write([]byte(`{"box":{"id":"box_123"},"sandboxToken":"runtime-secret"}`))
+		case "POST /api/sandboxes/box_123/messages":
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		case "DELETE /api/sandboxes/box_123":
+			deleteCalls.Add(1)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := clankercloud.NewSandboxClient(clankercloud.SandboxClientOptions{
+		BaseURL:    server.URL + "/api",
+		AccountKey: "account-token",
+		HTTPClient: server.Client(),
+	})
+	result, err := executeSandboxRun(
+		context.Background(),
+		client,
+		clankercloud.SandboxCreateRequest{Name: "retained"},
+		clankercloud.SandboxMessageRequest{Content: "inspect it"},
+		true,
+	)
+	if err != nil {
+		t.Fatalf("executeSandboxRun: %v", err)
+	}
+	if result["sandboxRetained"] != true || deleteCalls.Load() != 0 {
+		t.Fatalf("result=%#v delete calls=%d", result, deleteCalls.Load())
+	}
+}
+
+func TestExecuteSandboxRunReportsManageableCleanupFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case "POST /api/sandboxes":
+			_, _ = w.Write([]byte(`{"box":{"id":"box_cleanup"},"sandboxToken":"runtime-secret"}`))
+		case "POST /api/sandboxes/box_cleanup/messages":
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		case "DELETE /api/sandboxes/box_cleanup":
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"ok":false,"error":"cleanup temporarily unavailable"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := clankercloud.NewSandboxClient(clankercloud.SandboxClientOptions{
+		BaseURL:    server.URL + "/api",
+		AccountKey: "account-token",
+		HTTPClient: server.Client(),
+	})
+	result, err := executeSandboxRun(
+		context.Background(),
+		client,
+		clankercloud.SandboxCreateRequest{Name: "temporary"},
+		clankercloud.SandboxMessageRequest{Content: "build it"},
+		false,
+	)
+	if err == nil || !strings.Contains(err.Error(), "status 503") {
+		t.Fatalf("executeSandboxRun error = %v, want cleanup status error", err)
+	}
+	if result["sandboxId"] != "box_cleanup" || result["disposed"] != false || result["cleanupRequired"] != true {
+		t.Fatalf("cleanup failure result = %#v", result)
+	}
+	if hint, _ := result["cleanupHint"].(string); !strings.Contains(hint, "clanker cloud sandboxes delete box_cleanup") {
+		t.Fatalf("cleanup hint = %q", hint)
+	}
+}
+
+func TestExecuteSandboxRunDisposesAfterParentCancellation(t *testing.T) {
+	messageStarted := make(chan struct{})
+	var deleteCalls atomic.Int32
+	httpClient := &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		switch r.Method + " " + r.URL.Path {
+		case "POST /api/sandboxes":
+			return testHTTPResponse(http.StatusOK, `{"box":{"id":"box_cancel"},"sandboxToken":"runtime-secret"}`), nil
+		case "POST /api/sandboxes/box_cancel/messages":
+			close(messageStarted)
+			<-r.Context().Done()
+			return nil, r.Context().Err()
+		case "DELETE /api/sandboxes/box_cancel":
+			deleteCalls.Add(1)
+			if err := r.Context().Err(); err != nil {
+				t.Errorf("cleanup inherited cancelled context: %v", err)
+			}
+			return testHTTPResponse(http.StatusNoContent, ""), nil
+		default:
+			return testHTTPResponse(http.StatusNotFound, `{"ok":false,"error":"route not found"}`), nil
+		}
+	})}
+
+	client := clankercloud.NewSandboxClient(clankercloud.SandboxClientOptions{
+		BaseURL:    "http://127.0.0.1:8080/api",
+		AccountKey: "account-token",
+		HTTPClient: httpClient,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	type runResult struct {
+		value map[string]any
+		err   error
+	}
+	done := make(chan runResult, 1)
+	go func() {
+		value, err := executeSandboxRun(
+			ctx,
+			client,
+			clankercloud.SandboxCreateRequest{Name: "temporary"},
+			clankercloud.SandboxMessageRequest{Content: "wait"},
+			false,
+		)
+		done <- runResult{value: value, err: err}
+	}()
+
+	select {
+	case <-messageStarted:
+		cancel()
+	case <-time.After(5 * time.Second):
+		t.Fatal("message request did not start")
+	}
+
+	select {
+	case result := <-done:
+		if result.err == nil || !strings.Contains(result.err.Error(), "context canceled") {
+			t.Fatalf("executeSandboxRun error = %v, want cancellation", result.err)
+		}
+		if result.value["disposed"] != true {
+			t.Fatalf("cancellation result = %#v, want disposed=true", result.value)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("executeSandboxRun did not finish after cancellation")
+	}
+	if deleteCalls.Load() != 1 {
+		t.Fatalf("delete calls = %d, want cleanup after cancellation", deleteCalls.Load())
+	}
+}
+
+func TestExecuteSandboxRunRequiresManageableAccount(t *testing.T) {
+	client := clankercloud.NewSandboxClient(clankercloud.SandboxClientOptions{
+		BaseURL: "https://clankercloud.ai/api",
+	})
+	result, err := executeSandboxRun(
+		context.Background(),
+		client,
+		clankercloud.SandboxCreateRequest{Name: "unmanaged"},
+		clankercloud.SandboxMessageRequest{Content: "run"},
+		false,
+	)
+	if err == nil || !strings.Contains(err.Error(), "account API key is required") {
+		t.Fatalf("executeSandboxRun error = %v, want account requirement", err)
+	}
+	if len(result) != 0 {
+		t.Fatalf("account failure result = %#v, want no created sandbox", result)
+	}
+}
+
+func TestTrustedMCPSandboxTaskMetadataReservesProvenance(t *testing.T) {
+	metadata := trustedMCPSandboxTaskMetadata(map[string]any{
+		"source": "spoofed",
+		"mode":   "persistent",
+		"Source": "also-spoofed",
+		"ticket": "INC-123",
+	})
+	if metadata["source"] != "clanker-mcp" || metadata["mode"] != "sandbox-task" {
+		t.Fatalf("trusted metadata was overwritten: %#v", metadata)
+	}
+	if metadata["ticket"] != "INC-123" {
+		t.Fatalf("user metadata was lost: %#v", metadata)
+	}
+	if _, present := metadata["Source"]; present {
+		t.Fatalf("case-variant provenance key was retained: %#v", metadata)
+	}
+}
+
+func TestMCPSandboxSchemasDoNotExposeCredentialsOrEndpoints(t *testing.T) {
+	types := []reflect.Type{
+		reflect.TypeOf(cloudSandboxCreateArgs{}),
+		reflect.TypeOf(cloudSandboxListArgs{}),
+		reflect.TypeOf(cloudSandboxIDArgs{}),
+		reflect.TypeOf(cloudSandboxCommandArgs{}),
+		reflect.TypeOf(cloudSandboxMessageArgs{}),
+		reflect.TypeOf(cloudSandboxTaskArgs{}),
+	}
+	for _, typ := range types {
+		for index := 0; index < typ.NumField(); index++ {
+			field := typ.Field(index)
+			jsonName := strings.Split(field.Tag.Get("json"), ",")[0]
+			switch jsonName {
+			case "apiBaseUrl", "apiKey", "sandboxToken":
+				t.Fatalf("%s exposes forbidden MCP field %q", typ.Name(), jsonName)
+			}
+		}
+	}
+}
+
+func toJSONForTest(value any) string {
+	encoded, _ := json.Marshal(value)
+	return string(encoded)
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
+
+func testHTTPResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}

--- a/cmd/mcp_cloud_sandboxes.go
+++ b/cmd/mcp_cloud_sandboxes.go
@@ -11,67 +11,55 @@ import (
 )
 
 type cloudSandboxCreateArgs struct {
-	Name       string         `json:"name,omitempty" jsonschema:"description=Sandbox name; defaults to agent-sandbox."`
-	Agent      string         `json:"agent,omitempty" jsonschema:"description=Agent image: clanker-cli, codex, claude-code, openclaw, hermes, empty, or clanker-vision."`
-	Region     string         `json:"region,omitempty" jsonschema:"description=Sandbox region; defaults to earth."`
-	Metadata   map[string]any `json:"metadata,omitempty" jsonschema:"description=Optional non-secret orchestration metadata."`
-	APIBaseURL string         `json:"apiBaseUrl,omitempty" jsonschema:"description=Sandbox API base URL; defaults to CLANKER_CLOUD_SANDBOX_API_BASE_URL or https://clankercloud.ai/api."`
-	APIKey     string         `json:"apiKey,omitempty" jsonschema:"description=Clanker Cloud account API key; defaults to CLANKER_CLOUD_API_KEY."`
+	Name     string         `json:"name,omitempty" jsonschema:"description=Sandbox name; defaults to agent-sandbox."`
+	Agent    string         `json:"agent,omitempty" jsonschema:"description=Agent image: clanker-cli, codex, claude-code, openclaw, hermes, empty, or clanker-vision."`
+	Region   string         `json:"region,omitempty" jsonschema:"description=Sandbox region; defaults to earth."`
+	Metadata map[string]any `json:"metadata,omitempty" jsonschema:"description=Optional non-secret orchestration metadata."`
 }
 
-type cloudSandboxListArgs struct {
-	APIBaseURL string `json:"apiBaseUrl,omitempty" jsonschema:"description=Sandbox API base URL."`
-	APIKey     string `json:"apiKey,omitempty" jsonschema:"description=Clanker Cloud account API key; defaults to CLANKER_CLOUD_API_KEY."`
-}
+type cloudSandboxListArgs struct{}
 
 type cloudSandboxIDArgs struct {
-	SandboxID    string `json:"sandboxId" jsonschema:"description=Sandbox id,required"`
-	APIBaseURL   string `json:"apiBaseUrl,omitempty" jsonschema:"description=Sandbox API base URL."`
-	APIKey       string `json:"apiKey,omitempty" jsonschema:"description=Clanker Cloud account API key; defaults to CLANKER_CLOUD_API_KEY."`
-	SandboxToken string `json:"sandboxToken,omitempty" jsonschema:"description=Sandbox token returned by create; defaults to CLANKER_SANDBOX_TOKEN."`
+	SandboxID string `json:"sandboxId" jsonschema:"description=Sandbox id,required"`
 }
 
 type cloudSandboxCommandArgs struct {
 	SandboxID      string            `json:"sandboxId" jsonschema:"description=Sandbox id,required"`
 	Command        string            `json:"command" jsonschema:"description=Shell command to run in the sandbox,required"`
+	WorkingDir     string            `json:"workingDir,omitempty" jsonschema:"description=Optional sandbox working directory such as /workspace or /data."`
 	TimeoutSeconds int               `json:"timeoutSeconds,omitempty" jsonschema:"description=Optional command timeout in seconds."`
 	Env            map[string]string `json:"env,omitempty" jsonschema:"description=Optional non-secret environment variables for the command."`
-	APIBaseURL     string            `json:"apiBaseUrl,omitempty" jsonschema:"description=Sandbox API base URL."`
-	APIKey         string            `json:"apiKey,omitempty" jsonschema:"description=Clanker Cloud account API key; defaults to CLANKER_CLOUD_API_KEY."`
-	SandboxToken   string            `json:"sandboxToken,omitempty" jsonschema:"description=Sandbox token returned by create; defaults to CLANKER_SANDBOX_TOKEN."`
 }
 
 type cloudSandboxMessageArgs struct {
-	SandboxID    string         `json:"sandboxId" jsonschema:"description=Sandbox id,required"`
-	Role         string         `json:"role,omitempty" jsonschema:"description=Message role; defaults to user."`
-	Content      string         `json:"content" jsonschema:"description=Message content to send to the sandbox agent,required"`
-	Metadata     map[string]any `json:"metadata,omitempty" jsonschema:"description=Optional non-secret orchestration metadata."`
-	APIBaseURL   string         `json:"apiBaseUrl,omitempty" jsonschema:"description=Sandbox API base URL."`
-	APIKey       string         `json:"apiKey,omitempty" jsonschema:"description=Clanker Cloud account API key; defaults to CLANKER_CLOUD_API_KEY."`
-	SandboxToken string         `json:"sandboxToken,omitempty" jsonschema:"description=Sandbox token returned by create; defaults to CLANKER_SANDBOX_TOKEN."`
+	SandboxID string         `json:"sandboxId" jsonschema:"description=Sandbox id,required"`
+	Role      string         `json:"role,omitempty" jsonschema:"description=Message role; defaults to user."`
+	Content   string         `json:"content" jsonschema:"description=Message content to send to the sandbox agent,required"`
+	Metadata  map[string]any `json:"metadata,omitempty" jsonschema:"description=Optional non-secret orchestration metadata."`
 }
 
 type cloudSandboxTaskArgs struct {
-	Task       string         `json:"task" jsonschema:"description=Task to send to the new sandbox agent,required"`
-	Name       string         `json:"name,omitempty" jsonschema:"description=Sandbox name; defaults to agent-runner."`
-	Agent      string         `json:"agent,omitempty" jsonschema:"description=Agent image; defaults to clanker-cli."`
-	Region     string         `json:"region,omitempty" jsonschema:"description=Sandbox region; defaults to earth."`
-	Metadata   map[string]any `json:"metadata,omitempty" jsonschema:"description=Optional non-secret orchestration metadata."`
-	APIBaseURL string         `json:"apiBaseUrl,omitempty" jsonschema:"description=Sandbox API base URL."`
-	APIKey     string         `json:"apiKey,omitempty" jsonschema:"description=Clanker Cloud account API key; defaults to CLANKER_CLOUD_API_KEY."`
+	Task     string         `json:"task" jsonschema:"description=Task to send to the new sandbox agent,required"`
+	Name     string         `json:"name,omitempty" jsonschema:"description=Sandbox name; defaults to agent-runner."`
+	Agent    string         `json:"agent,omitempty" jsonschema:"description=Agent image; defaults to clanker-cli."`
+	Region   string         `json:"region,omitempty" jsonschema:"description=Sandbox region; defaults to earth."`
+	Metadata map[string]any `json:"metadata,omitempty" jsonschema:"description=Optional non-secret orchestration metadata."`
 }
 
 func registerCloudSandboxMCPTools(server *mcptransport.MCPServer) {
 	server.AddTool(
 		mcp.NewTool(
 			"clanker_cloud_create_sandbox",
-			mcp.WithDescription("Create an anonymous or account-owned hosted Clanker Cloud sandbox. The response includes sandboxToken; keep it out of user-visible transcripts unless the user explicitly asks."),
+			mcp.WithDescription("Create an account-owned hosted Clanker Cloud sandbox using trusted server configuration. The sandbox remains allocated until it is explicitly deleted."),
 			mcp.WithInputSchema[cloudSandboxCreateArgs](),
 			mcp.WithDestructiveHintAnnotation(false),
 			mcp.WithIdempotentHintAnnotation(false),
 		),
 		mcp.NewTypedToolHandler(func(ctx context.Context, _ mcp.CallToolRequest, args cloudSandboxCreateArgs) (*mcp.CallToolResult, error) {
-			client := newMCPSandboxClient(args.APIBaseURL, args.APIKey, "")
+			client := newMCPSandboxClient()
+			if client.AccountKey() == "" {
+				return mcp.NewToolResultError("CLANKER_CLOUD_API_KEY is required so the sandbox remains account-owned and cleanup can always be retried"), nil
+			}
 			result, err := client.Create(ctx, clankercloud.SandboxCreateRequest{
 				Name:     args.Name,
 				Agent:    args.Agent,
@@ -90,7 +78,7 @@ func registerCloudSandboxMCPTools(server *mcptransport.MCPServer) {
 			mcp.WithReadOnlyHintAnnotation(true),
 		),
 		mcp.NewTypedToolHandler(func(ctx context.Context, _ mcp.CallToolRequest, args cloudSandboxListArgs) (*mcp.CallToolResult, error) {
-			result, err := newMCPSandboxClient(args.APIBaseURL, args.APIKey, "").List(ctx)
+			result, err := newMCPSandboxClient().List(ctx)
 			return mcpSandboxResult(result, err)
 		}),
 	)
@@ -106,7 +94,7 @@ func registerCloudSandboxMCPTools(server *mcptransport.MCPServer) {
 			if strings.TrimSpace(args.SandboxID) == "" {
 				return mcp.NewToolResultError("sandboxId is required"), nil
 			}
-			result, err := newMCPSandboxClient(args.APIBaseURL, args.APIKey, args.SandboxToken).Inspect(ctx, args.SandboxID)
+			result, err := newMCPSandboxClient().Inspect(ctx, args.SandboxID)
 			return mcpSandboxResult(result, err)
 		}),
 	)
@@ -117,13 +105,13 @@ func registerCloudSandboxMCPTools(server *mcptransport.MCPServer) {
 			mcp.WithDescription("Delete one hosted Clanker Cloud sandbox by id. Use only after user approval if the sandbox still contains needed work."),
 			mcp.WithInputSchema[cloudSandboxIDArgs](),
 			mcp.WithDestructiveHintAnnotation(true),
-			mcp.WithIdempotentHintAnnotation(false),
+			mcp.WithIdempotentHintAnnotation(true),
 		),
 		mcp.NewTypedToolHandler(func(ctx context.Context, _ mcp.CallToolRequest, args cloudSandboxIDArgs) (*mcp.CallToolResult, error) {
 			if strings.TrimSpace(args.SandboxID) == "" {
 				return mcp.NewToolResultError("sandboxId is required"), nil
 			}
-			result, err := newMCPSandboxClient(args.APIBaseURL, args.APIKey, args.SandboxToken).Delete(ctx, args.SandboxID)
+			result, err := newMCPSandboxClient().Delete(ctx, args.SandboxID)
 			return mcpSandboxResult(result, err)
 		}),
 	)
@@ -131,9 +119,9 @@ func registerCloudSandboxMCPTools(server *mcptransport.MCPServer) {
 	server.AddTool(
 		mcp.NewTool(
 			"clanker_cloud_run_sandbox_command",
-			mcp.WithDescription("Run a shell command in a hosted Clanker Cloud sandbox. Prefer read-only commands unless the user has approved side effects."),
+			mcp.WithDescription("Run a shell command in a hosted Clanker Cloud sandbox. Shell commands may change or delete data and require appropriate user authorization."),
 			mcp.WithInputSchema[cloudSandboxCommandArgs](),
-			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithDestructiveHintAnnotation(true),
 		),
 		mcp.NewTypedToolHandler(func(ctx context.Context, _ mcp.CallToolRequest, args cloudSandboxCommandArgs) (*mcp.CallToolResult, error) {
 			if strings.TrimSpace(args.SandboxID) == "" {
@@ -142,8 +130,9 @@ func registerCloudSandboxMCPTools(server *mcptransport.MCPServer) {
 			if strings.TrimSpace(args.Command) == "" {
 				return mcp.NewToolResultError("command is required"), nil
 			}
-			result, err := newMCPSandboxClient(args.APIBaseURL, args.APIKey, args.SandboxToken).Command(ctx, args.SandboxID, clankercloud.SandboxCommandRequest{
+			result, err := newMCPSandboxClient().Command(ctx, args.SandboxID, clankercloud.SandboxCommandRequest{
 				Command:        args.Command,
+				WorkingDir:     args.WorkingDir,
 				TimeoutSeconds: args.TimeoutSeconds,
 				Env:            args.Env,
 			})
@@ -154,9 +143,9 @@ func registerCloudSandboxMCPTools(server *mcptransport.MCPServer) {
 	server.AddTool(
 		mcp.NewTool(
 			"clanker_cloud_send_sandbox_message",
-			mcp.WithDescription("Send a message to a hosted Clanker Cloud sandbox agent."),
+			mcp.WithDescription("Send a message to a hosted Clanker Cloud sandbox agent. Agent messages may cause side effects in the sandbox."),
 			mcp.WithInputSchema[cloudSandboxMessageArgs](),
-			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithDestructiveHintAnnotation(true),
 		),
 		mcp.NewTypedToolHandler(func(ctx context.Context, _ mcp.CallToolRequest, args cloudSandboxMessageArgs) (*mcp.CallToolResult, error) {
 			if strings.TrimSpace(args.SandboxID) == "" {
@@ -165,7 +154,7 @@ func registerCloudSandboxMCPTools(server *mcptransport.MCPServer) {
 			if strings.TrimSpace(args.Content) == "" {
 				return mcp.NewToolResultError("content is required"), nil
 			}
-			result, err := newMCPSandboxClient(args.APIBaseURL, args.APIKey, args.SandboxToken).Message(ctx, args.SandboxID, clankercloud.SandboxMessageRequest{
+			result, err := newMCPSandboxClient().Message(ctx, args.SandboxID, clankercloud.SandboxMessageRequest{
 				Role:     args.Role,
 				Content:  args.Content,
 				Metadata: args.Metadata,
@@ -177,62 +166,55 @@ func registerCloudSandboxMCPTools(server *mcptransport.MCPServer) {
 	server.AddTool(
 		mcp.NewTool(
 			"clanker_cloud_run_sandbox_task",
-			mcp.WithDescription("Create a hosted Clanker Cloud sandbox and send the initial task message to its agent."),
+			mcp.WithDescription("Create an account-owned temporary Clanker Cloud sandbox, run one task, and dispose the sandbox before returning. Account ownership preserves a manual cleanup path if automatic disposal fails."),
 			mcp.WithInputSchema[cloudSandboxTaskArgs](),
-			mcp.WithDestructiveHintAnnotation(false),
+			mcp.WithDestructiveHintAnnotation(true),
 			mcp.WithIdempotentHintAnnotation(false),
 		),
 		mcp.NewTypedToolHandler(func(ctx context.Context, _ mcp.CallToolRequest, args cloudSandboxTaskArgs) (*mcp.CallToolResult, error) {
 			if strings.TrimSpace(args.Task) == "" {
 				return mcp.NewToolResultError("task is required"), nil
 			}
-			client := newMCPSandboxClient(args.APIBaseURL, args.APIKey, "")
-			metadata := map[string]any{
-				"source": "clanker-mcp",
-				"mode":   "sandbox-task",
+			client := newMCPSandboxClient()
+			if client.AccountKey() == "" {
+				return mcp.NewToolResultError("CLANKER_CLOUD_API_KEY is required so the temporary sandbox remains manageable if automatic cleanup fails"), nil
 			}
-			for key, value := range args.Metadata {
-				metadata[key] = value
-			}
-			created, err := client.Create(ctx, clankercloud.SandboxCreateRequest{
+			metadata := trustedMCPSandboxTaskMetadata(args.Metadata)
+			result, err := executeSandboxRun(ctx, client, clankercloud.SandboxCreateRequest{
 				Name:     firstNonEmpty(args.Name, "agent-runner"),
 				Agent:    args.Agent,
 				Region:   args.Region,
 				Metadata: metadata,
-			})
-			if err != nil {
-				return mcp.NewToolResultError(err.Error()), nil
-			}
-			if !clankercloud.SandboxResultOK(created) {
-				return mcp.NewToolResultJSON(map[string]any{"created": created})
-			}
-			sandboxID := clankercloud.ExtractSandboxID(created.Body)
-			if sandboxID == "" {
-				return mcp.NewToolResultError("create response did not include a sandbox id"), nil
-			}
-			token := firstNonEmpty(clankercloud.ExtractSandboxToken(created.Body), client.SandboxToken(), client.AccountKey())
-			message, err := newMCPSandboxClient(args.APIBaseURL, args.APIKey, token).Message(ctx, sandboxID, clankercloud.SandboxMessageRequest{
+			}, clankercloud.SandboxMessageRequest{
 				Role:     "user",
 				Content:  args.Task,
 				Metadata: metadata,
-			})
+			}, false)
 			if err != nil {
-				return mcp.NewToolResultError(err.Error()), nil
+				result["ok"] = false
+				result["error"] = err.Error()
 			}
-			return mcp.NewToolResultJSON(map[string]any{
-				"created": created,
-				"message": message,
-			})
+			return mcp.NewToolResultJSON(result)
 		}),
 	)
 }
 
-func newMCPSandboxClient(apiBaseURL string, apiKey string, sandboxToken string) *clankercloud.SandboxClient {
-	return clankercloud.NewSandboxClient(clankercloud.SandboxClientOptions{
-		BaseURL:      apiBaseURL,
-		AccountKey:   apiKey,
-		SandboxToken: sandboxToken,
-	})
+func newMCPSandboxClient() *clankercloud.SandboxClient {
+	return clankercloud.NewSandboxClient(clankercloud.SandboxClientOptions{})
+}
+
+func trustedMCPSandboxTaskMetadata(input map[string]any) map[string]any {
+	metadata := make(map[string]any, len(input)+2)
+	for key, value := range input {
+		switch strings.ToLower(strings.TrimSpace(key)) {
+		case "source", "mode":
+			continue
+		}
+		metadata[key] = value
+	}
+	metadata["source"] = "clanker-mcp"
+	metadata["mode"] = "sandbox-task"
+	return metadata
 }
 
 func mcpSandboxResult(result *clankercloud.SandboxAPIResult, err error) (*mcp.CallToolResult, error) {

--- a/internal/clankercloud/apps.go
+++ b/internal/clankercloud/apps.go
@@ -1,0 +1,235 @@
+package clankercloud
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+)
+
+var appIdempotencyKeyPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$`)
+
+type AppsClient struct {
+	httpClient *http.Client
+	baseURL    string
+	accountKey string
+}
+
+type AppsClientOptions struct {
+	BaseURL    string
+	AccountKey string
+	HTTPClient *http.Client
+}
+
+type AppsAPIResult = APIResult
+
+type AppFile struct {
+	Path        string  `json:"path"`
+	Content     *string `json:"content,omitempty"`
+	Base64      *string `json:"base64,omitempty"`
+	ContentType string  `json:"contentType,omitempty"`
+}
+
+type AppCreateRequest struct {
+	Name           string         `json:"name"`
+	Description    string         `json:"description,omitempty"`
+	ProjectID      string         `json:"projectId,omitempty"`
+	Metadata       map[string]any `json:"metadata,omitempty"`
+	IdempotencyKey string         `json:"-"`
+}
+
+// AppDeploymentInput creates an immutable private deployment. It does not
+// activate or publish that deployment.
+type AppDeploymentInput struct {
+	HTML          string         `json:"html,omitempty"`
+	Files         []AppFile      `json:"files,omitempty"`
+	Entrypoint    string         `json:"entrypoint,omitempty"`
+	SPA           bool           `json:"spa,omitempty"`
+	DataSummary   map[string]any `json:"dataSummary,omitempty"`
+	NetworkPolicy string         `json:"networkPolicy"`
+	Exposure      map[string]any `json:"exposure,omitempty"`
+}
+
+type AppDeploymentCreateRequest struct {
+	AppDeploymentInput
+	IdempotencyKey string `json:"-"`
+}
+
+func NewAppsClient(opts AppsClientOptions) *AppsClient {
+	httpClient := opts.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultHTTPTimeout}
+	}
+	configuredAppsBaseURL := os.Getenv("CLANKER_CLOUD_APPS_API_BASE_URL")
+	configuredSandboxBaseURL := os.Getenv("CLANKER_CLOUD_SANDBOX_API_BASE_URL")
+	configuredLegacyBaseURL := os.Getenv("CLANKER_SANDBOX_API_BASE_URL")
+	accountKey := strings.TrimSpace(opts.AccountKey)
+	if configuredCredentialAllowed(opts.BaseURL, configuredAppsBaseURL, configuredSandboxBaseURL, configuredLegacyBaseURL) {
+		accountKey = firstNonEmpty(accountKey, os.Getenv("CLANKER_CLOUD_API_KEY"))
+	}
+	return &AppsClient{
+		httpClient: httpClient,
+		baseURL: firstNonEmpty(
+			opts.BaseURL,
+			configuredAppsBaseURL,
+			configuredSandboxBaseURL,
+			configuredLegacyBaseURL,
+			DefaultCloudAPIBaseURL,
+		),
+		accountKey: accountKey,
+	}
+}
+
+func (c *AppsClient) BaseURL() (string, error) {
+	return NormalizeCloudAPIBaseURL(c.baseURL)
+}
+
+func (c *AppsClient) AccountKey() string {
+	return strings.TrimSpace(c.accountKey)
+}
+
+func (c *AppsClient) ListApps(ctx context.Context) (*AppsAPIResult, error) {
+	return c.callJSON(ctx, http.MethodGet, "/apps", nil, "")
+}
+
+func (c *AppsClient) CreateApp(ctx context.Context, payload AppCreateRequest) (*AppsAPIResult, error) {
+	if strings.TrimSpace(payload.Name) == "" {
+		return nil, fmt.Errorf("app name is required")
+	}
+	idempotencyKey, err := ValidateAppIdempotencyKey(payload.IdempotencyKey)
+	if err != nil {
+		return nil, err
+	}
+	payload.Name = strings.TrimSpace(payload.Name)
+	payload.Description = strings.TrimSpace(payload.Description)
+	payload.ProjectID = strings.TrimSpace(payload.ProjectID)
+	return c.callJSON(ctx, http.MethodPost, "/apps", payload, idempotencyKey)
+}
+
+func (c *AppsClient) GetApp(ctx context.Context, appID string) (*AppsAPIResult, error) {
+	escaped, err := requiredCloudID("app", appID)
+	if err != nil {
+		return nil, err
+	}
+	return c.callJSON(ctx, http.MethodGet, "/apps/"+escaped, nil, "")
+}
+
+func (c *AppsClient) DeleteApp(ctx context.Context, appID string) (*AppsAPIResult, error) {
+	escaped, err := requiredCloudID("app", appID)
+	if err != nil {
+		return nil, err
+	}
+	return c.callJSON(ctx, http.MethodDelete, "/apps/"+escaped, nil, "")
+}
+
+func (c *AppsClient) ListDeployments(ctx context.Context, appID string) (*AppsAPIResult, error) {
+	escaped, err := requiredCloudID("app", appID)
+	if err != nil {
+		return nil, err
+	}
+	return c.callJSON(ctx, http.MethodGet, "/apps/"+escaped+"/deployments", nil, "")
+}
+
+func (c *AppsClient) CreateDeployment(ctx context.Context, appID string, payload AppDeploymentCreateRequest) (*AppsAPIResult, error) {
+	escaped, err := requiredCloudID("app", appID)
+	if err != nil {
+		return nil, err
+	}
+	hasHTML := payload.HTML != ""
+	hasFiles := len(payload.Files) > 0
+	if hasHTML == hasFiles {
+		return nil, fmt.Errorf("provide exactly one of deployment html or files")
+	}
+	for _, file := range payload.Files {
+		if strings.TrimSpace(file.Path) == "" {
+			return nil, fmt.Errorf("deployment file path is required")
+		}
+		if (file.Content == nil) == (file.Base64 == nil) {
+			return nil, fmt.Errorf("%s must provide exactly one of content or base64", strings.TrimSpace(file.Path))
+		}
+	}
+	if strings.TrimSpace(payload.Entrypoint) == "" {
+		payload.Entrypoint = "index.html"
+	}
+	if strings.TrimSpace(payload.NetworkPolicy) == "" {
+		payload.NetworkPolicy = "none"
+	}
+	if !strings.EqualFold(strings.TrimSpace(payload.NetworkPolicy), "none") {
+		return nil, fmt.Errorf("network policy must be none for static app deployments")
+	}
+	idempotencyKey, err := ValidateAppIdempotencyKey(payload.IdempotencyKey)
+	if err != nil {
+		return nil, err
+	}
+	payload.NetworkPolicy = "none"
+	return c.callJSON(ctx, http.MethodPost, "/apps/"+escaped+"/deployments", payload, idempotencyKey)
+}
+
+func (c *AppsClient) ActivateDeployment(ctx context.Context, appID string, deploymentID string) (*AppsAPIResult, error) {
+	escapedAppID, err := requiredCloudID("app", appID)
+	if err != nil {
+		return nil, err
+	}
+	escapedDeploymentID, err := requiredCloudID("deployment", deploymentID)
+	if err != nil {
+		return nil, err
+	}
+	path := "/apps/" + escapedAppID + "/deployments/" + escapedDeploymentID + "/activate"
+	return c.callJSON(ctx, http.MethodPost, path, map[string]any{}, "")
+}
+
+func (c *AppsClient) UnpublishApp(ctx context.Context, appID string) (*AppsAPIResult, error) {
+	escaped, err := requiredCloudID("app", appID)
+	if err != nil {
+		return nil, err
+	}
+	return c.callJSON(ctx, http.MethodPost, "/apps/"+escaped+"/unpublish", map[string]any{}, "")
+}
+
+func (c *AppsClient) callJSON(ctx context.Context, method string, path string, body any, idempotencyKey string) (*AppsAPIResult, error) {
+	baseURL, err := c.BaseURL()
+	if err != nil {
+		return nil, err
+	}
+	if c.AccountKey() == "" {
+		return nil, fmt.Errorf("Clanker Cloud account API key is required")
+	}
+	headers := make(http.Header)
+	if key := strings.TrimSpace(idempotencyKey); key != "" {
+		headers.Set("Idempotency-Key", key)
+	}
+	result, _, err := callCloudJSON(ctx, c.httpClient, baseURL, method, path, c.AccountKey(), body, headers)
+	return result, err
+}
+
+func AppsResultOK(result *AppsAPIResult) bool {
+	return CloudResultOK(result) || cloudDeleteResourceNotFound(result, "app not found")
+}
+
+func AppsResultStatusError(result *AppsAPIResult) error {
+	if cloudDeleteResourceNotFound(result, "app not found") {
+		return nil
+	}
+	return CloudResultStatusError("app", result)
+}
+
+// ValidateAppIdempotencyKey mirrors the hosted Apps API contract so invalid
+// requests fail locally instead of consuming a network attempt.
+func ValidateAppIdempotencyKey(raw string) (string, error) {
+	value := strings.TrimSpace(raw)
+	if !appIdempotencyKeyPattern.MatchString(value) {
+		return "", fmt.Errorf("idempotency key must be 8-128 characters using letters, numbers, dot, underscore, colon, or hyphen")
+	}
+	return value, nil
+}
+
+func requiredCloudID(kind string, raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", fmt.Errorf("%s id is required", kind)
+	}
+	return url.PathEscape(trimmed), nil
+}

--- a/internal/clankercloud/apps_test.go
+++ b/internal/clankercloud/apps_test.go
@@ -1,0 +1,251 @@
+package clankercloud
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAppsClientLifecycleRoutesAndPrivatePayloads(t *testing.T) {
+	var requests []string
+	var createPayload map[string]any
+	var deploymentPayload map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.URL.Path)
+		if got := r.Header.Get("X-API-Key"); got != "account-token" {
+			t.Errorf("%s X-API-Key = %q, want account-token", r.URL.Path, got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method + " " + r.URL.Path {
+		case "GET /api/apps":
+			_, _ = w.Write([]byte(`{"ok":true,"apps":[]}`))
+		case "POST /api/apps":
+			if got := r.Header.Get("Idempotency-Key"); got != "create-key" {
+				t.Errorf("create Idempotency-Key = %q", got)
+			}
+			if err := json.NewDecoder(r.Body).Decode(&createPayload); err != nil {
+				t.Errorf("decode create payload: %v", err)
+			}
+			_, _ = w.Write([]byte(`{"ok":true,"app":{"id":"app_123","visibility":"private"}}`))
+		case "GET /api/apps/app_123":
+			_, _ = w.Write([]byte(`{"ok":true,"app":{"id":"app_123"}}`))
+		case "DELETE /api/apps/app_123":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"ok":false,"error":"app not found"}`))
+		case "GET /api/apps/app_123/deployments":
+			_, _ = w.Write([]byte(`{"ok":true,"deployments":[]}`))
+		case "POST /api/apps/app_123/deployments":
+			if got := r.Header.Get("Idempotency-Key"); got != "deployment-key" {
+				t.Errorf("deployment Idempotency-Key = %q", got)
+			}
+			if err := json.NewDecoder(r.Body).Decode(&deploymentPayload); err != nil {
+				t.Errorf("decode deployment payload: %v", err)
+			}
+			_, _ = w.Write([]byte(`{"ok":true,"deployment":{"id":"dep_123","status":"private"}}`))
+		case "POST /api/apps/app_123/deployments/dep_123/activate":
+			_, _ = w.Write([]byte(`{"ok":true,"publicUrl":"https://apps.example/app_123"}`))
+		case "POST /api/apps/app_123/unpublish":
+			_, _ = w.Write([]byte(`{"ok":true,"published":false}`))
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := NewAppsClient(AppsClientOptions{
+		BaseURL:    server.URL + "/api",
+		AccountKey: "account-token",
+		HTTPClient: server.Client(),
+	})
+	ctx := context.Background()
+
+	if result, err := client.ListApps(ctx); err != nil || !AppsResultOK(result) {
+		t.Fatalf("ListApps result=%#v err=%v", result, err)
+	}
+	createResult, err := client.CreateApp(ctx, AppCreateRequest{
+		Name:        "Customer CRM",
+		Description: "Shared contact workspace",
+		ProjectID:   "project_123",
+		Metadata: map[string]any{
+			"source": "clanker-cli",
+		},
+		IdempotencyKey: "create-key",
+	})
+	if err != nil || !AppsResultOK(createResult) {
+		t.Fatalf("CreateApp result=%#v err=%v", createResult, err)
+	}
+	if createPayload["name"] != "Customer CRM" || createPayload["description"] != "Shared contact workspace" || createPayload["projectId"] != "project_123" {
+		t.Fatalf("create payload = %#v", createPayload)
+	}
+	for _, forbidden := range []string{"html", "files", "entrypoint", "spa", "activate"} {
+		if _, ok := createPayload[forbidden]; ok {
+			t.Fatalf("metadata-only create payload included %q: %#v", forbidden, createPayload)
+		}
+	}
+
+	if result, err := client.GetApp(ctx, "app_123"); err != nil || !AppsResultOK(result) {
+		t.Fatalf("GetApp result=%#v err=%v", result, err)
+	}
+	if result, err := client.ListDeployments(ctx, "app_123"); err != nil || !AppsResultOK(result) {
+		t.Fatalf("ListDeployments result=%#v err=%v", result, err)
+	}
+	indexHTML := "<h1>Revision 2</h1>"
+	emptyCSS := ""
+	deploymentResult, err := client.CreateDeployment(ctx, "app_123", AppDeploymentCreateRequest{
+		AppDeploymentInput: AppDeploymentInput{
+			Files: []AppFile{
+				{Path: "index.html", Content: &indexHTML},
+				{Path: "assets/empty.css", Content: &emptyCSS},
+			},
+			Entrypoint: "index.html",
+			DataSummary: map[string]any{
+				"records": 12,
+			},
+			NetworkPolicy: "none",
+			Exposure: map[string]any{
+				"publicFields": []any{"name", "company"},
+			},
+		},
+		IdempotencyKey: "deployment-key",
+	})
+	if err != nil || !AppsResultOK(deploymentResult) {
+		t.Fatalf("CreateDeployment result=%#v err=%v", deploymentResult, err)
+	}
+	if deploymentPayload["networkPolicy"] != "none" {
+		t.Fatalf("deployment payload = %#v", deploymentPayload)
+	}
+	filesPayload, ok := deploymentPayload["files"].([]any)
+	if !ok || len(filesPayload) != 2 {
+		t.Fatalf("deployment files payload = %#v", deploymentPayload["files"])
+	}
+	emptyFile, ok := filesPayload[1].(map[string]any)
+	if !ok || emptyFile["path"] != "assets/empty.css" {
+		t.Fatalf("empty file payload = %#v", filesPayload[1])
+	}
+	if content, present := emptyFile["content"]; !present || content != "" {
+		t.Fatalf("empty file content was omitted: %#v", emptyFile)
+	}
+	for _, forbidden := range []string{"name", "activate"} {
+		if _, ok := deploymentPayload[forbidden]; ok {
+			t.Fatalf("private deployment payload included %q: %#v", forbidden, deploymentPayload)
+		}
+	}
+
+	if result, err := client.ActivateDeployment(ctx, "app_123", "dep_123"); err != nil || !AppsResultOK(result) {
+		t.Fatalf("ActivateDeployment result=%#v err=%v", result, err)
+	}
+	if result, err := client.UnpublishApp(ctx, "app_123"); err != nil || !AppsResultOK(result) {
+		t.Fatalf("UnpublishApp result=%#v err=%v", result, err)
+	}
+	if result, err := client.DeleteApp(ctx, "app_123"); err != nil || !AppsResultOK(result) {
+		t.Fatalf("DeleteApp result=%#v err=%v", result, err)
+	}
+
+	want := []string{
+		"GET /api/apps",
+		"POST /api/apps",
+		"GET /api/apps/app_123",
+		"GET /api/apps/app_123/deployments",
+		"POST /api/apps/app_123/deployments",
+		"POST /api/apps/app_123/deployments/dep_123/activate",
+		"POST /api/apps/app_123/unpublish",
+		"DELETE /api/apps/app_123",
+	}
+	if len(requests) != len(want) {
+		t.Fatalf("requests = %#v, want %#v", requests, want)
+	}
+	for index := range want {
+		if requests[index] != want[index] {
+			t.Fatalf("request[%d] = %q, want %q", index, requests[index], want[index])
+		}
+	}
+}
+
+func TestAppsClientRequiresNamesAndIDs(t *testing.T) {
+	client := NewAppsClient(AppsClientOptions{BaseURL: "https://clankercloud.ai/api", AccountKey: "account-token"})
+	if _, err := client.CreateApp(context.Background(), AppCreateRequest{}); err == nil {
+		t.Fatal("CreateApp without a name succeeded")
+	}
+	if _, err := client.GetApp(context.Background(), " "); err == nil {
+		t.Fatal("GetApp without an id succeeded")
+	}
+	if _, err := client.ActivateDeployment(context.Background(), "app_123", " "); err == nil {
+		t.Fatal("ActivateDeployment without a deployment id succeeded")
+	}
+	if _, err := client.CreateApp(context.Background(), AppCreateRequest{
+		Name:           "Too many retries",
+		IdempotencyKey: strings.Repeat("x", 129),
+	}); err == nil {
+		t.Fatal("CreateApp accepted an oversized idempotency key")
+	}
+	for _, key := range []string{"", "1234567", "invalid key", "invalid/key"} {
+		if _, err := client.CreateApp(context.Background(), AppCreateRequest{
+			Name:           "Invalid retry key",
+			IdempotencyKey: key,
+		}); err == nil {
+			t.Fatalf("CreateApp accepted invalid idempotency key %q", key)
+		}
+	}
+	if _, err := client.CreateDeployment(context.Background(), "app_123", AppDeploymentCreateRequest{
+		AppDeploymentInput: AppDeploymentInput{HTML: "<h1>unsafe</h1>", NetworkPolicy: "connect"},
+		IdempotencyKey:     "deploy-valid-key",
+	}); err == nil {
+		t.Fatal("CreateDeployment accepted a network-enabled static app")
+	}
+}
+
+func TestAppsClientRequiresExactlyOneArtifactSourceAndFileEncoding(t *testing.T) {
+	content := "<h1>hello</h1>"
+	base64Content := "PGgxPmhlbGxvPC9oMT4="
+	client := NewAppsClient(AppsClientOptions{
+		BaseURL:    "https://clankercloud.ai/api",
+		AccountKey: "account-token",
+	})
+	ctx := context.Background()
+
+	cases := []AppDeploymentCreateRequest{
+		{IdempotencyKey: "artifact-none-key"},
+		{
+			AppDeploymentInput: AppDeploymentInput{
+				HTML:  content,
+				Files: []AppFile{{Path: "index.html", Content: &content}},
+			},
+			IdempotencyKey: "artifact-both-key",
+		},
+		{
+			AppDeploymentInput: AppDeploymentInput{
+				Files: []AppFile{{Path: "index.html"}},
+			},
+			IdempotencyKey: "encoding-none-key",
+		},
+		{
+			AppDeploymentInput: AppDeploymentInput{
+				Files: []AppFile{{Path: "index.html", Content: &content, Base64: &base64Content}},
+			},
+			IdempotencyKey: "encoding-both-key",
+		},
+	}
+	for index, payload := range cases {
+		if _, err := client.CreateDeployment(ctx, "app_123", payload); err == nil {
+			t.Fatalf("invalid artifact case %d succeeded", index)
+		}
+	}
+}
+
+func TestAppsDeleteRejectsUnstructuredRouteNotFound(t *testing.T) {
+	result := &AppsAPIResult{
+		Method: http.MethodDelete,
+		Status: http.StatusNotFound,
+		Body:   map[string]any{"error": "app route not found"},
+	}
+	if AppsResultOK(result) {
+		t.Fatal("unstructured route 404 was treated as successful deletion")
+	}
+	if err := AppsResultStatusError(result); err == nil {
+		t.Fatal("unstructured route 404 did not return an error")
+	}
+}

--- a/internal/clankercloud/cloud_api.go
+++ b/internal/clankercloud/cloud_api.go
@@ -1,0 +1,313 @@
+package clankercloud
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const (
+	DefaultCloudAPIBaseURL   = "https://clankercloud.ai/api"
+	maxCloudAPIResponseBytes = 8 << 20
+)
+
+// APIResult is the safe, user-presentable envelope returned by hosted Clanker
+// Cloud API clients. Credential-bearing fields and unsafe response headers are
+// removed before this value leaves the client package.
+type APIResult struct {
+	BaseURL     string            `json:"baseUrl"`
+	Method      string            `json:"method"`
+	Path        string            `json:"path"`
+	Status      int               `json:"status"`
+	ContentType string            `json:"contentType,omitempty"`
+	Headers     map[string]string `json:"headers,omitempty"`
+	Body        any               `json:"body,omitempty"`
+}
+
+// NormalizeCloudAPIBaseURL accepts HTTPS endpoints and loopback HTTP endpoints
+// used by local development. The API prefix remains explicit so credentials
+// cannot accidentally be sent to a site root.
+func NormalizeCloudAPIBaseURL(raw string) (string, error) {
+	trimmed := strings.TrimRight(strings.TrimSpace(raw), "/")
+	if trimmed == "" {
+		return "", fmt.Errorf("clanker cloud API base URL is empty")
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("parse clanker cloud API base URL: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("clanker cloud API base URL must use https or loopback http")
+	}
+	if parsed.Hostname() == "" {
+		return "", fmt.Errorf("clanker cloud API base URL must include a host")
+	}
+	if parsed.Scheme == "http" && !isLoopbackHost(parsed.Hostname()) {
+		return "", fmt.Errorf("clanker cloud API base URL must use https unless the host is loopback")
+	}
+	if parsed.User != nil {
+		return "", fmt.Errorf("clanker cloud API base URL must not include user info")
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", fmt.Errorf("clanker cloud API base URL must not include query or fragment")
+	}
+	path := strings.TrimRight(parsed.EscapedPath(), "/")
+	if path == "" {
+		parsed.Path = "/api"
+		parsed.RawPath = ""
+	} else if path != "/api" && !strings.HasSuffix(path, "/api") {
+		return "", fmt.Errorf("clanker cloud API base URL must end with /api")
+	}
+	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+func hardenedCloudHTTPClient(source *http.Client) *http.Client {
+	if source == nil {
+		source = &http.Client{Timeout: defaultHTTPTimeout}
+	}
+	clone := *source
+	originalCheckRedirect := source.CheckRedirect
+	clone.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) > 0 && !sameOriginURL(via[0].URL, req.URL) {
+			return fmt.Errorf("refusing cross-origin Clanker Cloud API redirect")
+		}
+		if originalCheckRedirect != nil {
+			return originalCheckRedirect(req, via)
+		}
+		if len(via) >= 10 {
+			return fmt.Errorf("stopped after 10 redirects")
+		}
+		return nil
+	}
+	return &clone
+}
+
+func sameOriginURL(left, right *url.URL) bool {
+	if left == nil || right == nil {
+		return false
+	}
+	return strings.EqualFold(left.Scheme, right.Scheme) &&
+		strings.EqualFold(left.Host, right.Host)
+}
+
+// configuredCredentialAllowed prevents an untrusted per-call base URL from
+// silently receiving credentials loaded from the process environment. A
+// caller using a custom explicit URL must also pass its credential explicitly.
+func configuredCredentialAllowed(explicitBaseURL string, configuredBaseURLs ...string) bool {
+	if strings.TrimSpace(explicitBaseURL) == "" {
+		return true
+	}
+	explicit, err := NormalizeCloudAPIBaseURL(explicitBaseURL)
+	if err != nil {
+		return false
+	}
+	candidates := append([]string{DefaultCloudAPIBaseURL}, configuredBaseURLs...)
+	for _, candidate := range candidates {
+		if strings.TrimSpace(candidate) == "" {
+			continue
+		}
+		normalized, err := NormalizeCloudAPIBaseURL(candidate)
+		if err == nil && sameOriginAndPath(explicit, normalized) {
+			return true
+		}
+	}
+	return false
+}
+
+func sameOriginAndPath(left string, right string) bool {
+	leftURL, leftErr := url.Parse(left)
+	rightURL, rightErr := url.Parse(right)
+	if leftErr != nil || rightErr != nil || !sameOriginURL(leftURL, rightURL) {
+		return false
+	}
+	return strings.TrimRight(leftURL.EscapedPath(), "/") == strings.TrimRight(rightURL.EscapedPath(), "/")
+}
+
+func callCloudJSON(
+	ctx context.Context,
+	httpClient *http.Client,
+	baseURL string,
+	method string,
+	path string,
+	token string,
+	body any,
+	extraHeaders http.Header,
+) (*APIResult, any, error) {
+	normalizedBaseURL, err := NormalizeCloudAPIBaseURL(baseURL)
+	if err != nil {
+		return nil, nil, err
+	}
+	trimmedPath := strings.TrimSpace(path)
+	if !strings.HasPrefix(trimmedPath, "/") {
+		trimmedPath = "/" + trimmedPath
+	}
+
+	var bodyReader io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return nil, nil, fmt.Errorf("encode Clanker Cloud request: %w", err)
+		}
+		bodyReader = bytes.NewReader(encoded)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, strings.TrimRight(normalizedBaseURL, "/")+trimmedPath, bodyReader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create Clanker Cloud request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	for key, values := range extraHeaders {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+	if trimmedToken := strings.TrimSpace(token); trimmedToken != "" {
+		req.Header.Set("X-API-Key", trimmedToken)
+	}
+
+	resp, err := hardenedCloudHTTPClient(httpClient).Do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("perform Clanker Cloud request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	result := &APIResult{
+		BaseURL:     normalizedBaseURL,
+		Method:      method,
+		Path:        trimmedPath,
+		Status:      resp.StatusCode,
+		ContentType: resp.Header.Get("Content-Type"),
+		Headers:     safeCloudResponseHeaders(resp.Header),
+	}
+
+	rawBody, err := io.ReadAll(io.LimitReader(resp.Body, maxCloudAPIResponseBytes+1))
+	if err != nil {
+		return nil, nil, fmt.Errorf("read Clanker Cloud response: %w", err)
+	}
+	if len(rawBody) > maxCloudAPIResponseBytes {
+		return nil, nil, fmt.Errorf("Clanker Cloud response exceeds %d bytes", maxCloudAPIResponseBytes)
+	}
+	decoded := decodeBody(rawBody)
+	result.Body = RedactCloudSecrets(decoded)
+	return result, decoded, nil
+}
+
+func safeCloudResponseHeaders(headers http.Header) map[string]string {
+	allowed := []string{
+		"Cache-Control",
+		"CF-Ray",
+		"ETag",
+		"Retry-After",
+		"Traceparent",
+		"X-Request-ID",
+	}
+	safe := make(map[string]string, len(allowed))
+	for _, key := range allowed {
+		if values := headers.Values(key); len(values) > 0 {
+			safe[http.CanonicalHeaderKey(key)] = strings.Join(values, ", ")
+		}
+	}
+	return safe
+}
+
+// RedactCloudSecrets creates a redacted copy suitable for CLI and MCP output.
+func RedactCloudSecrets(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		redacted := make(map[string]any, len(typed))
+		for key, item := range typed {
+			if sensitiveCloudField(key) {
+				redacted[key] = "[REDACTED]"
+				continue
+			}
+			redacted[key] = RedactCloudSecrets(item)
+		}
+		return redacted
+	case []any:
+		redacted := make([]any, len(typed))
+		for index, item := range typed {
+			redacted[index] = RedactCloudSecrets(item)
+		}
+		return redacted
+	default:
+		return value
+	}
+}
+
+func sensitiveCloudField(key string) bool {
+	normalized := strings.NewReplacer("-", "", "_", "", ".", "").Replace(strings.ToLower(strings.TrimSpace(key)))
+	switch normalized {
+	case "apikey",
+		"authorization",
+		"bearer",
+		"clientsecret",
+		"cookie",
+		"credential",
+		"credentials",
+		"deletetoken",
+		"idtoken",
+		"jwt",
+		"password",
+		"privatekey",
+		"refreshtoken",
+		"runtimetoken",
+		"sandboxtoken",
+		"secret",
+		"secretkey",
+		"setcookie",
+		"signingkey",
+		"token",
+		"accesstoken":
+		return true
+	default:
+		return strings.HasSuffix(normalized, "token") ||
+			strings.HasSuffix(normalized, "secret") ||
+			strings.HasSuffix(normalized, "password") ||
+			strings.HasSuffix(normalized, "credential")
+	}
+}
+
+func CloudResultOK(result *APIResult) bool {
+	return result != nil && result.Status >= 200 && result.Status < 300
+}
+
+func CloudResultStatusError(resource string, result *APIResult) error {
+	if CloudResultOK(result) {
+		return nil
+	}
+	if result == nil {
+		return fmt.Errorf("%s request failed", resource)
+	}
+	return fmt.Errorf("%s request returned status %d", resource, result.Status)
+}
+
+func cloudDeleteResourceNotFound(result *APIResult, expectedErrors ...string) bool {
+	if result == nil || result.Method != http.MethodDelete || result.Status != http.StatusNotFound {
+		return false
+	}
+	body, ok := result.Body.(map[string]any)
+	if !ok {
+		return false
+	}
+	if responseOK, present := body["ok"]; !present || responseOK != false {
+		return false
+	}
+	message, ok := body["error"].(string)
+	if !ok {
+		return false
+	}
+	message = strings.TrimSpace(message)
+	for _, expected := range expectedErrors {
+		if message == expected {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/clankercloud/sandbox.go
+++ b/internal/clankercloud/sandbox.go
@@ -1,23 +1,21 @@
 package clankercloud
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"fmt"
-	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
+	"sync"
+	"time"
 )
 
-const DefaultSandboxAPIBaseURL = "https://clankercloud.ai/api"
+const DefaultSandboxAPIBaseURL = DefaultCloudAPIBaseURL
 
 type SandboxClient struct {
 	httpClient   *http.Client
 	baseURL      string
 	accountKey   string
+	tokenMu      sync.RWMutex
 	sandboxToken string
 }
 
@@ -28,15 +26,7 @@ type SandboxClientOptions struct {
 	HTTPClient   *http.Client
 }
 
-type SandboxAPIResult struct {
-	BaseURL     string            `json:"baseUrl"`
-	Method      string            `json:"method"`
-	Path        string            `json:"path"`
-	Status      int               `json:"status"`
-	ContentType string            `json:"contentType,omitempty"`
-	Headers     map[string]string `json:"headers,omitempty"`
-	Body        any               `json:"body,omitempty"`
-}
+type SandboxAPIResult = APIResult
 
 type SandboxCreateRequest struct {
 	Name     string         `json:"name,omitempty"`
@@ -47,6 +37,7 @@ type SandboxCreateRequest struct {
 
 type SandboxCommandRequest struct {
 	Command        string            `json:"command"`
+	WorkingDir     string            `json:"workingDir,omitempty"`
 	TimeoutSeconds int               `json:"timeoutSeconds,omitempty"`
 	Env            map[string]string `json:"env,omitempty"`
 }
@@ -62,39 +53,24 @@ func NewSandboxClient(opts SandboxClientOptions) *SandboxClient {
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: defaultHTTPTimeout}
 	}
+	configuredSandboxBaseURL := os.Getenv("CLANKER_CLOUD_SANDBOX_API_BASE_URL")
+	configuredLegacyBaseURL := os.Getenv("CLANKER_SANDBOX_API_BASE_URL")
+	accountKey := strings.TrimSpace(opts.AccountKey)
+	sandboxToken := strings.TrimSpace(opts.SandboxToken)
+	if configuredCredentialAllowed(opts.BaseURL, configuredSandboxBaseURL, configuredLegacyBaseURL) {
+		accountKey = firstNonEmpty(accountKey, os.Getenv("CLANKER_CLOUD_API_KEY"))
+		sandboxToken = firstNonEmpty(sandboxToken, os.Getenv("CLANKER_SANDBOX_TOKEN"))
+	}
 	return &SandboxClient{
 		httpClient:   httpClient,
-		baseURL:      firstNonEmpty(opts.BaseURL, os.Getenv("CLANKER_CLOUD_SANDBOX_API_BASE_URL"), os.Getenv("CLANKER_SANDBOX_API_BASE_URL"), DefaultSandboxAPIBaseURL),
-		accountKey:   firstNonEmpty(opts.AccountKey, os.Getenv("CLANKER_CLOUD_API_KEY")),
-		sandboxToken: firstNonEmpty(opts.SandboxToken, os.Getenv("CLANKER_SANDBOX_TOKEN")),
+		baseURL:      firstNonEmpty(opts.BaseURL, configuredSandboxBaseURL, configuredLegacyBaseURL, DefaultSandboxAPIBaseURL),
+		accountKey:   accountKey,
+		sandboxToken: sandboxToken,
 	}
 }
 
 func NormalizeSandboxAPIBaseURL(raw string) (string, error) {
-	trimmed := strings.TrimRight(strings.TrimSpace(raw), "/")
-	if trimmed == "" {
-		return "", fmt.Errorf("clanker cloud sandbox API base URL is empty")
-	}
-	parsed, err := url.Parse(trimmed)
-	if err != nil {
-		return "", fmt.Errorf("parse clanker cloud sandbox API base URL: %w", err)
-	}
-	if parsed.Scheme != "http" && parsed.Scheme != "https" {
-		return "", fmt.Errorf("clanker cloud sandbox API base URL must use http or https")
-	}
-	if parsed.User != nil {
-		return "", fmt.Errorf("clanker cloud sandbox API base URL must not include user info")
-	}
-	if parsed.RawQuery != "" || parsed.Fragment != "" {
-		return "", fmt.Errorf("clanker cloud sandbox API base URL must not include query or fragment")
-	}
-	path := strings.TrimRight(parsed.EscapedPath(), "/")
-	if path == "" {
-		parsed.Path = "/api"
-	} else if path != "/api" && !strings.HasSuffix(path, "/api") {
-		return "", fmt.Errorf("clanker cloud sandbox API base URL must end with /api")
-	}
-	return strings.TrimRight(parsed.String(), "/"), nil
+	return NormalizeCloudAPIBaseURL(raw)
 }
 
 func (c *SandboxClient) BaseURL() (string, error) {
@@ -106,6 +82,8 @@ func (c *SandboxClient) AccountKey() string {
 }
 
 func (c *SandboxClient) SandboxToken() string {
+	c.tokenMu.RLock()
+	defer c.tokenMu.RUnlock()
 	return strings.TrimSpace(c.sandboxToken)
 }
 
@@ -119,7 +97,13 @@ func (c *SandboxClient) Create(ctx context.Context, payload SandboxCreateRequest
 	if strings.TrimSpace(payload.Region) == "" {
 		payload.Region = "earth"
 	}
-	return c.callJSON(ctx, http.MethodPost, "/sandboxes", c.AccountKey(), payload)
+	result, rawBody, err := c.callJSONWithRawBody(ctx, http.MethodPost, "/sandboxes", c.AccountKey(), payload)
+	if err == nil && SandboxResultOK(result) {
+		if token := ExtractSandboxToken(rawBody); token != "" {
+			c.setSandboxToken(token)
+		}
+	}
+	return result, err
 }
 
 func (c *SandboxClient) List(ctx context.Context) (*SandboxAPIResult, error) {
@@ -127,97 +111,96 @@ func (c *SandboxClient) List(ctx context.Context) (*SandboxAPIResult, error) {
 }
 
 func (c *SandboxClient) Inspect(ctx context.Context, sandboxID string) (*SandboxAPIResult, error) {
-	return c.callJSON(ctx, http.MethodGet, "/sandboxes/"+url.PathEscape(strings.TrimSpace(sandboxID)), c.preferredSandboxToken(), nil)
-}
-
-func (c *SandboxClient) Delete(ctx context.Context, sandboxID string) (*SandboxAPIResult, error) {
-	return c.callJSON(ctx, http.MethodDelete, "/sandboxes/"+url.PathEscape(strings.TrimSpace(sandboxID)), c.preferredSandboxToken(), nil)
-}
-
-func (c *SandboxClient) Command(ctx context.Context, sandboxID string, payload SandboxCommandRequest) (*SandboxAPIResult, error) {
-	return c.callJSON(ctx, http.MethodPost, "/sandboxes/"+url.PathEscape(strings.TrimSpace(sandboxID))+"/commands", c.preferredSandboxToken(), payload)
-}
-
-func (c *SandboxClient) Message(ctx context.Context, sandboxID string, payload SandboxMessageRequest) (*SandboxAPIResult, error) {
-	if strings.TrimSpace(payload.Role) == "" {
-		payload.Role = "user"
-	}
-	return c.callJSON(ctx, http.MethodPost, "/sandboxes/"+url.PathEscape(strings.TrimSpace(sandboxID))+"/messages", c.preferredSandboxToken(), payload)
-}
-
-func (c *SandboxClient) preferredSandboxToken() string {
-	return firstNonEmpty(c.sandboxToken, c.accountKey)
-}
-
-func (c *SandboxClient) callJSON(ctx context.Context, method string, path string, token string, body any) (*SandboxAPIResult, error) {
-	baseURL, err := c.BaseURL()
+	escaped, err := requiredCloudID("sandbox", sandboxID)
 	if err != nil {
 		return nil, err
 	}
-	trimmedPath := strings.TrimSpace(path)
-	if !strings.HasPrefix(trimmedPath, "/") {
-		trimmedPath = "/" + trimmedPath
-	}
+	return c.callJSON(ctx, http.MethodGet, "/sandboxes/"+escaped, c.preferredSandboxToken(), nil)
+}
 
-	var bodyReader io.Reader
-	if body != nil {
-		encoded, err := json.Marshal(body)
-		if err != nil {
-			return nil, fmt.Errorf("encode sandbox request: %w", err)
-		}
-		bodyReader = bytes.NewReader(encoded)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, method, strings.TrimRight(baseURL, "/")+trimmedPath, bodyReader)
+func (c *SandboxClient) Delete(ctx context.Context, sandboxID string) (*SandboxAPIResult, error) {
+	escaped, err := requiredCloudID("sandbox", sandboxID)
 	if err != nil {
-		return nil, fmt.Errorf("create sandbox request: %w", err)
+		return nil, err
 	}
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
+	path := "/sandboxes/" + escaped
+	token := c.preferredSandboxToken()
+	result, err := c.callJSON(ctx, http.MethodDelete, path, token, nil)
+	if err == nil &&
+		result != nil &&
+		(result.Status == http.StatusUnauthorized || result.Status == http.StatusForbidden) &&
+		c.AccountKey() != "" &&
+		token != c.AccountKey() {
+		return c.callJSON(ctx, http.MethodDelete, path, c.AccountKey(), nil)
 	}
-	if trimmedToken := strings.TrimSpace(token); trimmedToken != "" {
-		req.Header.Set("X-API-Key", trimmedToken)
-	}
+	return result, err
+}
 
-	resp, err := c.httpClient.Do(req)
+// Dispose deletes a sandbox with a fresh bounded context so cleanup still runs
+// after a command or parent request is cancelled. DELETE 404 is treated as an
+// idempotent already-disposed result.
+func (c *SandboxClient) Dispose(ctx context.Context, sandboxID string) (*SandboxAPIResult, error) {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
+	defer cancel()
+	result, err := c.Delete(cleanupCtx, sandboxID)
 	if err != nil {
-		return nil, fmt.Errorf("perform sandbox request: %w", err)
+		return result, err
 	}
-	defer resp.Body.Close()
+	return result, SandboxResultStatusError(result)
+}
 
-	result := &SandboxAPIResult{
-		BaseURL:     baseURL,
-		Method:      method,
-		Path:        trimmedPath,
-		Status:      resp.StatusCode,
-		ContentType: resp.Header.Get("Content-Type"),
-		Headers:     map[string]string{},
-	}
-	for key, values := range resp.Header {
-		if len(values) > 0 {
-			result.Headers[key] = strings.Join(values, ", ")
-		}
-	}
-	rawBody, err := io.ReadAll(resp.Body)
+func (c *SandboxClient) Command(ctx context.Context, sandboxID string, payload SandboxCommandRequest) (*SandboxAPIResult, error) {
+	escaped, err := requiredCloudID("sandbox", sandboxID)
 	if err != nil {
-		return nil, fmt.Errorf("read sandbox response: %w", err)
+		return nil, err
 	}
-	result.Body = decodeBody(rawBody)
-	return result, nil
+	return c.callJSON(ctx, http.MethodPost, "/sandboxes/"+escaped+"/commands", c.preferredSandboxToken(), payload)
+}
+
+func (c *SandboxClient) Message(ctx context.Context, sandboxID string, payload SandboxMessageRequest) (*SandboxAPIResult, error) {
+	escaped, err := requiredCloudID("sandbox", sandboxID)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(payload.Role) == "" {
+		payload.Role = "user"
+	}
+	return c.callJSON(ctx, http.MethodPost, "/sandboxes/"+escaped+"/messages", c.preferredSandboxToken(), payload)
+}
+
+func (c *SandboxClient) preferredSandboxToken() string {
+	return firstNonEmpty(c.SandboxToken(), c.accountKey)
+}
+
+func (c *SandboxClient) callJSON(ctx context.Context, method string, path string, token string, body any) (*SandboxAPIResult, error) {
+	result, _, err := c.callJSONWithRawBody(ctx, method, path, token, body)
+	return result, err
+}
+
+func (c *SandboxClient) callJSONWithRawBody(ctx context.Context, method string, path string, token string, body any) (*SandboxAPIResult, any, error) {
+	baseURL, err := c.BaseURL()
+	if err != nil {
+		return nil, nil, err
+	}
+	return callCloudJSON(ctx, c.httpClient, baseURL, method, path, token, body, nil)
+}
+
+func (c *SandboxClient) setSandboxToken(token string) {
+	c.tokenMu.Lock()
+	defer c.tokenMu.Unlock()
+	c.sandboxToken = strings.TrimSpace(token)
 }
 
 func SandboxResultOK(result *SandboxAPIResult) bool {
-	return result != nil && result.Status >= 200 && result.Status < 300
+	return CloudResultOK(result) ||
+		cloudDeleteResourceNotFound(result, "sandbox not found", "box not found")
 }
 
 func SandboxResultStatusError(result *SandboxAPIResult) error {
-	if SandboxResultOK(result) {
+	if cloudDeleteResourceNotFound(result, "sandbox not found", "box not found") {
 		return nil
 	}
-	if result == nil {
-		return fmt.Errorf("sandbox request failed")
-	}
-	return fmt.Errorf("sandbox request returned status %d", result.Status)
+	return CloudResultStatusError("sandbox", result)
 }
 
 func ExtractSandboxID(body any) string {
@@ -232,9 +215,16 @@ func ExtractSandboxID(body any) string {
 
 func ExtractSandboxToken(body any) string {
 	if token := extractStringAt(body, "sandboxToken"); token != "" {
-		return token
+		if token != "[REDACTED]" {
+			return token
+		}
+		return ""
 	}
-	return extractStringAt(body, "token")
+	token := extractStringAt(body, "token")
+	if token == "[REDACTED]" {
+		return ""
+	}
+	return token
 }
 
 func extractStringAt(value any, path ...string) string {

--- a/internal/clankercloud/sandbox_test.go
+++ b/internal/clankercloud/sandbox_test.go
@@ -3,8 +3,11 @@ package clankercloud
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -18,6 +21,8 @@ func TestNormalizeSandboxAPIBaseURL(t *testing.T) {
 		{name: "default host with api path", raw: "https://clankercloud.ai/api/", want: "https://clankercloud.ai/api"},
 		{name: "host without path appends api", raw: "https://clankercloud.ai", want: "https://clankercloud.ai/api"},
 		{name: "nested api path", raw: "https://gateway.example.com/v1/api", want: "https://gateway.example.com/v1/api"},
+		{name: "loopback http allowed", raw: "http://127.0.0.1:8080/api", want: "http://127.0.0.1:8080/api"},
+		{name: "remote http rejected", raw: "http://example.com/api", wantErr: true},
 		{name: "query rejected", raw: "https://clankercloud.ai/api?x=1", wantErr: true},
 		{name: "userinfo rejected", raw: "https://token@clankercloud.ai/api", wantErr: true},
 		{name: "wrong path rejected", raw: "https://clankercloud.ai/v1", wantErr: true},
@@ -59,7 +64,10 @@ func TestSandboxClientCreateAndCommand(t *testing.T) {
 			if err := json.NewDecoder(r.Body).Decode(&createPayload); err != nil {
 				t.Fatalf("decode create payload: %v", err)
 			}
-			_, _ = w.Write([]byte(`{"box":{"id":"box_123","expiresAt":"2026-07-07T10:00:00Z"},"sandboxToken":"sandbox-token"}`))
+			w.Header().Set("Set-Cookie", "session=secret")
+			w.Header().Set("X-Request-ID", "request-123")
+			w.Header().Set("X-Internal-Token", "internal-secret")
+			_, _ = w.Write([]byte(`{"box":{"id":"box_123","expiresAt":"2026-07-07T10:00:00Z"},"sandboxToken":"sandbox-token","nested":{"apiKey":"nested-secret","githubToken":"provider-secret"}}`))
 		case "/api/sandboxes/box_123/commands":
 			if r.Method != http.MethodPost {
 				t.Fatalf("command method = %s, want POST", r.Method)
@@ -98,8 +106,31 @@ func TestSandboxClientCreateAndCommand(t *testing.T) {
 	if got := ExtractSandboxID(created.Body); got != "box_123" {
 		t.Fatalf("ExtractSandboxID = %q, want box_123", got)
 	}
-	if got := ExtractSandboxToken(created.Body); got != "sandbox-token" {
-		t.Fatalf("ExtractSandboxToken = %q, want sandbox-token", got)
+	if got := ExtractSandboxToken(created.Body); got != "" {
+		t.Fatalf("redacted create body exposed sandbox token %q", got)
+	}
+	if got := client.SandboxToken(); got != "sandbox-token" {
+		t.Fatalf("client sandbox token = %q, want cached token", got)
+	}
+	body, ok := created.Body.(map[string]any)
+	if !ok || body["sandboxToken"] != "[REDACTED]" {
+		t.Fatalf("create body was not redacted: %#v", created.Body)
+	}
+	nested, ok := body["nested"].(map[string]any)
+	if !ok || nested["apiKey"] != "[REDACTED]" {
+		t.Fatalf("nested credential was not redacted: %#v", created.Body)
+	}
+	if nested["githubToken"] != "[REDACTED]" {
+		t.Fatalf("provider token was not redacted: %#v", created.Body)
+	}
+	if created.Headers["X-Request-Id"] != "request-123" {
+		t.Fatalf("safe request id header missing: %#v", created.Headers)
+	}
+	if _, ok := created.Headers["Set-Cookie"]; ok {
+		t.Fatalf("unsafe Set-Cookie header exposed: %#v", created.Headers)
+	}
+	if _, ok := created.Headers["X-Internal-Token"]; ok {
+		t.Fatalf("unsafe internal token header exposed: %#v", created.Headers)
 	}
 
 	result, err := client.Command(context.Background(), "box_123", SandboxCommandRequest{Command: "go test ./...", TimeoutSeconds: 600})
@@ -114,5 +145,171 @@ func TestSandboxClientCreateAndCommand(t *testing.T) {
 	}
 	if commandPayload.Command != "go test ./..." || commandPayload.TimeoutSeconds != 600 {
 		t.Fatalf("command payload = %+v", commandPayload)
+	}
+}
+
+func TestSandboxClientRejectsCrossOriginCredentialRedirect(t *testing.T) {
+	var redirectedRequests atomic.Int32
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectedRequests.Add(1)
+		if got := r.Header.Get("X-API-Key"); got != "" {
+			t.Errorf("redirect target received X-API-Key %q", got)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/api/sandboxes", http.StatusTemporaryRedirect)
+	}))
+	defer source.Close()
+
+	client := NewSandboxClient(SandboxClientOptions{
+		BaseURL:    source.URL + "/api",
+		AccountKey: "account-token",
+		HTTPClient: source.Client(),
+	})
+	_, err := client.List(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "cross-origin") {
+		t.Fatalf("List error = %v, want cross-origin redirect refusal", err)
+	}
+	if got := redirectedRequests.Load(); got != 0 {
+		t.Fatalf("redirect target requests = %d, want 0", got)
+	}
+}
+
+func TestSandboxClientBoundsResponseBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = fmt.Fprint(w, strings.Repeat("x", maxCloudAPIResponseBytes+1))
+	}))
+	defer server.Close()
+
+	client := NewSandboxClient(SandboxClientOptions{
+		BaseURL:    server.URL + "/api",
+		AccountKey: "account-token",
+		HTTPClient: server.Client(),
+	})
+	_, err := client.List(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("List error = %v, want bounded response error", err)
+	}
+}
+
+func TestSandboxDelete404IsIdempotent(t *testing.T) {
+	var deleteCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		deleteCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"ok":false,"error":"sandbox not found"}`))
+	}))
+	defer server.Close()
+
+	client := NewSandboxClient(SandboxClientOptions{
+		BaseURL:      server.URL + "/api",
+		SandboxToken: "sandbox-token",
+		HTTPClient:   server.Client(),
+	})
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	result, err := client.Dispose(cancelled, "box_missing")
+	if err != nil {
+		t.Fatalf("Dispose: %v", err)
+	}
+	if !SandboxResultOK(result) || result.Status != http.StatusNotFound {
+		t.Fatalf("Dispose result = %#v, want idempotent 404", result)
+	}
+	if deleteCalls.Load() != 1 {
+		t.Fatalf("delete calls = %d, want cleanup despite cancelled parent", deleteCalls.Load())
+	}
+}
+
+func TestSandboxDeleteDoesNotAcceptArbitrary404(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"ok":false,"error":"sandbox action not found"}`))
+	}))
+	defer server.Close()
+
+	client := NewSandboxClient(SandboxClientOptions{
+		BaseURL:      server.URL + "/api",
+		SandboxToken: "sandbox-token",
+		HTTPClient:   server.Client(),
+	})
+	result, err := client.Dispose(context.Background(), "box_missing")
+	if err == nil || !strings.Contains(err.Error(), "status 404") {
+		t.Fatalf("Dispose error = %v, want unrecognized 404 failure", err)
+	}
+	if SandboxResultOK(result) {
+		t.Fatalf("arbitrary 404 was treated as successful deletion: %#v", result)
+	}
+}
+
+func TestSandboxDeleteFallsBackToAccountForManageableCleanup(t *testing.T) {
+	var deleteCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		deleteCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Header.Get("X-API-Key") {
+		case "stale-sandbox-token":
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"ok":false,"error":"invalid sandbox token"}`))
+		case "account-token":
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected credential %q", r.Header.Get("X-API-Key"))
+			w.WriteHeader(http.StatusForbidden)
+		}
+	}))
+	defer server.Close()
+
+	client := NewSandboxClient(SandboxClientOptions{
+		BaseURL:      server.URL + "/api",
+		AccountKey:   "account-token",
+		SandboxToken: "stale-sandbox-token",
+		HTTPClient:   server.Client(),
+	})
+	result, err := client.Dispose(context.Background(), "box_owned")
+	if err != nil || !SandboxResultOK(result) {
+		t.Fatalf("Dispose result=%#v err=%v", result, err)
+	}
+	if deleteCalls.Load() != 2 {
+		t.Fatalf("delete calls = %d, want sandbox-token attempt then account fallback", deleteCalls.Load())
+	}
+}
+
+func TestSandboxClientRejectsEmptyResourceID(t *testing.T) {
+	client := NewSandboxClient(SandboxClientOptions{BaseURL: "https://clankercloud.ai/api"})
+	if _, err := client.Delete(context.Background(), " "); err == nil {
+		t.Fatal("Delete without a sandbox id succeeded")
+	}
+	if _, err := client.Command(context.Background(), "", SandboxCommandRequest{Command: "true"}); err == nil {
+		t.Fatal("Command without a sandbox id succeeded")
+	}
+}
+
+func TestSandboxClientDoesNotAttachConfiguredCredentialToUntrustedExplicitBase(t *testing.T) {
+	t.Setenv("CLANKER_CLOUD_API_KEY", "configured-secret")
+	t.Setenv("CLANKER_SANDBOX_TOKEN", "configured-sandbox-secret")
+
+	untrusted := NewSandboxClient(SandboxClientOptions{BaseURL: "https://example.com/api"})
+	if untrusted.AccountKey() != "" || untrusted.SandboxToken() != "" {
+		t.Fatalf("untrusted explicit base inherited configured credentials")
+	}
+
+	official := NewSandboxClient(SandboxClientOptions{BaseURL: DefaultSandboxAPIBaseURL})
+	if official.AccountKey() != "configured-secret" || official.SandboxToken() != "configured-sandbox-secret" {
+		t.Fatalf("official base did not inherit configured credentials")
+	}
+
+	explicit := NewSandboxClient(SandboxClientOptions{
+		BaseURL:      "https://example.com/api",
+		AccountKey:   "explicit-account",
+		SandboxToken: "explicit-sandbox",
+	})
+	if explicit.AccountKey() != "explicit-account" || explicit.SandboxToken() != "explicit-sandbox" {
+		t.Fatalf("explicit custom credentials were not preserved")
 	}
 }


### PR DESCRIPTION
## Summary
- add account-scoped Clanker Apps commands for create, list, deploy, activate, unpublish, and delete
- keep deployments private by default and require explicit activation before a public URL is live
- make one-shot cloud sandbox runs dispose on success, failure, and cancellation, with an exact cleanup command if disposal cannot be confirmed
- harden cloud transport, idempotency, redirects, response limits, structured 404 handling, and recursive secret redaction
- expose safe MCP schemas without model-visible account credentials or service endpoints

## Verification
- go test ./...
- go test -race ./cmd ./internal/clankercloud
- go vet ./cmd ./internal/clankercloud
