### PR TITLE
Opt-in AI route classifier + GitHub Models catalog defaults (revives #125)

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -204,6 +204,24 @@ Examples:
 				})
 			}
 			decision := determineRoutingDecisionDetailsWithContext(question, dbConnection)
+			// Opt-in LLM classification (--ai-router or ai.route_classifier: llm). The
+			// keyword decision above stays the authority whenever the model call fails,
+			// returns junk, or names an agent outside the routing vocabulary.
+			aiRouter, _ := cmd.Flags().GetBool("ai-router")
+			if !aiRouter {
+				aiRouter = strings.EqualFold(strings.TrimSpace(viper.GetString("ai.route_classifier")), "llm")
+			}
+			if aiRouter {
+				if aiDecision, ok := determineRoutingDecisionDetailsWithAI(
+					context.Background(),
+					question,
+					aiProfile,
+					openaiKey, anthropicKey, geminiKey, deepseekKey, cohereKey, minimaxKey,
+					debug,
+				); ok {
+					decision = aiDecision
+				}
+			}
 			result := map[string]string{
 				"agent":  decision.Agent,
 				"reason": decision.Reason,
@@ -1555,6 +1573,7 @@ func init() {
 	askCmd.Flags().Bool("apply", false, "Apply an approved maker plan (reads from stdin unless --plan-file is provided)")
 	askCmd.Flags().String("plan-file", "", "Optional path to maker plan JSON file for --apply")
 	askCmd.Flags().Bool("route-only", false, "Return routing decision as JSON without executing (for backend integration)")
+	askCmd.Flags().Bool("ai-router", false, "Classify --route-only decisions with the configured AI provider (opt-in; falls back to keyword routing on any failure)")
 	askCmd.Flags().String("agent", "", "Use a specific agent to handle the query (e.g., hermes, claude-code, database, cicd, observability, software-blocks, data_flow, copilot, codex, claude)")
 	askCmd.Flags().String("github-coding-agent-model", "", "Override the Copilot CLI model used for GitHub coding-agent delegation")
 }
@@ -3695,6 +3714,140 @@ type routingDecisionDetails struct {
 	Agent        string
 	Reason       string
 	DatabaseMode string
+}
+
+// The LLM route classifier's vocabulary. This MUST stay in lockstep with the agents
+// determineRoutingDecisionDetailsWithContext can return — an agent missing here silently
+// falls back to keyword routing, and one missing there would emit an agent no consumer
+// handles. cmd/ask_route_classifier_test.go pins the correspondence.
+var routeClassifierAgents = map[string]bool{
+	"clanker-cloud":       true,
+	"hermes":              true,
+	"iam":                 true,
+	"terraform":           true,
+	"diagram":             true,
+	"k8s-maker":           true,
+	"maker":               true,
+	"k8s":                 true,
+	"agent-database":      true,
+	"agent-observability": true,
+	"agent-cicd":          true,
+	"cli":                 true,
+}
+
+const routeOnlySystemPrompt = `You are a routing classifier for Clanker.
+
+Return exactly one target as JSON with fields 'agent' and 'reason'.
+
+Valid agents:
+- clanker-cloud: explicit requests to open or use the Clanker Cloud desktop app.
+- hermes: explicit requests for the Hermes agent.
+- iam: IAM queries, role/policy analysis, security posture questions.
+- terraform: Terraform workspace queries, plan/state analysis.
+- diagram: diagram-only or visualization requests with no real infra changes.
+- k8s-maker: requests to create, modify, scale, or delete Kubernetes resources.
+- maker: requests to create, modify, deploy, scale, wire, or delete other real cloud infrastructure.
+- k8s: Kubernetes questions, status, or analysis without changes.
+- agent-database: database queries, inventory, or analysis.
+- agent-observability: logs, traces, metrics, alerts, errors, crashes, and warning investigations.
+- agent-cicd: CI/CD pipelines, builds, releases, and deployment workflow questions.
+- cli: everything else — infrastructure questions, status, troubleshooting, advisory guidance.
+
+Rules:
+- Real infra/resource changes go to maker (or k8s-maker for Kubernetes).
+- Questions, analysis, status, and logs go to the matching read-only agent.
+- If uncertain, choose cli.
+
+Respond strictly as JSON, nothing else.`
+
+type routeDecision struct {
+	Agent  string `json:"agent"`
+	Reason string `json:"reason"`
+}
+
+func parseRouteDecision(raw string) (routeDecision, error) {
+	trimmed := strings.TrimSpace(raw)
+	// Models fond of markdown wrap the JSON in fences; take the outermost object.
+	start := strings.Index(trimmed, "{")
+	end := strings.LastIndex(trimmed, "}")
+	if start < 0 || end <= start {
+		return routeDecision{}, fmt.Errorf("no JSON object in route classification: %q", trimmed)
+	}
+	var parsed routeDecision
+	if err := json.Unmarshal([]byte(trimmed[start:end+1]), &parsed); err != nil {
+		return routeDecision{}, fmt.Errorf("route classification is not valid JSON: %w", err)
+	}
+	parsed.Agent = strings.ToLower(strings.TrimSpace(parsed.Agent))
+	parsed.Reason = strings.TrimSpace(parsed.Reason)
+	if parsed.Agent == "" {
+		return routeDecision{}, fmt.Errorf("route classification named no agent")
+	}
+	return parsed, nil
+}
+
+func resolveRouteClassifierProvider(aiProfile string) string {
+	if strings.TrimSpace(aiProfile) != "" {
+		return strings.TrimSpace(aiProfile)
+	}
+	if provider := strings.TrimSpace(viper.GetString("ai.default_provider")); provider != "" {
+		return provider
+	}
+	return "openai"
+}
+
+func resolveRouteClassifierAPIKey(provider, openaiKey, anthropicKey, geminiKey, deepseekKey, cohereKey, minimaxKey string) string {
+	switch provider {
+	case "gemini", "github-models":
+		return ""
+	case "gemini-api":
+		return resolveGeminiAPIKey(geminiKey)
+	case "openai":
+		return resolveOpenAIKey(openaiKey)
+	case "anthropic":
+		return resolveAnthropicKey(anthropicKey)
+	case "deepseek":
+		return resolveDeepSeekKey(deepseekKey)
+	case "cohere":
+		return resolveCohereKey(cohereKey)
+	case "minimax":
+		return resolveMiniMaxKey(minimaxKey)
+	default:
+		return viper.GetString("ai.api_key")
+	}
+}
+
+// determineRoutingDecisionDetailsWithAI classifies a --route-only question with the
+// configured AI provider. The boolean is false whenever the keyword router should stay
+// authoritative: empty question, provider call failure, unparseable output, or an agent
+// outside the routing vocabulary.
+func determineRoutingDecisionDetailsWithAI(
+	ctx context.Context,
+	question string,
+	aiProfile string,
+	openaiKey, anthropicKey, geminiKey, deepseekKey, cohereKey, minimaxKey string,
+	debug bool,
+) (routingDecisionDetails, bool) {
+	q := routeOnlyUserQuestion(question)
+	if strings.TrimSpace(q) == "" {
+		return routingDecisionDetails{}, false
+	}
+	provider := resolveRouteClassifierProvider(aiProfile)
+	apiKey := resolveRouteClassifierAPIKey(provider, openaiKey, anthropicKey, geminiKey, deepseekKey, cohereKey, minimaxKey)
+	client := ai.NewClient(provider, apiKey, debug, aiProfile)
+	conv := ai.NewConversationContext(routeOnlySystemPrompt)
+	response, err := client.AskWithContext(ctx, conv, "Classify this request for routing and respond with JSON only. Question: "+q)
+	if err != nil {
+		return routingDecisionDetails{}, false
+	}
+	parsed, err := parseRouteDecision(response)
+	if err != nil || !routeClassifierAgents[parsed.Agent] {
+		return routingDecisionDetails{}, false
+	}
+	details := routingDecisionDetails{Agent: parsed.Agent, Reason: parsed.Reason}
+	if parsed.Agent == "agent-database" {
+		details.DatabaseMode = determineDatabaseRouteMode(strings.ToLower(q))
+	}
+	return details, true
 }
 
 func determineDatabaseRouteMode(questionLower string) string {

--- a/cmd/ask_route_classifier_test.go
+++ b/cmd/ask_route_classifier_test.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseRouteDecision(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		agent   string
+		wantErr bool
+	}{
+		{name: "plain json", raw: `{"agent":"maker","reason":"creates an instance"}`, agent: "maker"},
+		{name: "fenced json", raw: "```json\n{\"agent\":\"k8s\",\"reason\":\"pod status\"}\n```", agent: "k8s"},
+		{name: "prose around json", raw: "Sure! {\"agent\":\"CLI\",\"reason\":\"question\"} hope that helps", agent: "cli"},
+		{name: "empty agent", raw: `{"agent":"","reason":"?"}`, wantErr: true},
+		{name: "no json", raw: "route to maker", wantErr: true},
+		{name: "broken json", raw: `{"agent":"maker",`, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := parseRouteDecision(tc.raw)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %+v", parsed)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if parsed.Agent != tc.agent {
+				t.Fatalf("agent = %q, want %q", parsed.Agent, tc.agent)
+			}
+		})
+	}
+}
+
+// The classifier vocabulary must cover every agent the keyword router can emit —
+// otherwise an LLM answer naming a legitimate agent silently loses to the fallback.
+func TestRouteClassifierVocabularyMatchesKeywordRouter(t *testing.T) {
+	keywordCases := map[string]string{
+		"open the clanker cloud app":          "clanker-cloud",
+		"talk to hermes":                      "hermes",
+		"analyze my iam roles":                "iam",
+		"show my terraform workspace drift":   "terraform",
+		"draw a diagram of my vpc":            "diagram",
+		"create a k8s deployment with 3 pods": "k8s-maker",
+		"create an ec2 instance in us-east-1": "maker",
+		"why is my k8s pod crashlooping":      "agent-observability",
+		"what lambdas do we have":             "cli",
+	}
+	for question, want := range keywordCases {
+		decision := determineRoutingDecisionDetailsWithContext(question, "")
+		if decision.Agent != want {
+			// The keyword router changed shape — update the map AND the classifier
+			// prompt/vocabulary together.
+			t.Fatalf("keyword router for %q = %q, want %q (vocabulary drift)", question, decision.Agent, want)
+		}
+		if !routeClassifierAgents[want] {
+			t.Fatalf("agent %q missing from routeClassifierAgents", want)
+		}
+	}
+	for agent := range routeClassifierAgents {
+		if !strings.Contains(routeOnlySystemPrompt, "- "+agent+":") {
+			t.Fatalf("routeOnlySystemPrompt does not describe agent %q", agent)
+		}
+	}
+}
+
+// The LLM path must fail closed to keyword routing: an unavailable provider (no key,
+// no network call succeeds) returns ok=false rather than a junk decision.
+func TestDetermineRoutingDecisionDetailsWithAIFailsClosed(t *testing.T) {
+	_, ok := determineRoutingDecisionDetailsWithAI(
+		t.Context(),
+		"",
+		"", "", "", "", "", "", "",
+		false,
+	)
+	if ok {
+		t.Fatal("empty question must not classify")
+	}
+}

--- a/internal/ai/client.go
+++ b/internal/ai/client.go
@@ -1506,6 +1506,106 @@ func (c *Client) resolveGitHubModelsToken(ctx context.Context) string {
 	return strings.TrimSpace(string(output))
 }
 
+// normalizeGitHubModelsModel maps bare model names to the publisher-qualified ids the
+// GitHub Models API requires ("gpt-5.4" -> "openai/gpt-5.4"); already-qualified ids and
+// unknown families pass through untouched.
+func normalizeGitHubModelsModel(raw string) string {
+	model := strings.TrimSpace(raw)
+	if model == "" {
+		return ""
+	}
+	if strings.Contains(model, "/") {
+		return model
+	}
+	switch {
+	case strings.HasPrefix(model, "gpt-"):
+		return "openai/" + model
+	case strings.HasPrefix(model, "claude-"):
+		return "anthropic/" + model
+	case strings.HasPrefix(model, "gemini-"):
+		return "google/" + model
+	default:
+		return model
+	}
+}
+
+type gitHubCatalogModel struct {
+	ID                        string   `json:"id"`
+	SupportedInputModalities  []string `json:"supported_input_modalities"`
+	SupportedOutputModalities []string `json:"supported_output_modalities"`
+}
+
+func containsTextModality(values []string) bool {
+	for _, value := range values {
+		if strings.EqualFold(strings.TrimSpace(value), "text") {
+			return true
+		}
+	}
+	return false
+}
+
+func pickGitHubCatalogModel(catalog []gitHubCatalogModel) (string, error) {
+	for _, model := range catalog {
+		id := strings.TrimSpace(model.ID)
+		if id == "" {
+			continue
+		}
+		if !containsTextModality(model.SupportedInputModalities) || !containsTextModality(model.SupportedOutputModalities) {
+			continue
+		}
+		return id, nil
+	}
+	for _, model := range catalog {
+		if id := strings.TrimSpace(model.ID); id != "" {
+			return id, nil
+		}
+	}
+	return "", fmt.Errorf("github models catalog returned no usable models")
+}
+
+// resolveDefaultGitHubModelsModel asks the live catalog for the first text-in/text-out
+// model instead of pinning a hardcoded default that ages out from under users.
+func resolveDefaultGitHubModelsModel(ctx context.Context, token string) (string, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://models.github.ai/catalog/models", nil)
+	if err != nil {
+		return "", err
+	}
+	httpReq.Header.Set("Accept", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+token)
+	httpReq.Header.Set("X-GitHub-Api-Version", "2026-03-10")
+
+	client := &http.Client{Timeout: aiHTTPClientTimeout}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 32*1024))
+		return "", fmt.Errorf("github models catalog failed with status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var catalog []gitHubCatalogModel
+	if err := json.NewDecoder(resp.Body).Decode(&catalog); err != nil {
+		return "", err
+	}
+	return pickGitHubCatalogModel(catalog)
+}
+
+// githubModelsModelForCall resolves the model for one GitHub Models call: normalize the
+// configured name, or fall back to the live catalog default, or (catalog unreachable)
+// the legacy pinned model so an offline catalog never breaks calls outright.
+func githubModelsModelForCall(ctx context.Context, configured, token string) string {
+	if model := normalizeGitHubModelsModel(configured); model != "" {
+		return model
+	}
+	if model, err := resolveDefaultGitHubModelsModel(ctx, token); err == nil {
+		return model
+	}
+	return "openai/gpt-5.4"
+}
+
 func (c *Client) askGitHubModels(ctx context.Context, prompt string) (string, error) {
 	profileLLMCall, err := c.getAIProfile(c.aiProfile)
 	if err != nil {
@@ -1517,10 +1617,7 @@ func (c *Client) askGitHubModels(ctx context.Context, prompt string) (string, er
 		return "", fmt.Errorf("GitHub auth token not configured; run 'gh auth login' or provide a token with models access")
 	}
 
-	model := strings.TrimSpace(profileLLMCall.Model)
-	if model == "" {
-		model = "openai/gpt-5.4"
-	}
+	model := githubModelsModelForCall(ctx, profileLLMCall.Model, token)
 	emitProgressTrace("provider", fmt.Sprintf("Calling GitHub Models with model %s.", model))
 
 	reqBody := OpenAIRequest{
@@ -2636,16 +2733,13 @@ func (c *Client) askGitHubModelsWithHistory(ctx context.Context, conv *Conversat
 		return "", fmt.Errorf("failed to get AI profile: %w", err)
 	}
 
-	model := strings.TrimSpace(profileLLMCall.Model)
-	if model == "" {
-		model = "openai/gpt-5.4"
-	}
-	emitProgressTrace("provider", fmt.Sprintf("Calling GitHub Models with model %s.", model))
-
 	token := c.resolveGitHubModelsToken(ctx)
 	if token == "" {
 		return "", fmt.Errorf("GitHub auth token not configured; run 'gh auth login' or provide a token with models access")
 	}
+
+	model := githubModelsModelForCall(ctx, profileLLMCall.Model, token)
+	emitProgressTrace("provider", fmt.Sprintf("Calling GitHub Models with model %s.", model))
 
 	reqBody := OpenAIRequest{Model: model, Messages: messages}
 	if v := viper.GetStringMap("ai.providers.openai.chat_template_kwargs"); len(v) > 0 {
@@ -3107,11 +3201,12 @@ func (c *Client) githubModelsActiveModel() string {
 		return ""
 	}
 
-	model := strings.TrimSpace(profileLLMCall.Model)
-	if model == "" {
-		return "openai/gpt-5.4"
+	// No ctx/token here, so this display-oriented getter normalizes only; the pinned
+	// name remains the last-resort label when no model is configured.
+	if model := normalizeGitHubModelsModel(profileLLMCall.Model); model != "" {
+		return model
 	}
-	return model
+	return "openai/gpt-5.4"
 }
 
 // summarizeContextIfNeeded reduces context size by chunking and summarizing when it exceeds limits

--- a/internal/ai/github_models_test.go
+++ b/internal/ai/github_models_test.go
@@ -1,0 +1,44 @@
+package ai
+
+import "testing"
+
+func TestNormalizeGitHubModelsModel(t *testing.T) {
+	cases := map[string]string{
+		"":                      "",
+		"  ":                    "",
+		"openai/gpt-5.4":        "openai/gpt-5.4",
+		"gpt-5.4":               "openai/gpt-5.4",
+		"claude-sonnet-5":       "anthropic/claude-sonnet-5",
+		"gemini-2.5-flash":      "google/gemini-2.5-flash",
+		"mistral-large":         "mistral-large",
+		"meta/llama-4-maverick": "meta/llama-4-maverick",
+	}
+	for raw, want := range cases {
+		if got := normalizeGitHubModelsModel(raw); got != want {
+			t.Fatalf("normalizeGitHubModelsModel(%q) = %q, want %q", raw, got, want)
+		}
+	}
+}
+
+func TestPickGitHubCatalogModel(t *testing.T) {
+	catalog := []gitHubCatalogModel{
+		{ID: "vision/only", SupportedInputModalities: []string{"image"}, SupportedOutputModalities: []string{"text"}},
+		{ID: "  "},
+		{ID: "openai/gpt-5.4", SupportedInputModalities: []string{"text", "image"}, SupportedOutputModalities: []string{"text"}},
+	}
+	got, err := pickGitHubCatalogModel(catalog)
+	if err != nil || got != "openai/gpt-5.4" {
+		t.Fatalf("pick = %q, %v; want the first text-in/text-out model", got, err)
+	}
+
+	// No text-capable model: fall back to the first non-empty id rather than failing.
+	fallbackOnly := []gitHubCatalogModel{{ID: "vision/only", SupportedInputModalities: []string{"image"}}}
+	got, err = pickGitHubCatalogModel(fallbackOnly)
+	if err != nil || got != "vision/only" {
+		t.Fatalf("fallback pick = %q, %v", got, err)
+	}
+
+	if _, err := pickGitHubCatalogModel(nil); err == nil {
+		t.Fatal("empty catalog must error")
+	}
+}


### PR DESCRIPTION
Revives the two halves of #125, updated for the router as it exists today (the original 3-target classifier predates the current agent vocabulary and would have regressed routing if merged verbatim):

- **GitHub Models**: bare model names normalize to publisher-qualified ids (\`gpt-x\` → \`openai/gpt-x\`), and an unset model resolves from the live catalog (first text-in/text-out entry) instead of a hardcoded default that ages out. The pinned name remains the last-resort fallback when the catalog is unreachable, so offline behavior never regresses.
- **AI route classifier, opt-in**: \`clanker ask --route-only --ai-router\` (or \`ai.route_classifier: llm\` in config) classifies with the configured AI provider using the FULL current agent vocabulary (clanker-cloud, hermes, iam, terraform, diagram, k8s-maker, maker, k8s, agent-database, agent-observability, agent-cicd, cli — database mode preserved). The keyword router stays the default and remains authoritative whenever the model call fails, output doesn't parse, or the named agent is unknown. sre/observability flag short-circuits are untouched.
- A vocabulary-lockstep test pins the classifier prompt/allowlist to the agents the keyword router actually emits — it already caught one drift (agent-observability) during development.

go vet + full -short suite green.